### PR TITLE
fix(loki.source.docker): Respect label changes

### DIFF
--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -215,12 +215,15 @@ func (c *Component) Update(args component.Arguments) error {
 		return targets[i].fingerPrint < targets[j].fingerPrint
 	})
 
-	source.Reconcile(
+	source.ReconcileWithDedup(
 		c.opts.Logger,
 		c.scheduler,
 		slices.Values(targets),
 		func(target containerTarget) positions.Entry {
 			return positions.Entry{Path: string(target.labels[dockerLabelContainerID]), Labels: target.labels.Merge(defaultLabels).String()}
+		},
+		func(target containerTarget) string {
+			return string(target.labels[dockerLabelContainerID])
 		},
 		func(entry positions.Entry, target containerTarget) (source.Source[positions.Entry], error) {
 			if entry.Path == "" {

--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -171,6 +171,8 @@ func (c *Component) Run(ctx context.Context) error {
 }
 
 type containerTarget struct {
+	containerID string
+	// labels is the target's own labels merged with the component's default labels.
 	labels      model.LabelSet
 	fingerPrint model.Fingerprint
 }
@@ -205,8 +207,12 @@ func (c *Component) Update(args component.Arguments) error {
 
 	targets := make([]containerTarget, len(newArgs.Targets))
 	for i, target := range newArgs.Targets {
-		lset := target.LabelSet()
-		targets[i] = containerTarget{labels: lset, fingerPrint: lset.Fingerprint()}
+		lbls := target.LabelSet().Merge(defaultLabels)
+		targets[i] = containerTarget{
+			containerID: string(lbls[dockerLabelContainerID]),
+			labels:      lbls,
+			fingerPrint: lbls.Fingerprint(),
+		}
 	}
 
 	// Sorting the targets before filtering ensures consistent filtering of targets
@@ -220,10 +226,10 @@ func (c *Component) Update(args component.Arguments) error {
 		c.scheduler,
 		slices.Values(targets),
 		func(target containerTarget) positions.Entry {
-			return positions.Entry{Path: string(target.labels[dockerLabelContainerID]), Labels: target.labels.Merge(defaultLabels).String()}
+			return positions.Entry{Path: target.containerID, Labels: target.labels.String()}
 		},
 		func(target containerTarget) string {
-			return string(target.labels[dockerLabelContainerID])
+			return target.containerID
 		},
 		func(entry positions.Entry, target containerTarget) (source.Source[positions.Entry], error) {
 			if entry.Path == "" {
@@ -237,7 +243,7 @@ func (c *Component) Update(args component.Arguments) error {
 				c.handler,
 				c.posFile,
 				entry.Path,
-				target.labels.Merge(defaultLabels),
+				target.labels,
 				c.rcs,
 				client,
 				5*time.Second,

--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -109,7 +109,7 @@ type Component struct {
 
 	mut       sync.RWMutex
 	args      Arguments
-	scheduler *source.Scheduler[string]
+	scheduler *source.Scheduler[positions.Entry]
 	client    client.APIClient
 	handler   loki.LogsReceiver
 	posFile   positions.Positions
@@ -139,7 +139,7 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		metrics:   newMetrics(o.Registerer),
 		exited:    atomic.NewBool(false),
 		handler:   loki.NewLogsReceiver(),
-		scheduler: source.NewScheduler[string](),
+		scheduler: source.NewScheduler[positions.Entry](),
 		fanout:    loki.NewFanout(args.ForwardTo),
 		posFile:   positionsFile,
 	}
@@ -218,19 +218,21 @@ func (c *Component) Update(args component.Arguments) error {
 		c.opts.Logger,
 		c.scheduler,
 		slices.Values(promTargets),
-		func(target promTarget) string { return string(target.labels[dockerLabelContainerID]) },
-		func(containerID string, target promTarget) (source.Source[string], error) {
-			if containerID == "" {
+		func(target promTarget) positions.Entry {
+			return positions.Entry{Path: string(target.labels[dockerLabelContainerID]), Labels: target.labels.Merge(defaultLabels).String()}
+		},
+		func(entry positions.Entry, target promTarget) (source.Source[positions.Entry], error) {
+			if entry.Path == "" {
 				c.opts.Logger.Debug("docker target did not include container ID label: " + dockerLabelContainerID)
 				return nil, source.ErrSkip
 			}
 
 			return newTailer(
 				c.metrics,
-				c.opts.Logger.With("component", "tailer", "container", fmt.Sprintf("docker/%s", containerID)),
+				c.opts.Logger.With("component", "tailer", "container", fmt.Sprintf("docker/%s", entry.Path)),
 				c.handler,
 				c.posFile,
-				containerID,
+				entry.Path,
 				target.labels.Merge(defaultLabels),
 				c.rcs,
 				client,

--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -170,7 +170,7 @@ func (c *Component) Run(ctx context.Context) error {
 	return nil
 }
 
-type promTarget struct {
+type containerTarget struct {
 	labels      model.LabelSet
 	fingerPrint model.Fingerprint
 }
@@ -189,7 +189,10 @@ func (c *Component) Update(args component.Arguments) error {
 		return err
 	}
 
-	if client != c.client {
+	rcs := alloy_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules)
+
+	if requiresReset(client, c.client, rcs, c.rcs) {
+		c.rcs = rcs
 		c.client = client
 		// Stop all tailers because we need to restart them.
 		c.scheduler.Reset()
@@ -200,28 +203,26 @@ func (c *Component) Update(args component.Arguments) error {
 		defaultLabels[model.LabelName(k)] = model.LabelValue(v)
 	}
 
-	c.rcs = alloy_relabel.ComponentToPromRelabelConfigs(newArgs.RelabelRules)
-
-	promTargets := make([]promTarget, len(newArgs.Targets))
+	targets := make([]containerTarget, len(newArgs.Targets))
 	for i, target := range newArgs.Targets {
-		labelsCopy := target.LabelSet()
-		promTargets[i] = promTarget{labels: labelsCopy, fingerPrint: labelsCopy.Fingerprint()}
+		lset := target.LabelSet()
+		targets[i] = containerTarget{labels: lset, fingerPrint: lset.Fingerprint()}
 	}
 
 	// Sorting the targets before filtering ensures consistent filtering of targets
 	// when multiple targets share the same containerID.
-	sort.Slice(promTargets, func(i, j int) bool {
-		return promTargets[i].fingerPrint < promTargets[j].fingerPrint
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].fingerPrint < targets[j].fingerPrint
 	})
 
 	source.Reconcile(
 		c.opts.Logger,
 		c.scheduler,
-		slices.Values(promTargets),
-		func(target promTarget) positions.Entry {
+		slices.Values(targets),
+		func(target containerTarget) positions.Entry {
 			return positions.Entry{Path: string(target.labels[dockerLabelContainerID]), Labels: target.labels.Merge(defaultLabels).String()}
 		},
-		func(entry positions.Entry, target promTarget) (source.Source[positions.Entry], error) {
+		func(entry positions.Entry, target containerTarget) (source.Source[positions.Entry], error) {
 			if entry.Path == "" {
 				c.opts.Logger.Debug("docker target did not include container ID label: " + dockerLabelContainerID)
 				return nil, source.ErrSkip
@@ -315,4 +316,8 @@ type sourceInfo struct {
 	Labels     string `alloy:"labels,attr"`
 	IsRunning  bool   `alloy:"is_running,attr"`
 	ReadOffset string `alloy:"read_offset,attr"`
+}
+
+func requiresReset(newClient, oldClient client.APIClient, newRcs, oldRcs []*relabel.Config) bool {
+	return newClient != oldClient || reflect.DeepEqual(newRcs, oldRcs)
 }

--- a/internal/component/loki/source/docker/docker.go
+++ b/internal/component/loki/source/docker/docker.go
@@ -319,5 +319,5 @@ type sourceInfo struct {
 }
 
 func requiresReset(newClient, oldClient client.APIClient, newRcs, oldRcs []*relabel.Config) bool {
-	return newClient != oldClient || reflect.DeepEqual(newRcs, oldRcs)
+	return newClient != oldClient || !reflect.DeepEqual(newRcs, oldRcs)
 }

--- a/internal/component/loki/source/docker/tailer.go
+++ b/internal/component/loki/source/docker/tailer.go
@@ -185,8 +185,11 @@ func (t *tailer) stop() {
 	}
 }
 
-func (t *tailer) Key() string {
-	return t.containerID
+func (t *tailer) Key() positions.Entry {
+	return positions.Entry{
+		Path:   t.containerID,
+		Labels: t.labelsStr,
+	}
 }
 
 func (t *tailer) DebugInfo() sourceInfo {

--- a/internal/component/loki/source/reconcile.go
+++ b/internal/component/loki/source/reconcile.go
@@ -13,6 +13,10 @@ var ErrSkip = errors.New("skip source")
 // The key is used to uniquely identify sources in the scheduler.
 type KeyFn[Key comparable, Input any] func(Input) Key
 
+// DedupFn extracts a comparable key of type Dedup from an input value of type Input.
+// Inputs that share a key are treated as the same source.
+type DedupFn[Dedup comparable, Input any] func(Input) Dedup
+
 // SourceFactoryFn creates a Source[Key] from a key and input value.
 // It returns the created source (or nil if creation failed or should be skipped)
 // and an error. Return ErrSkip to indicate that the source should not be scheduled
@@ -23,24 +27,43 @@ type SourceFactoryFn[Key comparable, Input any] func(Key, Input) (Source[Key], e
 // It iterates over inputs, creates sources for new items, and stops sources that are
 // no longer needed.
 func Reconcile[Key comparable, Input any](
-	logger *slog.Logger,
+	l *slog.Logger,
 	s *Scheduler[Key],
 	it iter.Seq[Input],
 	keyFn KeyFn[Key, Input],
 	sourceFactoryFn SourceFactoryFn[Key, Input],
 ) {
-	// shouldRun tracks the set of keys that should be active after reconciliation.
-	shouldRun := make(map[Key]struct{})
+	ReconcileWithDedup(l, s, it, keyFn, DedupFn[Key, Input](keyFn), sourceFactoryFn)
+}
+
+// ReconcileWithDedup behaves like Reconcile, but deduplicates inputs on a key that
+// is independent of the one used by the scheduler. When several inputs share a dedup
+// key only the first one is used, so callers control which one wins through the order
+// of inputs.
+func ReconcileWithDedup[Key, Dedup comparable, Input any](
+	l *slog.Logger,
+	s *Scheduler[Key],
+	it iter.Seq[Input],
+	keyFn KeyFn[Key, Input],
+	dedupFn DedupFn[Dedup, Input],
+	sourceFactoryFn SourceFactoryFn[Key, Input],
+) {
+	var (
+		// seen is used to deduplicate targets.
+		seen = make(map[Dedup]struct{})
+		// shouldRun tracks the set of keys that should be active after reconciliation.
+		shouldRun = make(map[Key]struct{})
+	)
 
 	// Process all inputs and create sources for new items.
 	for i := range it {
-		key := keyFn(i)
-
-		// Skip if we've already processed this key in this iteration.
-		if _, ok := shouldRun[key]; ok {
+		dedupKey, key := dedupFn(i), keyFn(i)
+		// Skip if we've already processed this input in this iteration.
+		if _, ok := seen[dedupKey]; ok {
 			continue
 		}
 
+		seen[dedupKey] = struct{}{}
 		shouldRun[key] = struct{}{}
 
 		// Skip if a source with this key is already running.
@@ -51,7 +74,7 @@ func Reconcile[Key comparable, Input any](
 		source, err := sourceFactoryFn(key, i)
 		if err != nil {
 			if !errors.Is(err, ErrSkip) {
-				logger.Error("failed to create source, skipping", "error", err, "key", key)
+				l.Error("failed to create source, skipping", "error", err, "key", key)
 			}
 			delete(shouldRun, key)
 			continue

--- a/internal/component/loki/source/reconcile.go
+++ b/internal/component/loki/source/reconcile.go
@@ -34,7 +34,7 @@ func Reconcile[Key comparable, Input any](
 	sourceFactoryFn SourceFactoryFn[Key, Input],
 ) {
 
-	ReconcileWithDedup(l, s, it, keyFn, DedupFn[Key, Input](keyFn), sourceFactoryFn)
+	reconcile(l, s, it, func(i Input) (Key, Key) { key := keyFn(i); return key, key }, sourceFactoryFn)
 }
 
 // ReconcileWithDedup behaves like Reconcile, but deduplicates inputs on a key that
@@ -50,6 +50,17 @@ func ReconcileWithDedup[Key, Dedup comparable, Input any](
 	sourceFactoryFn SourceFactoryFn[Key, Input],
 ) {
 
+	reconcile(l, s, it, func(i Input) (Key, Dedup) { return keyFn(i), dedupFn(i) }, sourceFactoryFn)
+}
+
+func reconcile[Key, Dedup comparable, Input any](
+	l *slog.Logger,
+	s *Scheduler[Key],
+	it iter.Seq[Input],
+	keysFn func(Input) (Key, Dedup),
+	sourceFactoryFn SourceFactoryFn[Key, Input],
+) {
+
 	var (
 		// seen is used to deduplicate targets.
 		seen = make(map[Dedup]struct{})
@@ -59,7 +70,7 @@ func ReconcileWithDedup[Key, Dedup comparable, Input any](
 
 	// Process all inputs and create sources for new items.
 	for i := range it {
-		dedupKey, key := dedupFn(i), keyFn(i)
+		key, dedupKey := keysFn(i)
 		// Skip if we've already processed this input in this iteration.
 		if _, ok := seen[dedupKey]; ok {
 			continue

--- a/internal/component/loki/source/reconcile.go
+++ b/internal/component/loki/source/reconcile.go
@@ -33,6 +33,7 @@ func Reconcile[Key comparable, Input any](
 	keyFn KeyFn[Key, Input],
 	sourceFactoryFn SourceFactoryFn[Key, Input],
 ) {
+
 	ReconcileWithDedup(l, s, it, keyFn, DedupFn[Key, Input](keyFn), sourceFactoryFn)
 }
 
@@ -48,6 +49,7 @@ func ReconcileWithDedup[Key, Dedup comparable, Input any](
 	dedupFn DedupFn[Dedup, Input],
 	sourceFactoryFn SourceFactoryFn[Key, Input],
 ) {
+
 	var (
 		// seen is used to deduplicate targets.
 		seen = make(map[Dedup]struct{})

--- a/internal/component/loki/source/reconcile.go
+++ b/internal/component/loki/source/reconcile.go
@@ -41,7 +41,7 @@ func Reconcile[Key comparable, Input any](
 // is independent of the one used by the scheduler. When several inputs share a dedup
 // key only the first one is used, so callers control which one wins through the order
 // of inputs.
-func ReconcileWithDedup[Key, Dedup comparable, Input any](
+func ReconcileWithDedup[Key comparable, Dedup comparable, Input any](
 	l *slog.Logger,
 	s *Scheduler[Key],
 	it iter.Seq[Input],

--- a/internal/component/loki/source/reconcile_test.go
+++ b/internal/component/loki/source/reconcile_test.go
@@ -75,3 +75,70 @@ func TestReconcile(t *testing.T) {
 		require.Equal(t, 2, s.Len())
 	})
 }
+
+func TestReconcileWithDedup(t *testing.T) {
+	type testInput struct {
+		key   int
+		dedup string
+	}
+
+	s := NewScheduler[int]()
+	defer s.Stop()
+
+	t.Run("should reconcile all new sources", func(t *testing.T) {
+		ReconcileWithDedup(
+			logging.NewSlogNop(),
+			s,
+			slices.Values([]testInput{{key: 1, dedup: "a"}, {key: 2, dedup: "b"}, {key: 3, dedup: "c"}}),
+			func(in testInput) int {
+				return in.key
+			},
+			func(in testInput) string {
+				return in.dedup
+			},
+			func(key int, in testInput) (Source[int], error) {
+				return newTestSource(key, false), nil
+			},
+		)
+		require.Equal(t, 3, s.Len())
+	})
+
+	t.Run("should stop all missing sources", func(t *testing.T) {
+		ReconcileWithDedup(
+			logging.NewSlogNop(),
+			s,
+			slices.Values([]testInput{{key: 2, dedup: "b"}, {key: 3, dedup: "c"}}),
+			func(in testInput) int {
+				return in.key
+			},
+			func(in testInput) string {
+				return in.dedup
+			},
+			func(key int, in testInput) (Source[int], error) {
+				return newTestSource(key, false), nil
+			},
+		)
+		require.Equal(t, 2, s.Len())
+		require.False(t, s.Contains(1))
+	})
+
+	t.Run("should only schedule first input that shares a dedup key", func(t *testing.T) {
+		ReconcileWithDedup(
+			logging.NewSlogNop(),
+			s,
+			slices.Values([]testInput{{key: 2, dedup: "b"}, {key: 3, dedup: "c"}, {key: 4, dedup: "c"}}),
+			func(in testInput) int {
+				return in.key
+			},
+			func(in testInput) string {
+				return in.dedup
+			},
+			func(key int, in testInput) (Source[int], error) {
+				return newTestSource(key, false), nil
+			},
+		)
+		require.Equal(t, 2, s.Len())
+		require.True(t, s.Contains(3))
+		require.False(t, s.Contains(4))
+	})
+}


### PR DESCRIPTION
### Pull Request Details
Before https://github.com/grafana/alloy/pull/5026 any change to labels would restart a tailer and re-ingest logs. It was unintended to get rid of this behavior. While it is a problem that logs are re-ingested when any labels changes that should be handled in a seperate pr / issue, we already track it here https://github.com/grafana/alloy/issues/5135

So this pr will revert to how it worked before _and_ fix the issue when relabel config change, i.e. not being picked up. We can probably rework this later to not require a restart but I suspect that chaining e.g relabel config is a thing that don't happen too often.

### Issue(s) fixed by this Pull Request

Fixes: https://github.com/grafana/alloy/issues/6714

### Notes to the Reviewer

Added `ReconcileWithDedup`, that Reconcile will call internally. This functions allows caller to provide a dedup key that can be different from the key used to schedule sources. This way we can keep the existing behavior of not scheduling duplicated tailers by container id but still respect the key (container id + labels).

### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
