### PR TITLE
chore(database_observability): Set logs emit interval for explain plans

### DIFF
--- a/internal/component/database_observability/database_observability.go
+++ b/internal/component/database_observability/database_observability.go
@@ -1,3 +1,11 @@
 package database_observability
 
-const JobName = "integrations/db-o11y"
+import "time"
+
+const (
+	JobName = "integrations/db-o11y"
+
+	// EmitInterval is the minimum time between repeated emissions for the same
+	// database object log lines, regardless of the configured collection interval.
+	EmitInterval = 30 * time.Minute
+)

--- a/internal/component/database_observability/mysql/collector/explain_plans.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans.go
@@ -372,12 +372,16 @@ type queryInfo struct {
 	uniqueKey  string
 }
 
+func explainPlanQueryKey(schemaName, digest string) string {
+	return fmt.Sprintf("%s:%s", schemaName, digest)
+}
+
 func newQueryInfo(schemaName, digest, queryText string) *queryInfo {
 	return &queryInfo{
 		schemaName: schemaName,
 		digest:     digest,
 		queryText:  queryText,
-		uniqueKey:  schemaName + digest,
+		uniqueKey:  explainPlanQueryKey(schemaName, digest),
 	}
 }
 
@@ -414,6 +418,8 @@ type ExplainPlans struct {
 	currentBatchSize int
 	entryHandler     loki.EntryHandler
 	lastSeen         time.Time
+	lastEmittedAt    map[string]time.Time
+	now              func() time.Time
 	logger           *slog.Logger
 	running          *atomic.Bool
 	ctx              context.Context
@@ -431,10 +437,40 @@ func NewExplainPlans(args ExplainPlansArguments) (*ExplainPlans, error) {
 		lastSeen:       args.InitialLookback,
 		queryCache:     make(map[string]*queryInfo),
 		queryDenylist:  make(map[string]struct{}),
+		lastEmittedAt:  make(map[string]time.Time),
+		now:            time.Now,
 		entryHandler:   args.EntryHandler,
 		logger:         args.Logger.With("collector", ExplainPlansCollector),
 		running:        atomic.NewBool(false),
 	}, nil
+}
+
+func (c *ExplainPlans) currentTime() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+func (c *ExplainPlans) isThrottled(key string) bool {
+	last, ok := c.lastEmittedAt[key]
+	return ok && c.currentTime().Sub(last) < database_observability.EmitInterval
+}
+
+func (c *ExplainPlans) recordEmission(key string) {
+	if c.lastEmittedAt == nil {
+		c.lastEmittedAt = make(map[string]time.Time)
+	}
+	c.lastEmittedAt[key] = c.currentTime()
+}
+
+func (c *ExplainPlans) pruneExpiredThrottle() {
+	now := c.currentTime()
+	for key, last := range c.lastEmittedAt {
+		if now.Sub(last) >= database_observability.EmitInterval {
+			delete(c.lastEmittedAt, key)
+		}
+	}
 }
 
 func (c *ExplainPlans) sendExplainPlansOutput(schemaName string, digest string, generatedAt string, result database_observability.ExplainProcessingResult, reason string, plan *database_observability.ExplainPlanNode) error {
@@ -469,6 +505,7 @@ func (c *ExplainPlans) sendExplainPlansOutput(schemaName string, digest string, 
 		OP_EXPLAIN_PLAN_OUTPUT,
 		logMessage,
 	)
+	c.recordEmission(explainPlanQueryKey(schemaName, digest))
 
 	return nil
 }
@@ -520,6 +557,8 @@ func (c *ExplainPlans) Stop() {
 }
 
 func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
+	c.pruneExpiredThrottle()
+
 	query := fmt.Sprintf(selectDigestsForExplainPlan, buildExcludedSchemasClause(c.excludeSchemas))
 	rs, err := c.dbConnection.QueryContext(ctx, query, c.lastSeen)
 	if err != nil {
@@ -539,25 +578,31 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 		}
 
 		qi := newQueryInfo(schemaName, digest, queryText)
-		if _, ok := c.queryDenylist[qi.uniqueKey]; !ok {
-			c.queryCache[qi.uniqueKey] = qi
-		} else {
-			err := c.sendExplainPlansOutput(
-				schemaName,
-				digest,
-				generatedAt,
-				database_observability.ExplainProcessingResultSkipped,
-				"query denylisted",
-				nil,
-			)
-			if err != nil {
-				c.logger.Error("failed to send denylisted query skip explain plan output", "err", err)
-			}
-			continue
-		}
 		if ls.After(c.lastSeen) {
 			c.lastSeen = ls
 		}
+
+		if _, ok := c.queryDenylist[qi.uniqueKey]; ok {
+			if !c.isThrottled(qi.uniqueKey) {
+				err := c.sendExplainPlansOutput(
+					schemaName,
+					digest,
+					generatedAt,
+					database_observability.ExplainProcessingResultSkipped,
+					"query denylisted",
+					nil,
+				)
+				if err != nil {
+					c.logger.Error("failed to send denylisted query skip explain plan output", "err", err)
+				}
+			}
+			continue
+		}
+
+		if c.isThrottled(qi.uniqueKey) {
+			continue
+		}
+		c.queryCache[qi.uniqueKey] = qi
 	}
 
 	if err := rs.Err(); err != nil {
@@ -580,6 +625,10 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 
 	processedCount := 0
 	for _, qi := range c.queryCache {
+		if c.isThrottled(qi.uniqueKey) {
+			delete(c.queryCache, qi.uniqueKey)
+			continue
+		}
 		if processedCount >= c.currentBatchSize {
 			break
 		}

--- a/internal/component/database_observability/mysql/collector/explain_plans_test.go
+++ b/internal/component/database_observability/mysql/collector/explain_plans_test.go
@@ -1569,245 +1569,506 @@ func TestExplainPlans(t *testing.T) {
 		err = mock.ExpectationsWereMet()
 		require.NoError(t, err)
 	})
+}
 
-	t.Run("query validation", func(t *testing.T) {
+func TestExplainPlansSkipsTruncatedQueries(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lastSeen := time.Now().Add(-time.Hour)
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
+
+	c, err := NewExplainPlans(ExplainPlansArguments{
+		DB:              db,
+		Logger:          logger.Slog(),
+		ScrapeInterval:  time.Second,
+		PerScrapeRatio:  1,
+		EntryHandler:    lokiClient,
+		DBVersion:       "8.0.32",
+		InitialLookback: lastSeen,
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
+		"schema_name",
+		"digest",
+		"query_sample_text",
+		"last_seen",
+	}).AddRow(
+		"some_schema",
+		"some_digest",
+		"select * from some_table where ...",
+		lastSeen,
+	))
+
+	require.NoError(t, c.fetchExplainPlans(t.Context()))
+
+	require.Eventually(
+		t,
+		func() bool { return len(lokiClient.Received()) == 1 },
+		5*time.Second,
+		10*time.Millisecond,
+		"did not receive the explain plan output log message within the timeout",
+	)
+	require.NotContains(t, logBuffer.String(), "error")
+	lokiEntries := lokiClient.Received()
+	require.Equal(t, 1, len(lokiEntries))
+	epo, err := database_observability.ExtractExplainPlanOutputFromLogMsg(lokiEntries[0])
+	require.NoError(t, err)
+	require.Equal(t, database_observability.ExplainProcessingResultSkipped, epo.Metadata.ProcessingResult)
+	require.Equal(t, "query is truncated", epo.Metadata.ProcessingResultReason)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestExplainPlansSkipsNonSelectQueries(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lastSeen := time.Now().Add(-time.Hour)
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
+
+	c, err := NewExplainPlans(ExplainPlansArguments{
+		DB:              db,
+		Logger:          logger.Slog(),
+		ScrapeInterval:  time.Second,
+		PerScrapeRatio:  1,
+		EntryHandler:    lokiClient,
+		DBVersion:       "8.0.32",
+		InitialLookback: lastSeen,
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
+		"schema_name",
+		"digest",
+		"query_sample_text",
+		"last_seen",
+	}).AddRow(
+		"some_schema",
+		"update_digest",
+		"update some_table set col = 1 where id = 1",
+		lastSeen,
+	).AddRow(
+		"some_schema",
+		"delete_digest",
+		"delete from some_table",
+		lastSeen,
+	).AddRow(
+		"some_schema",
+		"insert_digest",
+		"insert into some_table (col) values (1)",
+		lastSeen,
+	).AddRow(
+		"some_schema",
+		"show_digest",
+		"show global status like 'Uptime'",
+		lastSeen,
+	).AddRow(
+		"some_schema",
+		"kill_digest",
+		"kill query 123",
+		lastSeen,
+	).AddRow(
+		"some_schema",
+		"call_digest",
+		"call refresh_summary()",
+		lastSeen,
+	).AddRow(
+		"some_schema",
+		"do_digest",
+		"do release_lock('foo')",
+		lastSeen,
+	))
+
+	require.NoError(t, c.fetchExplainPlans(t.Context()))
+
+	require.Eventually(
+		t,
+		func() bool { return len(lokiClient.Received()) == 7 },
+		5*time.Second,
+		10*time.Millisecond,
+		"did not receive the explain plan output log messages within the timeout",
+	)
+
+	lokiEntries := lokiClient.Received()
+	require.Equal(t, 7, len(lokiEntries))
+
+	for _, lokiEntry := range lokiEntries {
+		ep, err := database_observability.ExtractExplainPlanOutputFromLogMsg(lokiEntry)
+		require.NoError(t, err)
+		require.Equal(t, database_observability.ExplainProcessingResultSkipped, ep.Metadata.ProcessingResult)
+		require.Equal(t, "query contains reserved word", ep.Metadata.ProcessingResultReason)
+	}
+
+	require.NotContains(t, logBuffer.String(), "error")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestExplainPlansSkipsNoRowResult(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lastSeen := time.Now().Add(-time.Hour)
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
+
+	c, err := NewExplainPlans(ExplainPlansArguments{
+		DB:              db,
+		Logger:          logger.Slog(),
+		ScrapeInterval:  time.Second,
+		PerScrapeRatio:  1,
+		EntryHandler:    lokiClient,
+		DBVersion:       "8.0.32",
+		InitialLookback: lastSeen,
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
+		"schema_name",
+		"digest",
+		"query_sample_text",
+		"last_seen",
+	}).AddRow(
+		"some_schema",
+		"some_digest",
+		"select * from some_table where id = 1",
+		lastSeen,
+	))
+
+	mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 1").WillReturnRows(sqlmock.NewRows([]string{
+		"json",
+	}).AddRow(
+		[]byte(`{"query_block": {"message": "no matching row in const table"}}`),
+	))
+
+	require.NoError(t, c.fetchExplainPlans(t.Context()))
+
+	require.NotContains(t, logBuffer.String(), "error")
+	require.Contains(t, logBuffer.String(), "no matching row in const table")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestExplainPlansPassesQueriesBeginningInSelect(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lastSeen := time.Now().Add(-time.Hour)
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
+
+	c, err := NewExplainPlans(ExplainPlansArguments{
+		DB:              db,
+		Logger:          logger.Slog(),
+		ScrapeInterval:  time.Second,
+		PerScrapeRatio:  1,
+		EntryHandler:    lokiClient,
+		DBVersion:       "8.0.32",
+		InitialLookback: lastSeen,
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
+		"schema_name",
+		"digest",
+		"query_sample_text",
+		"last_seen",
+	}).AddRow(
+		"some_schema",
+		"some_digest",
+		"select * from some_table where id = 1",
+		lastSeen,
+	))
+
+	mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 1").WillReturnRows(sqlmock.NewRows([]string{
+		"json",
+	}).AddRow(
+		[]byte(`{"query_block": {"select_id": 1}}`),
+	))
+
+	require.NoError(t, c.fetchExplainPlans(t.Context()))
+
+	require.NotContains(t, logBuffer.String(), "error")
+
+	require.Eventually(
+		t,
+		func() bool { return len(lokiClient.Received()) == 1 },
+		5*time.Second,
+		10*time.Millisecond,
+		"did not receive the explain plan output log message within the timeout",
+	)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestExplainPlansPassesQueriesBeginningInWith(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lastSeen := time.Now().Add(-time.Hour)
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	logBuffer := syncbuffer.Buffer{}
+	logger, err := logging.New(&logBuffer, logging.Options{
+		Level:  logging.LevelDebug,
+		Format: logging.FormatLogfmt,
+	})
+	require.NoError(t, err)
+
+	c, err := NewExplainPlans(ExplainPlansArguments{
+		DB:              db,
+		Logger:          logger.Slog(),
+		ScrapeInterval:  time.Second,
+		PerScrapeRatio:  1,
+		EntryHandler:    lokiClient,
+		DBVersion:       "8.0.32",
+		InitialLookback: lastSeen,
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
+		"schema_name",
+		"digest",
+		"query_sample_text",
+		"last_seen",
+	}).AddRow(
+		"some_schema",
+		"some_digest",
+		"with cte as (select * from some_table where id = 1) select * from cte",
+		lastSeen,
+	))
+
+	mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery(selectExplainPlanPrefix + "with cte as (select * from some_table where id = 1) select * from cte").WillReturnRows(sqlmock.NewRows([]string{
+		"json",
+	}).AddRow(
+		[]byte(`{"query_block": {"select_id": 1}}`),
+	))
+
+	require.NoError(t, c.fetchExplainPlans(t.Context()))
+
+	require.NotContains(t, logBuffer.String(), "error")
+
+	require.Eventually(
+		t,
+		func() bool { return len(lokiClient.Received()) == 1 },
+		5*time.Second,
+		10*time.Millisecond,
+		"did not receive the explain plan output log message within the timeout",
+	)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestExplainPlansThrottling(t *testing.T) {
+	base := time.Date(2026, time.July, 31, 12, 0, 0, 0, time.UTC)
+
+	t.Run("all emitted results start the throttle", func(t *testing.T) {
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		c, err := NewExplainPlans(ExplainPlansArguments{
+			Logger:       util.TestAlloyLogger(t).Slog(),
+			EntryHandler: lokiClient,
+			DBVersion:    "8.0.32",
+		})
+		require.NoError(t, err)
+		c.now = func() time.Time { return base }
+
+		results := []database_observability.ExplainProcessingResult{
+			database_observability.ExplainProcessingResultSuccess,
+			database_observability.ExplainProcessingResultSkipped,
+			database_observability.ExplainProcessingResultError,
+		}
+		for i, result := range results {
+			digest := fmt.Sprintf("digest_%d", i)
+			require.NoError(t, c.sendExplainPlansOutput(
+				"some_schema",
+				digest,
+				base.Format(time.RFC3339),
+				result,
+				"",
+				nil,
+			))
+			require.Equal(t, base, c.lastEmittedAt[explainPlanQueryKey("some_schema", digest)])
+		}
+
+		lokiClient.Stop()
+		require.Len(t, lokiClient.Received(), len(results))
+	})
+
+	t.Run("skips explain within interval and retries after interval", func(t *testing.T) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.NoError(t, err)
 		defer db.Close()
 
-		lastSeen := time.Now().Add(-time.Hour)
 		lokiClient := loki.NewCollectingHandler()
 		defer lokiClient.Stop()
 
-		logBuffer := syncbuffer.Buffer{}
-		logger, err := logging.New(&logBuffer, logging.Options{
-			Level:  logging.LevelDebug,
-			Format: logging.FormatLogfmt,
+		c, err := NewExplainPlans(ExplainPlansArguments{
+			DB:             db,
+			Logger:         util.TestAlloyLogger(t).Slog(),
+			PerScrapeRatio: 1,
+			EntryHandler:   lokiClient,
+			DBVersion:      "8.0.32",
 		})
 		require.NoError(t, err)
+
+		fakeNow := base
+		c.now = func() time.Time { return fakeNow }
+		qi := newQueryInfo("some_schema", "some_digest", "select * from some_table")
+		explainJSON := []byte(`{"query_block":{"table":{"table_name":"some_table","access_type":"ALL"}}}`)
+
+		expectExplain := func() {
+			mock.ExpectExec("USE `some_schema`").WillReturnResult(sqlmock.NewResult(0, 0))
+			mock.ExpectQuery(selectExplainPlanPrefix + qi.queryText).
+				WillReturnRows(sqlmock.NewRows([]string{"json"}).AddRow(explainJSON))
+		}
+		queueQuery := func() {
+			c.queryCache[qi.uniqueKey] = qi
+			c.currentBatchSize = 1
+		}
+
+		expectExplain()
+		queueQuery()
+		require.NoError(t, c.fetchExplainPlans(t.Context()))
+		require.Equal(t, base, c.lastEmittedAt[qi.uniqueKey])
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		fakeNow = base.Add(time.Minute)
+		queueQuery()
+		require.NoError(t, c.fetchExplainPlans(t.Context()))
+		require.Empty(t, c.queryCache)
+		require.Equal(t, base, c.lastEmittedAt[qi.uniqueKey])
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		fakeNow = base.Add(database_observability.EmitInterval + time.Minute)
+		expectExplain()
+		queueQuery()
+		require.NoError(t, c.fetchExplainPlans(t.Context()))
+		require.Equal(t, fakeNow, c.lastEmittedAt[qi.uniqueKey])
+		require.NoError(t, mock.ExpectationsWereMet())
+		lokiClient.Stop()
+		require.Len(t, lokiClient.Received(), 2)
+	})
+
+	t.Run("filters throttled discoveries without consuming batch capacity", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
 
 		c, err := NewExplainPlans(ExplainPlansArguments{
 			DB:              db,
-			Logger:          logger.Slog(),
-			ScrapeInterval:  time.Second,
+			Logger:          util.TestAlloyLogger(t).Slog(),
 			PerScrapeRatio:  1,
+			InitialLookback: base.Add(-time.Hour),
+		})
+		require.NoError(t, err)
+
+		fakeNow := base.Add(time.Minute)
+		c.now = func() time.Time { return fakeNow }
+		throttledKey := explainPlanQueryKey("some_schema", "throttled_digest")
+		c.lastEmittedAt[throttledKey] = base
+
+		nextSeen := base.Add(2 * time.Minute)
+		mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).
+			WithArgs(base.Add(-time.Hour)).
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name", "digest", "query_sample_text", "last_seen"}).
+				AddRow("some_schema", "throttled_digest", "select * from throttled_table", base).
+				AddRow("some_schema", "due_digest", "select * from due_table", nextSeen))
+
+		require.NoError(t, c.populateQueryCache(t.Context()))
+		require.NotContains(t, c.queryCache, throttledKey)
+		require.Contains(t, c.queryCache, explainPlanQueryKey("some_schema", "due_digest"))
+		require.Equal(t, 1, c.currentBatchSize)
+		require.Equal(t, nextSeen, c.lastSeen)
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		fakeNow = base.Add(database_observability.EmitInterval)
+		c.pruneExpiredThrottle()
+		require.NotContains(t, c.lastEmittedAt, throttledKey)
+	})
+
+	t.Run("throttles denylist output", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		c, err := NewExplainPlans(ExplainPlansArguments{
+			DB:              db,
+			Logger:          util.TestAlloyLogger(t).Slog(),
+			PerScrapeRatio:  1,
+			InitialLookback: base.Add(-time.Hour),
 			EntryHandler:    lokiClient,
 			DBVersion:       "8.0.32",
-			InitialLookback: lastSeen,
 		})
 		require.NoError(t, err)
+		c.now = func() time.Time { return base }
 
-		t.Run("skips truncated queries", func(t *testing.T) {
-			logBuffer.Reset()
-			mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
-				"schema_name",
-				"digest",
-				"query_sample_text",
-				"last_seen",
-			}).AddRow(
-				"some_schema",
-				"some_digest",
-				"select * from some_table where ...",
-				lastSeen,
-			))
+		key := explainPlanQueryKey("some_schema", "some_digest")
+		c.queryDenylist[key] = struct{}{}
+		require.NoError(t, c.sendExplainPlansOutput(
+			"some_schema",
+			"some_digest",
+			base.Format(time.RFC3339),
+			database_observability.ExplainProcessingResultSkipped,
+			"query denylisted",
+			nil,
+		))
 
-			err = c.fetchExplainPlans(t.Context())
-			require.NoError(t, err)
+		mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).
+			WithArgs(base.Add(-time.Hour)).
+			WillReturnRows(sqlmock.NewRows([]string{"schema_name", "digest", "query_sample_text", "last_seen"}).
+				AddRow("some_schema", "some_digest", "select * from some_table", base))
 
-			require.Eventually(
-				t,
-				func() bool { return len(lokiClient.Received()) == 1 },
-				5*time.Second,
-				10*time.Millisecond,
-				"did not receive the explain plan output log message within the timeout",
-			)
-			require.NotContains(t, logBuffer.String(), "error")
-			lokiEntries := lokiClient.Received()
-			require.Equal(t, 1, len(lokiEntries))
-			epo, err := database_observability.ExtractExplainPlanOutputFromLogMsg(lokiEntries[0])
-			require.NoError(t, err)
-			require.Equal(t, database_observability.ExplainProcessingResultSkipped, epo.Metadata.ProcessingResult)
-			require.Equal(t, "query is truncated", epo.Metadata.ProcessingResultReason)
-			lokiClient.Clear()
-		})
-
-		t.Run("skips non-select queries", func(t *testing.T) {
-			lokiClient.Clear()
-			logBuffer.Reset()
-			mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
-				"schema_name",
-				"digest",
-				"query_sample_text",
-				"last_seen",
-			}).AddRow(
-				"some_schema",
-				"update_digest",
-				"update some_table set col = 1 where id = 1",
-				lastSeen,
-			).AddRow(
-				"some_schema",
-				"delete_digest",
-				"delete from some_table",
-				lastSeen,
-			).AddRow(
-				"some_schema",
-				"insert_digest",
-				"insert into some_table (col) values (1)",
-				lastSeen,
-			).AddRow(
-				"some_schema",
-				"show_digest",
-				"show global status like 'Uptime'",
-				lastSeen,
-			).AddRow(
-				"some_schema",
-				"kill_digest",
-				"kill query 123",
-				lastSeen,
-			).AddRow(
-				"some_schema",
-				"call_digest",
-				"call refresh_summary()",
-				lastSeen,
-			).AddRow(
-				"some_schema",
-				"do_digest",
-				"do release_lock('foo')",
-				lastSeen,
-			))
-
-			err = c.fetchExplainPlans(t.Context())
-			require.NoError(t, err)
-
-			require.Eventually(
-				t,
-				func() bool { return len(lokiClient.Received()) == 7 },
-				5*time.Second,
-				10*time.Millisecond,
-				"did not receive the explain plan output log messages within the timeout",
-			)
-
-			lokiEntries := lokiClient.Received()
-			require.Equal(t, 7, len(lokiEntries))
-
-			for _, lokiEntry := range lokiEntries {
-				ep, err := database_observability.ExtractExplainPlanOutputFromLogMsg(lokiEntry)
-				require.NoError(t, err)
-				require.Equal(t, database_observability.ExplainProcessingResultSkipped, ep.Metadata.ProcessingResult)
-				require.Equal(t, "query contains reserved word", ep.Metadata.ProcessingResultReason)
-			}
-
-			require.NotContains(t, logBuffer.String(), "error")
-			lokiClient.Clear()
-		})
-
-		t.Run("skips no row result", func(t *testing.T) {
-			logBuffer.Reset()
-			mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
-				"schema_name",
-				"digest",
-				"query_sample_text",
-				"last_seen",
-			}).AddRow(
-				"some_schema",
-				"some_digest",
-				"select * from some_table where id = 1",
-				lastSeen,
-			))
-
-			mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
-
-			mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 1").WillReturnRows(sqlmock.NewRows([]string{
-				"json",
-			}).AddRow(
-				[]byte(`{"query_block": {"message": "no matching row in const table"}}`),
-			))
-
-			err = c.fetchExplainPlans(t.Context())
-			require.NoError(t, err)
-
-			lokiClient.Clear()
-
-			require.NotContains(t, logBuffer.String(), "error")
-			require.Contains(t, logBuffer.String(), "no matching row in const table")
-		})
-
-		t.Run("passes queries beginning in select", func(t *testing.T) {
-			lokiClient.Clear()
-			logBuffer.Reset()
-			mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
-				"schema_name",
-				"digest",
-				"query_sample_text",
-				"last_seen",
-			}).AddRow(
-				"some_schema",
-				"some_digest",
-				"select * from some_table where id = 1",
-				lastSeen,
-			))
-
-			mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
-
-			mock.ExpectQuery(selectExplainPlanPrefix + "select * from some_table where id = 1").WillReturnRows(sqlmock.NewRows([]string{
-				"json",
-			}).AddRow(
-				[]byte(`{"query_block": {"select_id": 1}}`),
-			))
-
-			err = c.fetchExplainPlans(t.Context())
-			require.NoError(t, err)
-
-			require.NotContains(t, logBuffer.String(), "error")
-
-			require.Eventually(
-				t,
-				func() bool { return len(lokiClient.Received()) == 1 },
-				5*time.Second,
-				10*time.Millisecond,
-				"did not receive the explain plan output log message within the timeout",
-			)
-		})
-
-		t.Run("passes queries beginning in with", func(t *testing.T) {
-			lokiClient.Clear()
-			logBuffer.Reset()
-			mock.ExpectQuery(fmt.Sprintf(selectDigestsForExplainPlan, exclusionClause)).WithArgs(lastSeen).RowsWillBeClosed().WillReturnRows(sqlmock.NewRows([]string{
-				"schema_name",
-				"digest",
-				"query_sample_text",
-				"last_seen",
-			}).AddRow(
-				"some_schema",
-				"some_digest",
-				"with cte as (select * from some_table where id = 1) select * from cte",
-				lastSeen,
-			))
-
-			mock.ExpectExec("USE `some_schema`").WithoutArgs().WillReturnResult(sqlmock.NewResult(0, 0))
-
-			mock.ExpectQuery(selectExplainPlanPrefix + "with cte as (select * from some_table where id = 1) select * from cte").WillReturnRows(sqlmock.NewRows([]string{
-				"json",
-			}).AddRow(
-				[]byte(`{"query_block": {"select_id": 1}}`),
-			))
-
-			err = c.fetchExplainPlans(t.Context())
-			require.NoError(t, err)
-
-			require.NotContains(t, logBuffer.String(), "error")
-
-			require.Eventually(
-				t,
-				func() bool { return len(lokiClient.Received()) == 1 },
-				5*time.Second,
-				10*time.Millisecond,
-				"did not receive the explain plan output log message within the timeout",
-			)
-		})
-
-		err = mock.ExpectationsWereMet()
-		require.NoError(t, err)
+		require.NoError(t, c.populateQueryCache(t.Context()))
+		require.Empty(t, c.queryCache)
+		require.Equal(t, base, c.lastSeen)
+		require.Equal(t, base, c.lastEmittedAt[key])
+		require.NoError(t, mock.ExpectationsWereMet())
+		lokiClient.Stop()
+		require.Len(t, lokiClient.Received(), 1)
 	})
 }
 
@@ -1827,7 +2088,7 @@ func TestQueryFailureDenylist(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	queryUnderTestHash := "some_schemasome_digest1"
+	queryUnderTestHash := explainPlanQueryKey("some_schema", "some_digest1")
 
 	c, err := NewExplainPlans(ExplainPlansArguments{
 		DB:              db,
@@ -1852,6 +2113,7 @@ func TestQueryFailureDenylist(t *testing.T) {
 	))
 
 	c.populateQueryCache(t.Context())
+
 	t.Run("non-recoverable sql error denylists query", func(t *testing.T) {
 		lokiClient.Clear()
 		logBuffer.Reset()
@@ -1865,6 +2127,7 @@ func TestQueryFailureDenylist(t *testing.T) {
 		require.Equal(t, 0, len(c.queryCache))
 		require.Equal(t, 1, len(c.queryDenylist))
 		require.Contains(t, c.queryDenylist, queryUnderTestHash)
+		require.Empty(t, c.lastEmittedAt, "a failure without explain_plan_output must remain unthrottled")
 	})
 
 	t.Run("denylisted queries are not added to query cache", func(t *testing.T) {
@@ -1926,10 +2189,10 @@ func TestBatchSizeLimitsProcessing(t *testing.T) {
 	require.NoError(t, err)
 
 	c.queryCache = map[string]*queryInfo{
-		"s1d1": newQueryInfo("s1", "d1", "select * from t1 where ..."),
-		"s1d2": newQueryInfo("s1", "d2", "select * from t2 where ..."),
-		"s1d3": newQueryInfo("s1", "d3", "select * from t3 where ..."),
-		"s1d4": newQueryInfo("s1", "d4", "select * from t4 where ..."),
+		explainPlanQueryKey("s1", "d1"): newQueryInfo("s1", "d1", "select * from t1 where ..."),
+		explainPlanQueryKey("s1", "d2"): newQueryInfo("s1", "d2", "select * from t2 where ..."),
+		explainPlanQueryKey("s1", "d3"): newQueryInfo("s1", "d3", "select * from t3 where ..."),
+		explainPlanQueryKey("s1", "d4"): newQueryInfo("s1", "d4", "select * from t4 where ..."),
 	}
 	c.currentBatchSize = 2
 
@@ -1938,7 +2201,8 @@ func TestBatchSizeLimitsProcessing(t *testing.T) {
 
 	require.Equal(t, 2, len(c.queryCache), "batch size limit should leave unprocessed items in cache")
 
-	require.Eventually(t,
+	require.Eventually(
+		t,
 		func() bool { return len(lokiClient.Received()) == 2 },
 		5*time.Second, 10*time.Millisecond,
 		"expected exactly 2 loki entries (one per processed item), got %d", len(lokiClient.Received()),

--- a/internal/component/database_observability/mysql/collector/schema_details.go
+++ b/internal/component/database_observability/mysql/collector/schema_details.go
@@ -24,11 +24,6 @@ const (
 	OP_CREATE_STATEMENT    = "create_statement"
 )
 
-// emitInterval is the minimum amount of time that must elapse between
-// successive OP_CREATE_STATEMENT emissions for the same table, regardless of
-// the configured collect_interval.
-const emitInterval = 30 * time.Minute
-
 const (
 	selectTablesTemplate = `
 	SELECT
@@ -281,13 +276,13 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	}
 
 	// Compute the due set: tables that have never emitted OP_CREATE_STATEMENT
-	// or whose last emission is older than emitInterval.
+	// or whose last emission is older than EmitInterval.
 	// Group by schema to preserve the iteration order from the tables-list query.
 	dueBySchema := map[string][]*tableInfo{}
 	dueSchemas := []string{}
 	for _, t := range tables {
 		k := fullyQualifiedName(t.schema, t.tableName)
-		if last, ok := c.lastEmittedAt[k]; ok && now.Sub(last) < emitInterval {
+		if last, ok := c.lastEmittedAt[k]; ok && now.Sub(last) < database_observability.EmitInterval {
 			continue
 		}
 		if _, exists := dueBySchema[t.schema]; !exists {

--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -528,7 +528,7 @@ func TestSchemaDetails(t *testing.T) {
 				AddRow("some_schema.some_table", "CREATE TABLE some_table (id INT)"))
 
 		// Second scrape: only the tables list. The scrape is throttled (still
-		// within emitInterval) so it must not trigger any create-statement
+		// within EmitInterval) so it must not trigger any create-statement
 		// related queries.
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{
@@ -540,7 +540,7 @@ func TestSchemaDetails(t *testing.T) {
 			))
 
 		require.NoError(t, collector.extractSchema(t.Context()))
-		fakeNow = fakeNow.Add(time.Minute) // well within emitInterval
+		fakeNow = fakeNow.Add(time.Minute) // well within EmitInterval
 		require.NoError(t, collector.extractSchema(t.Context()))
 
 		// First scrape emits OP_TABLE_DETECTION + OP_CREATE_STATEMENT; second
@@ -620,7 +620,7 @@ func TestSchemaDetails(t *testing.T) {
 		}
 
 		require.NoError(t, collector.extractSchema(t.Context()))
-		fakeNow = fakeNow.Add(emitInterval + time.Minute) // past the throttle window
+		fakeNow = fakeNow.Add(database_observability.EmitInterval + time.Minute) // past the throttle window
 		require.NoError(t, collector.extractSchema(t.Context()))
 
 		require.Eventually(t, func() bool {
@@ -713,7 +713,7 @@ func TestSchemaDetails(t *testing.T) {
 
 		// Second scrape: only table_a remains. table_b should be evicted from
 		// the throttle map by housekeeping. Since table_a was already emitted
-		// less than emitInterval ago, no further fetch queries are expected.
+		// less than EmitInterval ago, no further fetch queries are expected.
 		fakeNow = fakeNow.Add(time.Minute)
 		mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{

--- a/internal/component/database_observability/postgres/collector/explain_plans.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans.go
@@ -203,12 +203,16 @@ type processedQueryInfo struct {
 	callsReset time.Time
 }
 
+func explainPlanQueryKey(datname, queryId string) string {
+	return fmt.Sprintf("%s:%s", datname, queryId)
+}
+
 func newQueryInfo(datname, queryId, queryText string, calls int64, callsReset time.Time) *queryInfo {
 	return &queryInfo{
 		datname:    datname,
 		queryId:    queryId,
 		queryText:  queryText,
-		uniqueKey:  datname + queryId,
+		uniqueKey:  explainPlanQueryKey(datname, queryId),
 		calls:      calls,
 		callsReset: callsReset,
 	}
@@ -241,6 +245,8 @@ type ExplainPlans struct {
 	perScrapeRatio      float64
 	currentBatchSize    int
 	entryHandler        loki.EntryHandler
+	lastEmittedAt       map[string]time.Time
+	now                 func() time.Time
 	logger              *slog.Logger
 	running             *atomic.Bool
 	ctx                 context.Context
@@ -260,6 +266,8 @@ func NewExplainPlan(args ExplainPlansArguments) (*ExplainPlans, error) {
 		queryCache:          make(map[string]*queryInfo),
 		queryDenylist:       make(map[string]struct{}),
 		finishedQueryCache:  make(map[string]processedQueryInfo),
+		lastEmittedAt:       make(map[string]time.Time),
+		now:                 time.Now,
 		entryHandler:        args.EntryHandler,
 		logger:              args.Logger.With("collector", ExplainPlanCollector),
 		running:             atomic.NewBool(false),
@@ -273,6 +281,43 @@ func NewExplainPlan(args ExplainPlansArguments) (*ExplainPlans, error) {
 	ep.dbVersion = engineSemver
 
 	return ep, nil
+}
+
+func (c *ExplainPlans) currentTime() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+func (c *ExplainPlans) isThrottled(key string) bool {
+	last, ok := c.lastEmittedAt[key]
+	return ok && c.currentTime().Sub(last) < database_observability.EmitInterval
+}
+
+func (c *ExplainPlans) recordEmission(key string) {
+	if c.lastEmittedAt == nil {
+		c.lastEmittedAt = make(map[string]time.Time)
+	}
+	c.lastEmittedAt[key] = c.currentTime()
+}
+
+func (c *ExplainPlans) markFinished(qi *queryInfo) {
+	if c.finishedQueryCache == nil {
+		c.finishedQueryCache = make(map[string]processedQueryInfo)
+	}
+	c.finishedQueryCache[qi.uniqueKey] = processedQueryInfo{
+		calls:      qi.calls,
+		callsReset: qi.callsReset,
+	}
+}
+
+func (c *ExplainPlans) pruneThrottle(seen map[string]struct{}) {
+	for key := range c.lastEmittedAt {
+		if _, ok := seen[key]; !ok {
+			delete(c.lastEmittedAt, key)
+		}
+	}
 }
 
 func (c *ExplainPlans) sendExplainPlansOutput(schemaName string, digest string, generatedAt string, result database_observability.ExplainProcessingResult, reason string, plan *database_observability.ExplainPlanNode) error {
@@ -307,6 +352,7 @@ func (c *ExplainPlans) sendExplainPlansOutput(schemaName string, digest string, 
 		OP_EXPLAIN_PLAN_OUTPUT,
 		logMessage,
 	)
+	c.recordEmission(explainPlanQueryKey(schemaName, digest))
 
 	return nil
 }
@@ -382,6 +428,7 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 	}
 	defer rs.Close()
 
+	seen := make(map[string]struct{})
 	for rs.Next() {
 		generatedAt := time.Now().Format(time.RFC3339)
 		var datname, queryId, query string
@@ -396,37 +443,46 @@ func (c *ExplainPlans) populateQueryCache(ctx context.Context) error {
 			statsReset = ls
 		}
 		qi := newQueryInfo(datname, queryId, query, calls, statsReset)
-		if _, ok := c.queryDenylist[qi.uniqueKey]; !ok {
-			if previous, ok := c.finishedQueryCache[qi.uniqueKey]; ok {
-				if calls == previous.calls {
-					continue
+		seen[qi.uniqueKey] = struct{}{}
+
+		if _, ok := c.queryDenylist[qi.uniqueKey]; ok {
+			if !c.isThrottled(qi.uniqueKey) {
+				err := c.sendExplainPlansOutput(
+					datname,
+					queryId,
+					generatedAt,
+					database_observability.ExplainProcessingResultSkipped,
+					"query denylisted",
+					nil,
+				)
+				if err != nil {
+					c.logger.Error("failed to send denylisted query skip explain plan output", "err", err)
 				}
-				if calls < previous.calls && (statsReset.Equal(previous.callsReset) || statsReset.Before(previous.callsReset)) {
-					continue
-				}
-				delete(c.finishedQueryCache, qi.uniqueKey)
-			}
-			c.queryCache[qi.uniqueKey] = qi
-		} else {
-			err := c.sendExplainPlansOutput(
-				datname,
-				queryId,
-				generatedAt,
-				database_observability.ExplainProcessingResultSkipped,
-				"query denylisted",
-				nil,
-			)
-			if err != nil {
-				c.logger.Error("failed to send denylisted query skip explain plan output", "err", err)
 			}
 			continue
 		}
+
+		if previous, ok := c.finishedQueryCache[qi.uniqueKey]; ok {
+			if calls == previous.calls {
+				continue
+			}
+			if calls < previous.calls && (statsReset.Equal(previous.callsReset) || statsReset.Before(previous.callsReset)) {
+				continue
+			}
+		}
+		if c.isThrottled(qi.uniqueKey) {
+			c.markFinished(qi)
+			continue
+		}
+		delete(c.finishedQueryCache, qi.uniqueKey)
+		c.queryCache[qi.uniqueKey] = qi
 	}
 
 	if err := rs.Err(); err != nil {
 		return fmt.Errorf("failed to iterate query rows for explain plans: %w", err)
 	}
 
+	c.pruneThrottle(seen)
 	c.currentBatchSize = int(math.Ceil(float64(len(c.queryCache)) * c.perScrapeRatio))
 	c.logger.Debug("populated query cache", "count", len(c.queryCache), "batch_size", c.currentBatchSize)
 	return nil
@@ -443,6 +499,11 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 	for _, qi := range c.queryCache {
 		generatedAt := time.Now().Format(time.RFC3339)
 		nonRecoverableFailureOccurred := false
+		if c.isThrottled(qi.uniqueKey) {
+			c.markFinished(qi)
+			delete(c.queryCache, qi.uniqueKey)
+			continue
+		}
 		if processedCount >= c.currentBatchSize {
 			break
 		}
@@ -452,10 +513,7 @@ func (c *ExplainPlans) fetchExplainPlans(ctx context.Context) error {
 			if *nonRecoverableFailureOccurred {
 				c.queryDenylist[qi.uniqueKey] = struct{}{}
 			} else {
-				c.finishedQueryCache[qi.uniqueKey] = processedQueryInfo{
-					calls:      qi.calls,
-					callsReset: qi.callsReset,
-				}
+				c.markFinished(qi)
 			}
 			delete(c.queryCache, qi.uniqueKey)
 			processedCount++

--- a/internal/component/database_observability/postgres/collector/explain_plans_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans_test.go
@@ -2286,6 +2286,8 @@ func TestNewExplainPlan(t *testing.T) {
 		assert.NotNil(t, explainPlan.queryCache)
 		assert.NotNil(t, explainPlan.queryDenylist)
 		assert.NotNil(t, explainPlan.finishedQueryCache)
+		assert.NotNil(t, explainPlan.lastEmittedAt)
+		assert.NotNil(t, explainPlan.now)
 		assert.NotNil(t, explainPlan.running)
 		assert.False(t, explainPlan.running.Load())
 	})
@@ -2319,6 +2321,168 @@ func TestNewExplainPlan(t *testing.T) {
 	})
 }
 
+func TestExplainPlansThrottling(t *testing.T) {
+	base := time.Date(2026, time.July, 31, 12, 0, 0, 0, time.UTC)
+
+	t.Run("all emitted results start the throttle", func(t *testing.T) {
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		c, err := NewExplainPlan(ExplainPlansArguments{
+			Logger:       logging.NewSlogNop(),
+			EntryHandler: lokiClient,
+			DBVersion:    "17.0",
+		})
+		require.NoError(t, err)
+		c.now = func() time.Time { return base }
+
+		results := []database_observability.ExplainProcessingResult{
+			database_observability.ExplainProcessingResultSuccess,
+			database_observability.ExplainProcessingResultSkipped,
+			database_observability.ExplainProcessingResultError,
+		}
+		for i, result := range results {
+			queryID := fmt.Sprintf("%d", i)
+			require.NoError(t, c.sendExplainPlansOutput(
+				"testdb",
+				queryID,
+				base.Format(time.RFC3339),
+				result,
+				"",
+				nil,
+			))
+			require.Equal(t, base, c.lastEmittedAt[explainPlanQueryKey("testdb", queryID)])
+		}
+
+		lokiClient.Stop()
+		require.Len(t, lokiClient.Received(), len(results))
+	})
+
+	t.Run("skips explain within interval and retries after interval", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		c, err := NewExplainPlan(ExplainPlansArguments{
+			DB:             db,
+			DSN:            "postgres://user:pass@host:1234/database",
+			Logger:         logging.NewSlogNop(),
+			PerScrapeRatio: 1,
+			EntryHandler:   lokiClient,
+			DBVersion:      "17.0",
+		})
+		require.NoError(t, err)
+
+		dbConnFactory := &mockDbConnectionFactory{
+			db:   db,
+			Mock: &mock,
+		}
+		c.dbConnectionFactory = dbConnFactory.NewDBConnection
+		fakeNow := base
+		c.now = func() time.Time { return fakeNow }
+
+		queryID := "123456"
+		key := explainPlanQueryKey("testdb", queryID)
+		require.NoError(t, c.sendExplainPlansOutput(
+			"testdb",
+			queryID,
+			base.Format(time.RFC3339),
+			database_observability.ExplainProcessingResultSuccess,
+			"",
+			nil,
+		))
+		require.Equal(t, base, c.lastEmittedAt[key])
+		c.finishedQueryCache[key] = processedQueryInfo{calls: 10, callsReset: base}
+
+		fakeNow = base.Add(time.Minute)
+		mock.ExpectQuery(fmt.Sprintf(selectQueriesForExplainPlanTemplate, "s.stats_since", exclusionClause, "")).
+			WillReturnRows(sqlmock.NewRows([]string{"datname", "queryid", "query", "calls", "stats_since"}).
+				AddRow("testdb", queryID, "select * from some_table", int64(11), base).
+				AddRow("otherdb", "654321", "select * from other_table", int64(1), base))
+
+		require.NoError(t, c.populateQueryCache(t.Context()))
+		require.NotContains(t, c.queryCache, key)
+		require.Contains(t, c.queryCache, explainPlanQueryKey("otherdb", "654321"))
+		require.Equal(t, int64(11), c.finishedQueryCache[key].calls)
+		require.Equal(t, 1, c.currentBatchSize)
+		require.Equal(t, 0, dbConnFactory.InstantiationCount)
+		require.Equal(t, base, c.lastEmittedAt[key])
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		delete(c.queryCache, explainPlanQueryKey("otherdb", "654321"))
+		fakeNow = base.Add(database_observability.EmitInterval + time.Minute)
+		mock.ExpectQuery(fmt.Sprintf(selectQueriesForExplainPlanTemplate, "s.stats_since", exclusionClause, "")).
+			WillReturnRows(sqlmock.NewRows([]string{"datname", "queryid", "query", "calls", "stats_since"}).
+				AddRow("testdb", queryID, "select * from some_table", int64(12), base))
+
+		require.NoError(t, c.populateQueryCache(t.Context()))
+		require.Contains(t, c.queryCache, key)
+		require.Equal(t, 1, c.currentBatchSize)
+
+		mock.ExpectExec(`SET SESSION search_path TO "testdb", public`).WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec("PREPARE explain_plan_123456 AS select * from some_table").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456").
+			WillReturnRows(sqlmock.NewRows([]string{"json"}).
+				AddRow([]byte(`[{"Plan":{"Node Type":"Seq Scan","Alias":"some_table","Total Cost":1,"Plan Rows":1}}]`)))
+		mock.ExpectExec("DEALLOCATE explain_plan_123456").WillReturnResult(sqlmock.NewResult(0, 1))
+
+		require.NoError(t, c.fetchExplainPlans(t.Context()))
+		require.Equal(t, fakeNow, c.lastEmittedAt[key])
+		require.Equal(t, 1, dbConnFactory.InstantiationCount)
+		require.NoError(t, mock.ExpectationsWereMet())
+		lokiClient.Stop()
+		require.Len(t, lokiClient.Received(), 2)
+	})
+
+	t.Run("throttles denylist output and prunes absent queries", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		lokiClient := loki.NewCollectingHandler()
+		defer lokiClient.Stop()
+
+		c, err := NewExplainPlan(ExplainPlansArguments{
+			DB:             db,
+			Logger:         logging.NewSlogNop(),
+			PerScrapeRatio: 1,
+			EntryHandler:   lokiClient,
+			DBVersion:      "17.0",
+		})
+		require.NoError(t, err)
+		c.now = func() time.Time { return base }
+
+		key := explainPlanQueryKey("testdb", "123456")
+		c.queryDenylist[key] = struct{}{}
+		require.NoError(t, c.sendExplainPlansOutput(
+			"testdb",
+			"123456",
+			base.Format(time.RFC3339),
+			database_observability.ExplainProcessingResultSkipped,
+			"query denylisted",
+			nil,
+		))
+		c.lastEmittedAt["absent999"] = base
+
+		mock.ExpectQuery(fmt.Sprintf(selectQueriesForExplainPlanTemplate, "s.stats_since", exclusionClause, "")).
+			WillReturnRows(sqlmock.NewRows([]string{"datname", "queryid", "query", "calls", "stats_since"}).
+				AddRow("testdb", "123456", "select * from some_table", int64(10), base))
+
+		require.NoError(t, c.populateQueryCache(t.Context()))
+		require.Empty(t, c.queryCache)
+		require.Contains(t, c.lastEmittedAt, key)
+		require.NotContains(t, c.lastEmittedAt, "absent999")
+		require.Equal(t, base, c.lastEmittedAt[key])
+		require.NoError(t, mock.ExpectationsWereMet())
+		lokiClient.Stop()
+		require.Len(t, lokiClient.Received(), 1)
+	})
+}
+
 func TestExplainPlan_Name(t *testing.T) {
 	explainPlan := &ExplainPlans{}
 	assert.Equal(t, ExplainPlanCollector, explainPlan.Name())
@@ -2348,7 +2512,7 @@ func TestNewQueryInfo(t *testing.T) {
 	assert.Equal(t, queryText, qi.queryText)
 	assert.Equal(t, calls, qi.calls)
 	assert.Equal(t, callsReset, qi.callsReset)
-	assert.Equal(t, datname+queryId, qi.uniqueKey)
+	assert.Equal(t, "testdb:123456789", qi.uniqueKey)
 }
 
 func TestPlanNode_TotalCost(t *testing.T) {
@@ -2564,7 +2728,7 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 			assert.Len(t, explainPlan.queryCache, 1)
 			assert.Equal(t, 1, explainPlan.currentBatchSize)
 
-			qi := explainPlan.queryCache["testdb123456"]
+			qi := explainPlan.queryCache[explainPlanQueryKey("testdb", "123456")]
 			assert.Equal(t, resetTime, qi.callsReset)
 
 			assert.NoError(t, mock.ExpectationsWereMet())
@@ -2601,8 +2765,8 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 			assert.Len(t, explainPlan.queryCache, 2)
 			assert.Equal(t, 1, explainPlan.currentBatchSize)
 
-			assert.Contains(t, explainPlan.queryCache, "testdb123456")
-			assert.Contains(t, explainPlan.queryCache, "testdb2345678")
+			assert.Contains(t, explainPlan.queryCache, explainPlanQueryKey("testdb", "123456"))
+			assert.Contains(t, explainPlan.queryCache, explainPlanQueryKey("testdb2", "345678"))
 
 			assert.NoError(t, mock.ExpectationsWereMet())
 		})
@@ -2621,7 +2785,7 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				entryHandler: lokiClient,
 				queryCache:   make(map[string]*queryInfo),
 				finishedQueryCache: map[string]processedQueryInfo{
-					"testdb123456": {calls: int64(10), callsReset: time.Now()},
+					explainPlanQueryKey("testdb", "123456"): {calls: int64(10), callsReset: time.Now()},
 				},
 			}
 
@@ -2647,7 +2811,7 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				entryHandler: lokiClient,
 				queryCache:   make(map[string]*queryInfo),
 				finishedQueryCache: map[string]processedQueryInfo{
-					"testdb123456": {calls: int64(10), callsReset: time.Now().Add(-time.Hour)},
+					explainPlanQueryKey("testdb", "123456"): {calls: int64(10), callsReset: time.Now().Add(-time.Hour)},
 				},
 			}
 
@@ -2674,7 +2838,7 @@ func TestExplainPlan_PopulateQueryCache(t *testing.T) {
 				entryHandler: lokiClient,
 				queryCache:   make(map[string]*queryInfo),
 				finishedQueryCache: map[string]processedQueryInfo{
-					"testdb123456": {calls: int64(10), callsReset: time.Now()},
+					explainPlanQueryKey("testdb", "123456"): {calls: int64(10), callsReset: time.Now()},
 				},
 			}
 
@@ -2786,6 +2950,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 		// Should succeed but not process any queries since they require actual DB connections
 		require.NoError(t, err)
 		require.Equal(t, 1, len(explainPlan.finishedQueryCache))
+		require.Empty(t, explainPlan.lastEmittedAt, "a failure without explain_plan_output must remain unthrottled")
 
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})
@@ -2811,7 +2976,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				dbDSN:               "postgres://user:pass@host:1234/database",
 				dbVersion:           post17ver,
 				queryCache: map[string]*queryInfo{
-					"testdb123456": {
+					explainPlanQueryKey("testdb", "123456"): {
 						queryId:    "123456",
 						queryText:  "SELECT * FROM users WHERE ...",
 						calls:      int64(10),
@@ -2854,37 +3019,37 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				dbDSN:               "postgres://user:pass@host:1234/database",
 				dbVersion:           post17ver,
 				queryCache: map[string]*queryInfo{
-					"testdb123456": {
+					explainPlanQueryKey("testdb", "123456"): {
 						queryId:    "123456",
 						queryText:  "update some_table set col = 1 where id = 1",
 						calls:      int64(10),
 						callsReset: time.Now(),
 					},
-					"testdb123457": {
+					explainPlanQueryKey("testdb", "123457"): {
 						queryId:    "123457",
 						queryText:  "delete from some_table",
 						calls:      int64(10),
 						callsReset: time.Now(),
 					},
-					"testdb123458": {
+					explainPlanQueryKey("testdb", "123458"): {
 						queryId:    "123458",
 						queryText:  "insert into some_table (col) values (1)",
 						calls:      int64(10),
 						callsReset: time.Now(),
 					},
-					"testdb123459": {
+					explainPlanQueryKey("testdb", "123459"): {
 						queryId:    "123459",
 						queryText:  "show search_path",
 						calls:      int64(10),
 						callsReset: time.Now(),
 					},
-					"testdb123460": {
+					explainPlanQueryKey("testdb", "123460"): {
 						queryId:    "123460",
 						queryText:  "call refresh_summary()",
 						calls:      int64(10),
 						callsReset: time.Now(),
 					},
-					"testdb123461": {
+					explainPlanQueryKey("testdb", "123461"): {
 						queryId:    "123461",
 						queryText:  "do 'begin perform 1; end'",
 						calls:      int64(10),
@@ -2936,7 +3101,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				dbConnectionFactory: dbConnFactory.NewDBConnection,
 				dbVersion:           post17ver,
 				queryCache: map[string]*queryInfo{
-					"testdb123456": {
+					explainPlanQueryKey("testdb", "123456"): {
 						datname:    "testdb",
 						queryId:    "123456",
 						queryText:  "select * from some_table where id = $1",
@@ -3003,7 +3168,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				dbConnectionFactory: dbConnFactory.NewDBConnection,
 				dbVersion:           post17ver,
 				queryCache: map[string]*queryInfo{
-					"testdb123456": {
+					explainPlanQueryKey("testdb", "123456"): {
 						datname:    "testdb",
 						queryId:    "123456",
 						queryText:  "with cte as (select * from some_table where id = $1) select * from cte",
@@ -3071,7 +3236,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				dbConnectionFactory: dbConnFactory.NewDBConnection,
 				dbVersion:           post17ver,
 				queryCache: map[string]*queryInfo{
-					"testdb123456": {
+					explainPlanQueryKey("testdb", "123456"): {
 						datname:    "testdb",
 						queryId:    "123456",
 						queryText:  dupParamQuery,
@@ -3139,7 +3304,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 				dbConnectionFactory: dbConnFactory.NewDBConnection,
 				dbVersion:           post17ver,
 				queryCache: map[string]*queryInfo{
-					"testdb123456": {
+					explainPlanQueryKey("testdb", "123456"): {
 						datname:    "testdb",
 						queryId:    "123456",
 						queryText:  "select * from some_table",
@@ -3238,7 +3403,7 @@ func TestExplainPlans_ExcludeDatabases_NoLogSent(t *testing.T) {
 
 	// Verify only included_db query is in the cache
 	assert.Len(t, explainPlan.queryCache, 1)
-	assert.Contains(t, explainPlan.queryCache, "included_db222222")
+	assert.Contains(t, explainPlan.queryCache, explainPlanQueryKey("included_db", "222222"))
 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -3285,7 +3450,7 @@ func TestExplainPlans_ExcludeUsers(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, explainPlan.queryCache, 1)
-	assert.Contains(t, explainPlan.queryCache, "testdb111111")
+	assert.Contains(t, explainPlan.queryCache, explainPlanQueryKey("testdb", "111111"))
 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -25,11 +25,6 @@ const (
 	OP_CREATE_STATEMENT    = "create_statement"
 )
 
-// emitInterval is the minimum amount of time that must elapse between
-// successive OP_CREATE_STATEMENT emissions for the same table, regardless of
-// the configured collect_interval.
-const emitInterval = 30 * time.Minute
-
 const (
 	// selectAllDatabases makes use of the initial DB connection to discover other databases on the same Postgres instance
 	selectAllDatabases = `
@@ -331,7 +326,7 @@ type SchemaDetails struct {
 	// lastEmittedAt records the wall-clock time at which OP_CREATE_STATEMENT
 	// was last emitted for a table. The outer key is the database name and
 	// the inner key is "schema.table". Used to throttle logging to at most
-	// one per emitInterval per table.
+	// one per EmitInterval per table.
 	lastEmittedAt map[database]map[string]time.Time
 
 	// now allows overriding time.Now() in tests
@@ -539,7 +534,7 @@ func (c *SchemaDetails) extractSchemas(ctx context.Context, dbName string, dbCon
 	for _, table := range tables {
 		key := schemaTableKey(table.schema, table.tableName)
 		if inner := c.lastEmittedAt[db]; inner != nil {
-			if last, ok := inner[key]; ok && now.Sub(last) < emitInterval {
+			if last, ok := inner[key]; ok && now.Sub(last) < database_observability.EmitInterval {
 				continue
 			}
 		}

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/internal/util/syncbuffer"
@@ -1172,7 +1173,7 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 		}
 
 		require.NoError(t, collector.extractNames(context.Background()))
-		fakeNow = fakeNow.Add(emitInterval + time.Minute) // past the throttle window
+		fakeNow = fakeNow.Add(database_observability.EmitInterval + time.Minute) // past the throttle window
 		require.NoError(t, collector.extractNames(context.Background()))
 
 		require.Eventually(t, func() bool {
@@ -1243,7 +1244,7 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 
 		// Second scrape: only table_a remains. table_b should be evicted from
 		// the throttle map by housekeeping. Since table_a was already emitted
-		// less than emitInterval ago, no further metadata queries are expected.
+		// less than EmitInterval ago, no further metadata queries are expected.
 		fakeNow = fakeNow.Add(time.Minute)
 		mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 			WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("throttle_test_db"))
@@ -1388,7 +1389,7 @@ func Test_Postgres_SchemaDetails_throttling(t *testing.T) {
 		require.Contains(t, collector.lastEmittedAt[database("db_a")], schemaTableKey("public", "test_table"))
 		require.Contains(t, collector.lastEmittedAt[database("db_b")], schemaTableKey("public", "test_table"))
 
-		// Second scrape (within emitInterval): db_a scrapes successfully but
+		// Second scrape (within EmitInterval): db_a scrapes successfully but
 		// is throttled (no metadata queries). db_b's selectSchemaNames fails
 		// transiently. The throttle entry for db_b must survive — otherwise
 		// the throttle guarantee is broken.

--- a/internal/component/database_observability/sql_server/collector/query_details.go
+++ b/internal/component/database_observability/sql_server/collector/query_details.go
@@ -66,7 +66,7 @@ type QueryDetails struct {
 
 	// lastEmittedAt records the wall-clock time at which OP_QUERY_ASSOCIATION
 	// was last emitted for a (database, query_hash), used to throttle logging
-	// to at most one emission per emitInterval per query.
+	// to at most one emission per EmitInterval per query.
 	lastEmittedAt map[queryMetricsKey]time.Time
 
 	// now allows overriding time.Now() in tests.
@@ -206,7 +206,7 @@ func (c *QueryDetails) collect(ctx context.Context) error {
 		}
 		seen[key] = struct{}{}
 
-		if last, ok := c.lastEmittedAt[key]; ok && now.Sub(last) < emitInterval {
+		if last, ok := c.lastEmittedAt[key]; ok && now.Sub(last) < database_observability.EmitInterval {
 			continue
 		}
 

--- a/internal/component/database_observability/sql_server/collector/query_details_test.go
+++ b/internal/component/database_observability/sql_server/collector/query_details_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/util"
 )
 
@@ -237,6 +238,7 @@ func TestQueryDetails_ThrottlesWithinEmitInterval(t *testing.T) {
 
 	base := time.Now()
 	c.now = func() time.Time { return base }
+	key := queryMetricsKey{database: testDatabase, queryHash: testHash}
 
 	poll := func() {
 		t.Helper()
@@ -247,19 +249,22 @@ func TestQueryDetails_ThrottlesWithinEmitInterval(t *testing.T) {
 
 	// First cycle emits the association + parsed table (2 entries).
 	poll()
-	require.Eventually(t, func() bool { return len(lokiClient.Received()) == 2 }, 5*time.Second, 20*time.Millisecond)
+	require.Equal(t, base, c.lastEmittedAt[key])
 
-	// Second cycle within emitInterval: the query still runs but nothing new is emitted.
-	c.now = func() time.Time { return base.Add(emitInterval / 2) }
+	// Second cycle within EmitInterval: the query still runs but nothing new is emitted.
+	c.now = func() time.Time { return base.Add(database_observability.EmitInterval / 2) }
 	poll()
-	require.Never(t, func() bool { return len(lokiClient.Received()) != 2 }, 500*time.Millisecond, 50*time.Millisecond)
+	require.Equal(t, base, c.lastEmittedAt[key])
 
-	// Once emitInterval has elapsed, the query is emitted again (2 more entries).
-	c.now = func() time.Time { return base.Add(emitInterval + time.Minute) }
+	// Once EmitInterval has elapsed, the query is emitted again (2 more entries).
+	afterInterval := base.Add(database_observability.EmitInterval + time.Minute)
+	c.now = func() time.Time { return afterInterval }
 	poll()
-	require.Eventually(t, func() bool { return len(lokiClient.Received()) == 4 }, 5*time.Second, 20*time.Millisecond)
+	require.Equal(t, afterInterval, c.lastEmittedAt[key])
 
 	require.NoError(t, mock.ExpectationsWereMet())
+	lokiClient.Stop()
+	require.Len(t, lokiClient.Received(), 4)
 }
 
 func TestBuildQueryTextStatement(t *testing.T) {

--- a/internal/component/database_observability/sql_server/collector/schema_details.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details.go
@@ -23,11 +23,6 @@ const (
 	OP_CREATE_STATEMENT    = "create_statement"
 )
 
-// emitInterval is the minimum amount of time that must elapse between
-// successive OP_CREATE_STATEMENT emissions for the same table, regardless of
-// the configured collect_interval.
-const emitInterval = 30 * time.Minute
-
 const (
 	selectDatabasesTemplate = `
 		SELECT name, QUOTENAME(name)
@@ -132,7 +127,7 @@ type SchemaDetails struct {
 	// lastEmittedAt records the wall-clock time at which OP_CREATE_STATEMENT
 	// was last emitted for a table. The outer key is the database name and
 	// the inner key is "schema.table". Used to throttle logging to at most
-	// one per emitInterval per table.
+	// one per EmitInterval per table.
 	lastEmittedAt map[string]map[string]time.Time
 
 	// now allows overriding time.Now() in tests
@@ -289,7 +284,7 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	// returns (dropped, access revoked, newly excluded). Per-table cleanup
 	// within a still-present database is handled by extractSchemaForDatabase
 	// and is gated on a clean scan so a transient failure does not evict
-	// state that would defeat emitInterval on the next successful cycle.
+	// state that would defeat EmitInterval on the next successful cycle.
 	for db := range c.lastEmittedAt {
 		if _, ok := discovered[db]; !ok {
 			delete(c.lastEmittedAt, db)
@@ -376,13 +371,13 @@ func (c *SchemaDetails) extractSchemaForDatabase(ctx context.Context, conn *sql.
 	}
 
 	// Compute the due set: tables that have never emitted OP_CREATE_STATEMENT
-	// or whose last emission is older than emitInterval.
+	// or whose last emission is older than EmitInterval.
 	// Group by schema to preserve the iteration order from the tables-list query.
 	dueBySchema := map[string][]*tableInfo{}
 	dueSchemas := []string{}
 	for _, t := range tables {
 		if inner := c.lastEmittedAt[dbName]; inner != nil {
-			if last, ok := inner[schemaTableKey(t.schema, t.tableName)]; ok && now.Sub(last) < emitInterval {
+			if last, ok := inner[schemaTableKey(t.schema, t.tableName)]; ok && now.Sub(last) < database_observability.EmitInterval {
 				continue
 			}
 		}

--- a/internal/component/database_observability/sql_server/collector/schema_details_test.go
+++ b/internal/component/database_observability/sql_server/collector/schema_details_test.go
@@ -425,7 +425,7 @@ func TestSchemaDetails(t *testing.T) {
 			}))
 
 		// Second scrape: only the tables list. The scrape is throttled (still
-		// within emitInterval) so it must not trigger any metadata queries.
+		// within EmitInterval) so it must not trigger any metadata queries.
 		expectListDatabases(mock, "some_db")
 		expectUseDatabase(mock, "some_db")
 
@@ -435,7 +435,7 @@ func TestSchemaDetails(t *testing.T) {
 			}).AddRow("some_db", "dbo", "some_table", "BASE TABLE"))
 
 		require.NoError(t, collector.extractSchema(t.Context()))
-		fakeNow = fakeNow.Add(time.Minute) // well within emitInterval
+		fakeNow = fakeNow.Add(time.Minute) // well within EmitInterval
 		require.NoError(t, collector.extractSchema(t.Context()))
 
 		// First scrape emits OP_TABLE_DETECTION + OP_CREATE_STATEMENT; second
@@ -503,7 +503,7 @@ func TestSchemaDetails(t *testing.T) {
 		}
 
 		require.NoError(t, collector.extractSchema(t.Context()))
-		fakeNow = fakeNow.Add(emitInterval + time.Minute) // past the throttle window
+		fakeNow = fakeNow.Add(database_observability.EmitInterval + time.Minute) // past the throttle window
 		require.NoError(t, collector.extractSchema(t.Context()))
 
 		require.Eventually(t, func() bool {
@@ -577,7 +577,7 @@ func TestSchemaDetails(t *testing.T) {
 		require.Contains(t, collector.lastEmittedAt["some_db"], schemaTableKey("dbo", "table_b"))
 
 		// Second scrape: only table_a remains. table_b should be evicted from
-		// the throttle map. Since table_a is still within emitInterval, no
+		// the throttle map. Since table_a is still within EmitInterval, no
 		// metadata queries are expected.
 		fakeNow = fakeNow.Add(time.Minute)
 		expectListDatabases(mock, "some_db")
@@ -1102,7 +1102,7 @@ func TestSchemaDetailsMultiDatabase_UseFailureContinues(t *testing.T) {
 // TestSchemaDetailsUseFailurePreservesThrottle verifies that a USE failure
 // for one database does not evict its throttle entries. Without this
 // guarantee a flapping database would re-emit OP_CREATE_STATEMENT on every
-// recovery, defeating emitInterval.
+// recovery, defeating EmitInterval.
 func TestSchemaDetailsUseFailurePreservesThrottle(t *testing.T) {
 	defer goleak.VerifyNone(t)
 


### PR DESCRIPTION
### Brief description of Pull Request
Bring the same approach to `explain_plans` as we have for `schema_details` collectors (and `query_details` in sql_server), where logging is throttled to at most one emission per EmitInterval. Now every processing result (success, skipped, error) throttles uniformly, and a failure that emits nothing stays unthrottled.

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
