### PR TITLE
chore(loki.relabel): Implement consumer interface

### DIFF
--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -53,14 +53,9 @@ func (b *Batch) add(labels model.LabelSet, entries ...push.Entry) {
 // entry is kept, if fn returns false the entry is dropped. Kept entries are
 // written back, and entries whose labels change are moved to a different stream.
 func (b *Batch) FilterMap(fn func(entry *Entry) (keep bool)) {
-	type movedEntry struct {
-		labels model.LabelSet
-		entry  push.Entry
-	}
-
 	var (
 		newLen int
-		moves  []movedEntry
+		moves  []Entry
 	)
 
 	// Process each entry and compact each stream in place.
@@ -69,6 +64,9 @@ func (b *Batch) FilterMap(fn func(entry *Entry) (keep bool)) {
 	// so we do not mutate the stream set while iterating it.
 	for i := range b.streams {
 		var (
+			// dst is where the next kept entry is written. It only moves forward
+			// when an entry is kept, so it never gets ahead of the entry being read
+			// and we only write to slots the loop has already read.
 			dst    = 0
 			stream = &b.streams[i]
 		)
@@ -84,10 +82,7 @@ func (b *Batch) FilterMap(fn func(entry *Entry) (keep bool)) {
 			}
 
 			if !stream.Labels.Equal(entry.Labels) {
-				moves = append(moves, movedEntry{
-					labels: entry.Labels,
-					entry:  entry.Entry,
-				})
+				moves = append(moves, entry)
 				newLen++
 
 				continue
@@ -98,12 +93,14 @@ func (b *Batch) FilterMap(fn func(entry *Entry) (keep bool)) {
 			newLen++
 		}
 
+		// Entries from dst onwards were either dropped or saved in moves, so it is
+		// safe to cut them here and let add reuse that spare capacity.
 		stream.Entries = stream.Entries[:dst]
 	}
 
 	// Reinsert entries whose labels changed into their destination streams.
 	for _, moved := range moves {
-		b.add(moved.labels, moved.entry)
+		b.add(moved.Labels, moved.Entry)
 	}
 	b.entryLen = newLen
 
@@ -125,10 +122,17 @@ func (b *Batch) FilterMap(fn func(entry *Entry) (keep bool)) {
 func (b *Batch) FilterMapStreams(fn func(stream *Stream) (keep bool)) {
 	var (
 		newLen int
-		dst    int
-		moves  []Stream
+		// dst is where the next kept stream is written. It only moves forward when
+		// a stream is kept, so it never gets ahead of i and we only write to slots
+		// the loop has already read.
+		dst   int
+		moves []Stream
 	)
 
+	// Process each stream and compact the stream slice in place. Dropped streams
+	// are skipped, and streams whose labels changed are deferred into moves so we
+	// do not mutate the stream set while iterating it. They are reinserted below
+	// and may merge into an existing stream.
 	for i := range b.streams {
 		stream := Stream{
 			// FIXME(kalleep): Once the new batched pipeline owns this path, consider
@@ -153,6 +157,8 @@ func (b *Batch) FilterMapStreams(fn func(stream *Stream) (keep bool)) {
 		dst++
 	}
 
+	// Streams from dst onwards were either dropped or saved in moves, so it is
+	// safe to cut them here and let add reuse those slots.
 	b.streams = b.streams[:dst]
 
 	// Reinsert streams whose labels changed into their destination streams.

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -119,45 +119,33 @@ func (b *Batch) FilterMap(fn func(entry *Entry) (keep bool)) {
 	b.streams = b.streams[:streamDst]
 }
 
-// FilterMapStreams calls fn once for each stream in the batch. If fn returns
-// true the stream is kept, if fn returns false the stream and all of its
-// entries are dropped. The returned labels replace the labels of a kept stream,
-// and a stream whose labels change is merged into another stream if that stream
-// already carries the returned labels.
-func (b *Batch) FilterMapStreams(fn func(stream Stream) (labels model.LabelSet, keep bool)) {
-	type movedStream struct {
-		labels  model.LabelSet
-		entries []push.Entry
-	}
-
+// FilterMapStreams calls fn once for each stream in the batch, passing a mutable
+// view of that stream. If fn returns true the stream is kept, if fn returns
+// false the stream and all of its entries are dropped.
+func (b *Batch) FilterMapStreams(fn func(stream *Stream) (keep bool)) {
 	var (
 		newLen int
 		dst    int
-		moves  []movedStream
+		moves  []Stream
 	)
 
-	// Compact the stream set in place. Kept streams are written back, dropped
-	// streams are skipped, and streams whose labels changed are deferred so we do
-	// not mutate the stream set while iterating it.
-	for _, stream := range b.streams {
-		// A stream without entries has nothing to relabel and should not survive.
-		if len(stream.Entries) == 0 {
-			continue
+	for i := range b.streams {
+		stream := Stream{
+			// FIXME(kalleep): Once the new batched pipeline owns this path, consider
+			// copy-on-write label mutation methods so unchanged streams skip the copy.
+			Labels:  b.streams[i].Labels.Clone(),
+			Entries: b.streams[i].Entries,
 		}
 
-		labels, keep := fn(stream)
+		keep := fn(&stream)
 		if !keep {
 			continue
 		}
 
 		newLen += len(stream.Entries)
 
-		if !stream.Labels.Equal(labels) {
-			moves = append(moves, movedStream{
-				labels:  labels,
-				entries: stream.Entries,
-			})
-
+		if !b.streams[i].Labels.Equal(stream.Labels) {
+			moves = append(moves, stream)
 			continue
 		}
 
@@ -169,7 +157,7 @@ func (b *Batch) FilterMapStreams(fn func(stream Stream) (labels model.LabelSet, 
 
 	// Reinsert streams whose labels changed into their destination streams.
 	for _, moved := range moves {
-		b.add(moved.labels, moved.entries...)
+		b.add(moved.Labels, moved.Entries...)
 	}
 
 	b.entryLen = newLen

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -119,6 +119,62 @@ func (b *Batch) FilterMap(fn func(entry *Entry) (keep bool)) {
 	b.streams = b.streams[:streamDst]
 }
 
+// FilterMapStreams calls fn once for each stream in the batch. If fn returns
+// true the stream is kept, if fn returns false the stream and all of its
+// entries are dropped. The returned labels replace the labels of a kept stream,
+// and a stream whose labels change is merged into another stream if that stream
+// already carries the returned labels.
+func (b *Batch) FilterMapStreams(fn func(stream Stream) (labels model.LabelSet, keep bool)) {
+	type movedStream struct {
+		labels  model.LabelSet
+		entries []push.Entry
+	}
+
+	var (
+		newLen int
+		dst    int
+		moves  []movedStream
+	)
+
+	// Compact the stream set in place. Kept streams are written back, dropped
+	// streams are skipped, and streams whose labels changed are deferred so we do
+	// not mutate the stream set while iterating it.
+	for _, stream := range b.streams {
+		// A stream without entries has nothing to relabel and should not survive.
+		if len(stream.Entries) == 0 {
+			continue
+		}
+
+		labels, keep := fn(stream)
+		if !keep {
+			continue
+		}
+
+		newLen += len(stream.Entries)
+
+		if !stream.Labels.Equal(labels) {
+			moves = append(moves, movedStream{
+				labels:  labels,
+				entries: stream.Entries,
+			})
+
+			continue
+		}
+
+		b.streams[dst] = stream
+		dst++
+	}
+
+	b.streams = b.streams[:dst]
+
+	// Reinsert streams whose labels changed into their destination streams.
+	for _, moved := range moves {
+		b.add(moved.labels, moved.entries...)
+	}
+
+	b.entryLen = newLen
+}
+
 // StreamLen returns the number of streams in the batch.
 func (b *Batch) StreamLen() int {
 	return len(b.streams)

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -68,6 +68,44 @@ func TestBatch_FilterMap(t *testing.T) {
 	require.Equal(t, []push.Entry{{Line: "moved"}}, streams[1].Entries)
 }
 
+func TestBatch_FilterMapStreams(t *testing.T) {
+	stream1 := model.LabelSet{"job": "move"}
+	stream2 := model.LabelSet{"job": "drop"}
+	stream3 := model.LabelSet{"job": "keep"}
+
+	var b Batch
+	b.Add(NewStream(stream1, push.Entry{Line: "1"}))
+	b.Add(NewStream(stream2, push.Entry{Line: "2"}))
+	b.Add(NewStream(stream3, push.Entry{Line: "3"}))
+
+	require.Equal(t, 3, b.EntryLen())
+	require.Equal(t, 3, b.StreamLen())
+
+	b.FilterMapStreams(func(stream Stream) (model.LabelSet, bool) {
+		action := stream.Labels["job"]
+
+		switch action {
+		case "keep":
+			return stream.Labels, true
+		case "move":
+			return stream3, true
+		case "drop":
+			return nil, false
+		default:
+			t.Fatalf("unexpected stream %q", stream)
+			return nil, false
+		}
+	})
+
+	require.Equal(t, 2, b.EntryLen())
+	require.Equal(t, 1, b.StreamLen())
+
+	streams := collectStreams(&b)
+	require.Equal(t, stream3, streams[0].Labels)
+	require.Contains(t, streams[0].Entries, push.Entry{Line: "1"})
+	require.Contains(t, streams[0].Entries, push.Entry{Line: "3"})
+}
+
 func TestBatch_ConsumeStreams(t *testing.T) {
 	foo := model.LabelSet{"job": "foo"}
 	bar := model.LabelSet{"job": "bar"}

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -82,7 +82,7 @@ func TestBatch_FilterMapStreams(t *testing.T) {
 	require.Equal(t, 3, b.StreamLen())
 
 	b.FilterMapStreams(func(stream *Stream) bool {
-		action := stream.Labels["job"]
+		action := stream.Labels[model.LabelName("job")]
 
 		switch action {
 		case "keep":
@@ -93,7 +93,7 @@ func TestBatch_FilterMapStreams(t *testing.T) {
 		case "drop":
 			return false
 		default:
-			t.Fatalf("unexpected stream %q", stream)
+			t.Fatalf("unexpected stream labels %v", stream.Labels)
 			return false
 		}
 	})

--- a/internal/component/common/loki/batch_test.go
+++ b/internal/component/common/loki/batch_test.go
@@ -81,19 +81,20 @@ func TestBatch_FilterMapStreams(t *testing.T) {
 	require.Equal(t, 3, b.EntryLen())
 	require.Equal(t, 3, b.StreamLen())
 
-	b.FilterMapStreams(func(stream Stream) (model.LabelSet, bool) {
+	b.FilterMapStreams(func(stream *Stream) bool {
 		action := stream.Labels["job"]
 
 		switch action {
 		case "keep":
-			return stream.Labels, true
+			return true
 		case "move":
-			return stream3, true
+			stream.Labels = stream3
+			return true
 		case "drop":
-			return nil, false
+			return false
 		default:
 			t.Fatalf("unexpected stream %q", stream)
-			return nil, false
+			return false
 		}
 	})
 

--- a/internal/component/common/loki/consumer.go
+++ b/internal/component/common/loki/consumer.go
@@ -61,3 +61,19 @@ func (c *CollectingConsumer) Entries() []Entry {
 	defer c.mut.Unlock()
 	return slices.Clone(c.entries)
 }
+
+var _ Consumer = (*NopConsumer)(nil)
+
+func NewNopConsumer() *NopConsumer {
+	return &NopConsumer{}
+}
+
+type NopConsumer struct{}
+
+func (n *NopConsumer) Consume(_ context.Context, _ Batch) error {
+	return nil
+}
+
+func (n *NopConsumer) ConsumeEntry(_ context.Context, _ Entry) error {
+	return nil
+}

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -59,28 +59,26 @@ type Exports struct {
 	Rules    alloy_relabel.Rules `alloy:"rules,attr"`
 }
 
-// Component implements the loki.relabel component.
-type Component struct {
-	opts    component.Options
-	metrics *metrics
-
-	mut      sync.RWMutex
-	rcs      []*relabel.Config
-	receiver loki.LogsReceiver
-	fanout   *loki.Fanout
-
-	cache        *lru.Cache
-	maxCacheSize int
-
-	debugDataPublisher livedebugging.DebugDataPublisher
-
-	builder labels.ScratchBuilder
-}
-
 var (
 	_ component.Component     = (*Component)(nil)
 	_ component.LiveDebugging = (*Component)(nil)
 )
+
+// Component implements the loki.relabel component.
+type Component struct {
+	opts     component.Options
+	metrics  *metrics
+	receiver loki.LogsReceiver
+	fanout   *loki.Fanout
+
+	mut          sync.RWMutex
+	rcs          []*relabel.Config
+	builder      labels.ScratchBuilder
+	maxCacheSize int
+	cache        *lru.Cache
+
+	debugDataPublisher livedebugging.DebugDataPublisher
+}
 
 // New creates a new loki.relabel component.
 func New(o component.Options, args Arguments) (*Component, error) {
@@ -173,20 +171,7 @@ func (c *Component) Update(args component.Arguments) error {
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
 
 	c.opts.OnStateChange(Exports{Receiver: c.receiver, Rules: newArgs.RelabelConfigs})
-
 	return nil
-}
-
-func relabelingChanged(prev, next []*relabel.Config) bool {
-	if len(prev) != len(next) {
-		return true
-	}
-	for i := range prev {
-		if !reflect.DeepEqual(prev[i], next[i]) {
-			return true
-		}
-	}
-	return false
 }
 
 type cacheItem struct {
@@ -272,3 +257,15 @@ func (c *Component) process(e loki.Entry) model.LabelSet {
 }
 
 func (c *Component) LiveDebugging() {}
+
+func relabelingChanged(prev, next []*relabel.Config) bool {
+	if len(prev) != len(next) {
+		return true
+	}
+	for i := range prev {
+		if !reflect.DeepEqual(prev[i], next[i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -75,6 +75,7 @@ type Component struct {
 	interceptor *loki.InterceptorConsumer
 
 	mut          sync.RWMutex
+	stopped      bool
 	rcs          []*relabel.Config
 	maxCacheSize int
 
@@ -112,14 +113,18 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			c.mut.RLock()
 			defer c.mut.RUnlock()
 
+			if c.stopped {
+				return loki.Batch{}, loki.ErrConsumerStopped
+			}
+
 			c.metrics.entriesProcessed.Add(float64(batch.EntryLen()))
 
 			batch.FilterMapStreams(func(stream *loki.Stream) bool {
 				relabeled, ok := c.relabel(stream.Labels)
 
-				count := uint64(len(stream.Entries))
-				if !ok {
-					count = 0
+				var count uint64
+				if ok {
+					count = uint64(len(stream.Entries))
 				}
 
 				c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
@@ -144,6 +149,10 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		loki.WithConsumeEntryHook(func(ctx context.Context, entry loki.Entry) (loki.Entry, bool, error) {
 			c.mut.RLock()
 			defer c.mut.RUnlock()
+
+			if c.stopped {
+				return loki.Entry{}, false, loki.ErrConsumerStopped
+			}
 
 			c.metrics.entriesProcessed.Inc()
 
@@ -185,6 +194,12 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 // Run implements component.Component.
 func (c *Component) Run(ctx context.Context) error {
+	defer func() {
+		c.mut.Lock()
+		defer c.mut.Unlock()
+		c.stopped = true
+	}()
+
 	loki.ConsumeAndProcess(ctx, c.receiver, c.fanout, func(entry loki.Entry) (loki.Entry, bool) {
 		c.mut.RLock()
 		defer c.mut.RUnlock()

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -163,7 +163,8 @@ func (c *Component) Update(args component.Arguments) error {
 		c.metrics.cacheSize.Set(0)
 	}
 	if newArgs.MaxCacheSize != c.maxCacheSize {
-		evicted := c.cache.Resize(newArgs.MaxCacheSize)
+		c.maxCacheSize = newArgs.MaxCacheSize
+		evicted := c.cache.Resize(c.maxCacheSize)
 		if evicted > 0 {
 			c.opts.Logger.Debug("resizing the cache led to evicting items", "len_items_evicted", evicted)
 		}

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -70,12 +70,11 @@ type Component struct {
 	metrics  *metrics
 	receiver loki.LogsReceiver
 	fanout   *loki.Fanout
+	cache    *lru.Cache
 
 	mut          sync.RWMutex
 	rcs          []*relabel.Config
-	builder      labels.ScratchBuilder
 	maxCacheSize int
-	cache        *lru.Cache
 
 	debugDataPublisher livedebugging.DebugDataPublisher
 }
@@ -98,16 +97,11 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		cache:              cache,
 		maxCacheSize:       args.MaxCacheSize,
 		debugDataPublisher: debugDataPublisher.(livedebugging.DebugDataPublisher),
-		builder:            labels.NewScratchBuilder(0),
 		fanout:             loki.NewFanout(args.ForwardTo),
+		receiver:           loki.NewLogsReceiver(loki.WithComponentID(o.ID)),
 	}
 
-	// Create and immediately export the receiver which remains the same for
-	// the component's lifetime.
-	c.receiver = loki.NewLogsReceiver(loki.WithComponentID(o.ID))
-	o.OnStateChange(Exports{Receiver: c.receiver, Rules: args.RelabelConfigs})
-
-	// Call to Update() to set the relabelling rules once at the start.
+	// Call to Update() to set the relabelling rules once at the start and export rules and receiver.
 	if err := c.Update(args); err != nil {
 		return nil, err
 	}
@@ -169,8 +163,8 @@ func (c *Component) Update(args component.Arguments) error {
 	}
 	c.rcs = newRCS
 	c.fanout.UpdateChildren(newArgs.ForwardTo)
-
 	c.opts.OnStateChange(Exports{Receiver: c.receiver, Rules: newArgs.RelabelConfigs})
+
 	return nil
 }
 
@@ -234,23 +228,19 @@ func (c *Component) process(e loki.Entry) model.LabelSet {
 	rcs := c.rcs
 	c.mut.RUnlock()
 
-	c.builder.Reset()
+	br := labels.NewBuilder(labels.EmptyLabels())
 	for k, v := range e.Labels {
-		c.builder.Add(string(k), string(v))
+		br.Set(string(k), string(v))
 	}
-	c.builder.Sort()
-	lbls := c.builder.Labels()
 
 	if len(c.rcs) > 0 {
-		lb := labels.NewBuilder(lbls)
-		if !relabel.ProcessBuilder(lb, rcs...) {
+		if !relabel.ProcessBuilder(br, rcs...) {
 			return nil
 		}
-		lbls = lb.Labels()
 	}
 
-	relabeled := make(model.LabelSet, lbls.Len())
-	lbls.Range(func(lbl labels.Label) {
+	relabeled := make(model.LabelSet, len(e.Labels))
+	br.Range(func(lbl labels.Label) {
 		relabeled[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 	})
 	return relabeled

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -270,7 +270,7 @@ type cacheItem struct {
 // not have this issue as relabel config rules are only applied to targets.
 // Do we want to use labels.Labels in loki.Entry instead?
 func (c *Component) relabel(lset model.LabelSet) (model.LabelSet, bool) {
-	hash := lset.Fingerprint()
+	hash := lset.FastFingerprint()
 
 	// Let's look in the cache for the hash of the entry's labels.
 	val, found := c.cache.Get(hash)

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -66,11 +66,13 @@ var (
 
 // Component implements the loki.relabel component.
 type Component struct {
-	opts     component.Options
-	metrics  *metrics
-	receiver loki.LogsReceiver
-	fanout   *loki.Fanout
-	cache    *lru.Cache
+	opts    component.Options
+	metrics *metrics
+	cache   *lru.Cache
+
+	receiver    loki.LogsReceiver
+	fanout      *loki.Fanout
+	interceptor *loki.InterceptorConsumer
 
 	mut          sync.RWMutex
 	rcs          []*relabel.Config
@@ -101,6 +103,78 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		receiver:           loki.NewLogsReceiver(loki.WithComponentID(o.ID)),
 	}
 
+	c.interceptor = loki.NewInterceptorConsumer(
+		o.ID,
+		// FIXME(kalleep): Forward entries through consumer interface once we have migrated at pipeline level.
+		// See https://github.com/grafana/alloy/issues/4953
+		loki.NewNopConsumer(),
+		loki.WithConsumeHook(func(ctx context.Context, batch loki.Batch) (loki.Batch, error) {
+			c.mut.RLock()
+			defer c.mut.RUnlock()
+
+			c.metrics.entriesProcessed.Add(float64(batch.EntryLen()))
+
+			batch.FilterMapStreams(func(stream *loki.Stream) bool {
+				relabeled, ok := c.relabel(stream.Labels)
+
+				count := uint64(len(stream.Entries))
+				if !ok {
+					count = 0
+				}
+
+				c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
+					livedebugging.ComponentID(c.opts.ID),
+					livedebugging.LokiLog,
+					count,
+					func() string {
+						if !ok {
+							return fmt.Sprintf("stream: %s => <dropped>", stream.Labels.String())
+						}
+						return fmt.Sprintf("stream: %s => %s", stream.Labels.String(), relabeled.String())
+					},
+				))
+
+				stream.Labels = relabeled
+				return ok
+			})
+
+			c.metrics.entriesOutgoing.Add(float64(batch.EntryLen()))
+			return batch, nil
+		}),
+		loki.WithConsumeEntryHook(func(ctx context.Context, entry loki.Entry) (loki.Entry, bool, error) {
+			c.mut.RLock()
+			defer c.mut.RUnlock()
+
+			c.metrics.entriesProcessed.Inc()
+
+			relabeled, ok := c.relabel(entry.Labels)
+			count := uint64(1)
+			if !ok {
+				count = 0
+			}
+			c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
+				livedebugging.ComponentID(c.opts.ID),
+				livedebugging.LokiLog,
+				count,
+				func() string {
+					if !ok {
+						return fmt.Sprintf("entry: %s, labels: %s => <dropped>", entry.Line, entry.Labels.String())
+					}
+					return fmt.Sprintf("entry: %s, labels: %s => %s", entry.Line, entry.Labels.String(), relabeled.String())
+				},
+			))
+
+			if !ok {
+				c.opts.Logger.Debug("dropping entry after relabeling", "labels", entry.Labels.String())
+				return loki.Entry{}, false, nil
+			}
+
+			c.metrics.entriesOutgoing.Inc()
+			entry.Labels = relabeled
+			return entry, true, nil
+		}),
+	)
+
 	// Call to Update() to set the relabelling rules once at the start and export rules and receiver.
 	if err := c.Update(args); err != nil {
 		return nil, err
@@ -111,23 +185,25 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 // Run implements component.Component.
 func (c *Component) Run(ctx context.Context) error {
-	componentID := livedebugging.ComponentID(c.opts.ID)
 	loki.ConsumeAndProcess(ctx, c.receiver, c.fanout, func(entry loki.Entry) (loki.Entry, bool) {
-		relabeled, ok := c.relabel(entry)
+		c.mut.RLock()
+		defer c.mut.RUnlock()
+		c.metrics.entriesProcessed.Inc()
 
+		relabeled, ok := c.relabel(entry.Labels)
 		count := uint64(1)
 		if !ok {
 			count = 0
 		}
 		c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
-			componentID,
+			livedebugging.ComponentID(c.opts.ID),
 			livedebugging.LokiLog,
 			count,
 			func() string {
 				if !ok {
 					return fmt.Sprintf("entry: %s, labels: %s => <dropped>", entry.Line, entry.Labels.String())
 				}
-				return fmt.Sprintf("entry: %s, labels: %s => %s", entry.Line, entry.Labels.String(), relabeled.Labels.String())
+				return fmt.Sprintf("entry: %s, labels: %s => %s", entry.Line, entry.Labels.String(), relabeled.String())
 			},
 		))
 
@@ -137,7 +213,8 @@ func (c *Component) Run(ctx context.Context) error {
 		}
 
 		c.metrics.entriesOutgoing.Inc()
-		return relabeled, true
+		entry.Labels = relabeled
+		return entry, true
 	})
 	return nil
 }
@@ -177,10 +254,8 @@ type cacheItem struct {
 // between model.LabelSet (map) and labels.Labels (slice). Promtail does
 // not have this issue as relabel config rules are only applied to targets.
 // Do we want to use labels.Labels in loki.Entry instead?
-func (c *Component) relabel(e loki.Entry) (loki.Entry, bool) {
-	c.metrics.entriesProcessed.Inc()
-
-	hash := e.Labels.Fingerprint()
+func (c *Component) relabel(lset model.LabelSet) (model.LabelSet, bool) {
+	hash := lset.Fingerprint()
 
 	// Let's look in the cache for the hash of the entry's labels.
 	val, found := c.cache.Get(hash)
@@ -189,57 +264,49 @@ func (c *Component) relabel(e loki.Entry) (loki.Entry, bool) {
 	// specific entry before and can return early, or if it's a collision.
 	if found {
 		for _, ci := range val.([]cacheItem) {
-			if e.Labels.Equal(ci.original) {
+			if lset.Equal(ci.original) {
 				c.metrics.cacheHits.Inc()
 				if len(ci.relabeled) == 0 {
-					return loki.Entry{}, false
+					return nil, false
 				}
-				e.Labels = ci.relabeled
-				return e, true
+				return ci.relabeled, true
 			}
 		}
 	}
 
 	// Seems like it's either a new entry or a hash collision.
 	c.metrics.cacheMisses.Inc()
-	relabeled := c.process(e)
+	relabeled := c.process(lset)
 
 	// In case it's a new hash, initialize it as a new cacheItem.
 	// If it was a collision, append the result to the cached slice.
 	if !found {
-		val = []cacheItem{{e.Labels, relabeled}}
+		val = []cacheItem{{lset, relabeled}}
 	} else {
-		val = append(val.([]cacheItem), cacheItem{e.Labels, relabeled})
+		val = append(val.([]cacheItem), cacheItem{lset, relabeled})
 	}
 
 	c.cache.Add(hash, val)
 	c.metrics.cacheSize.Set(float64(c.cache.Len()))
 
 	if len(relabeled) == 0 {
-		return loki.Entry{}, false
+		return nil, false
 	}
 
-	e.Labels = relabeled
-	return e, true
+	return relabeled, true
 }
 
-func (c *Component) process(e loki.Entry) model.LabelSet {
-	c.mut.RLock()
-	rcs := c.rcs
-	c.mut.RUnlock()
-
+func (c *Component) process(lset model.LabelSet) model.LabelSet {
 	br := labels.NewBuilder(labels.EmptyLabels())
-	for k, v := range e.Labels {
+	for k, v := range lset {
 		br.Set(string(k), string(v))
 	}
 
-	if len(c.rcs) > 0 {
-		if !relabel.ProcessBuilder(br, rcs...) {
-			return nil
-		}
+	if !relabel.ProcessBuilder(br, c.rcs...) {
+		return nil
 	}
 
-	relabeled := make(model.LabelSet, len(e.Labels))
+	relabeled := make(model.LabelSet, len(lset))
 	br.Range(func(lbl labels.Label) {
 		relabeled[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 	})

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -270,7 +270,7 @@ type cacheItem struct {
 // not have this issue as relabel config rules are only applied to targets.
 // Do we want to use labels.Labels in loki.Entry instead?
 func (c *Component) relabel(lset model.LabelSet) (model.LabelSet, bool) {
-	hash := lset.FastFingerprint()
+	hash := lset.Fingerprint()
 
 	// Let's look in the cache for the hash of the entry's labels.
 	val, found := c.cache.Get(hash)

--- a/internal/component/loki/relabel/relabel.go
+++ b/internal/component/loki/relabel/relabel.go
@@ -245,15 +245,20 @@ func (c *Component) relabel(e loki.Entry) (loki.Entry, bool) {
 }
 
 func (c *Component) process(e loki.Entry) model.LabelSet {
+	c.mut.RLock()
+	rcs := c.rcs
+	c.mut.RUnlock()
+
 	c.builder.Reset()
 	for k, v := range e.Labels {
 		c.builder.Add(string(k), string(v))
 	}
 	c.builder.Sort()
 	lbls := c.builder.Labels()
+
 	if len(c.rcs) > 0 {
 		lb := labels.NewBuilder(lbls)
-		if !relabel.ProcessBuilder(lb, c.rcs...) {
+		if !relabel.ProcessBuilder(lb, rcs...) {
 			return nil
 		}
 		lbls = lb.Labels()


### PR DESCRIPTION
### Brief description of Pull Request
Implement `loki.Consumer` for `loki.relabel` component.

### Pull Request Details
Instead of doing one big pr to loki pipelines I started splitting the changes up in several prs and only at the end we will change at the pipeline level. 

So in this pr I implemented `Consume` and `ConsumeEntry` functions without forwarding, since we have not made the changes at pipeline level yet. 

I fixed some existing issues:
1. We did not use read lock for relabel config
2. We never updated the cached `maxCacheSize` when that value changed.

`ConsumeEntry` is doing identical work like we do in the run loop but `Consume` will instead iterate on streams within a batch since all entries within a stream shares labels.

### Issue(s) fixed by this Pull Request

Part of: https://github.com/grafana/alloy/issues/4953

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->

### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
