### PR TITLE
fix(prometheus.fanout): Correct series-ref handling on the unmapped fanout path

### DIFF
--- a/internal/component/prometheus/appenders/seriesrefmapping.go
+++ b/internal/component/prometheus/appenders/seriesrefmapping.go
@@ -186,11 +186,9 @@ func (s *seriesRefMapping) appendToChildren(ref storage.SeriesRef, lbls labels.L
 		return ref, nil
 	}
 
-	// No existing mapping. Forward 0, not ref: a nonzero ref here is a store-issued
-	// unique ref that means nothing to a child and could collide with one of its own
-	// series. Zero makes each child resolve by labels and hand back its real ref.
+	// No mapping for this ref, so pass 0: each child resolves by labels rather than
+	// risking the ref matching an unrelated series of its own.
 	var nonZeroCount int
-	var nonZeroRef storage.SeriesRef
 	for _, child := range s.children {
 		childRef, err := af(child, 0)
 		if err != nil {
@@ -200,7 +198,6 @@ func (s *seriesRefMapping) appendToChildren(ref storage.SeriesRef, lbls labels.L
 		s.childRefs = append(s.childRefs, childRef)
 		if childRef != 0 {
 			nonZeroCount++
-			nonZeroRef = childRef
 		}
 	}
 
@@ -209,15 +206,11 @@ func (s *seriesRefMapping) appendToChildren(ref storage.SeriesRef, lbls labels.L
 	}
 
 	if nonZeroCount == 0 {
-		// All children returned ref 0, so return the input ref
+		// No child allocated a ref, so there's nothing to map; return the input ref.
 		return ref, nil
 	}
 
-	if nonZeroCount == 1 {
-		// Only one child allocated a ref; return it directly — no mapping needed.
-		return nonZeroRef, nil
-	}
-
+	// At least one child allocated a ref, so create a mapping.
 	uniqueRef := s.store.CreateMapping(s.childRefs, lbls)
 	s.uniqueRefCell.Refs = append(s.uniqueRefCell.Refs, uniqueRef)
 	return uniqueRef, nil

--- a/internal/component/prometheus/appenders/seriesrefmapping.go
+++ b/internal/component/prometheus/appenders/seriesrefmapping.go
@@ -186,11 +186,13 @@ func (s *seriesRefMapping) appendToChildren(ref storage.SeriesRef, lbls labels.L
 		return ref, nil
 	}
 
-	// No existing mapping, proceed with normal append to all children.
+	// No existing mapping. Forward 0, not ref: a nonzero ref here is a store-issued
+	// unique ref that means nothing to a child and could collide with one of its own
+	// series. Zero makes each child resolve by labels and hand back its real ref.
 	var nonZeroCount int
 	var nonZeroRef storage.SeriesRef
 	for _, child := range s.children {
-		childRef, err := af(child, ref)
+		childRef, err := af(child, 0)
 		if err != nil {
 			appendErr = multierror.Append(appendErr, err)
 		}

--- a/internal/component/prometheus/appenders/seriesrefmapping_test.go
+++ b/internal/component/prometheus/appenders/seriesrefmapping_test.go
@@ -484,7 +484,7 @@ func TestSeriesRefMapping_AppendUnmappedNonZeroRefForwardsZeroToChildren(t *test
 	require.Equal(t, []storage.SeriesRef{5001, 6002}, store.createCalls[0].refs)
 }
 
-func TestSeriesRefMapping_AppendSingleNonZeroChildReturnsChildRefDirectly(t *testing.T) {
+func TestSeriesRefMapping_AppendSingleNonZeroChildCreatesMapping(t *testing.T) {
 	store := newMockMappingStore()
 	child1 := &mockAppender{}
 	child2 := &mockAppender{appendFn: func(_ storage.SeriesRef, _ labels.Labels, _ int64, _ float64) (storage.SeriesRef, error) {
@@ -495,12 +495,14 @@ func TestSeriesRefMapping_AppendSingleNonZeroChildReturnsChildRefDirectly(t *tes
 	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_single_nonzero_forwarded", Help: "test"})
 	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
 
-	// The single non-zero child ref is returned directly — no mapping created.
+	// A single allocating child still gets a mapping, so the series stays routable on
+	// later appends rather than being returned bare and unmapped.
 	ref, err := app.Append(0, labels.FromStrings("job", "test"), 1, 1)
 	require.NoError(t, err)
-	require.Equal(t, storage.SeriesRef(77), ref)
-	require.Len(t, store.createCalls, 0)
-	require.Empty(t, store.cell.Refs)
+	require.Equal(t, storage.SeriesRef(1000), ref)
+	require.Len(t, store.createCalls, 1)
+	require.Equal(t, []storage.SeriesRef{0, 77}, store.createCalls[0].refs)
+	require.Equal(t, []storage.SeriesRef{1000}, store.cell.Refs)
 }
 
 func TestSeriesRefMapping_AppendSecondAppendUsesChildRefsFromMapping(t *testing.T) {

--- a/internal/component/prometheus/appenders/seriesrefmapping_test.go
+++ b/internal/component/prometheus/appenders/seriesrefmapping_test.go
@@ -456,6 +456,34 @@ func TestSeriesRefMapping_AppendAllChildrenZeroPassesThroughInputRef(t *testing.
 	require.Empty(t, store.cell.Refs)
 }
 
+func TestSeriesRefMapping_AppendUnmappedNonZeroRefForwardsZeroToChildren(t *testing.T) {
+	store := newMockMappingStore()
+
+	// Children hand back their own refs regardless of what they're given.
+	child1 := &mockAppender{appendFn: func(_ storage.SeriesRef, _ labels.Labels, _ int64, _ float64) (storage.SeriesRef, error) {
+		return 5001, nil
+	}}
+	child2 := &mockAppender{appendFn: func(_ storage.SeriesRef, _ labels.Labels, _ int64, _ float64) (storage.SeriesRef, error) {
+		return 6002, nil
+	}}
+
+	writeLatency := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_unmapped_nonzero_latency", Help: "test"})
+	samplesForwarded := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_unmapped_nonzero_forwarded", Help: "test"})
+	app := NewSeriesRefMapping([]storage.Appender{child1, child2}, store, writeLatency, samplesForwarded)
+
+	// Ref 9999 has no mapping (e.g. a store ref whose mapping was cleaned or predates a
+	// topology change). It must not reach the children — they'd risk misattributing the
+	// sample to whichever of their own series happens to share that number.
+	ref, err := app.Append(9999, labels.FromStrings("job", "test"), 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, storage.SeriesRef(1000), ref)
+
+	require.Equal(t, []storage.SeriesRef{0}, child1.appendRefs)
+	require.Equal(t, []storage.SeriesRef{0}, child2.appendRefs)
+	require.Len(t, store.createCalls, 1)
+	require.Equal(t, []storage.SeriesRef{5001, 6002}, store.createCalls[0].refs)
+}
+
 func TestSeriesRefMapping_AppendSingleNonZeroChildReturnsChildRefDirectly(t *testing.T) {
 	store := newMockMappingStore()
 	child1 := &mockAppender{}

--- a/internal/component/prometheus/fanout_test.go
+++ b/internal/component/prometheus/fanout_test.go
@@ -274,9 +274,9 @@ func TestFanout_SeriesRefMappingToPassthroughTransition(t *testing.T) {
 
 // TestFanout_PassthroughToSeriesRefMappingTransition verifies that when the fanout
 // transitions from passthrough (1 child) to seriesRefMapping (2 children) via
-// UpdateChildren, a cached raw child ref that collides numerically with a new
-// store-issued unique ref for a different series is handled correctly via label
-// hash guards.
+// UpdateChildren, a cached raw child ref from the old topology is not forwarded to
+// the new children: it's zeroed so each child resolves the series by labels rather
+// than risk colliding with one of its own series.
 func TestFanout_PassthroughToSeriesRefMappingTransition(t *testing.T) {
 	walChild := newRecordingStore()
 	fanout := prometheus.NewFanout([]storage.Appendable{walChild}, "test", promclient.NewRegistry(), nil)
@@ -311,9 +311,10 @@ func TestFanout_PassthroughToSeriesRefMappingTransition(t *testing.T) {
 	require.NotEqual(t, storage.SeriesRef(1), refB,
 		"seriesB must not reuse seriesA's store-issued unique ref")
 
-	// Both children must have been called with passthroughRef for lblsB, not seriesA's child refs.
-	require.Equal(t, passthroughRef, child1.appender.appendRefs[1],
-		"child1 must be called with passthrough ref for seriesB")
-	require.Equal(t, passthroughRef, child2.appender.appendRefs[1],
-		"child2 must be called with passthrough ref for seriesB")
+	// The stale passthrough ref belonged to the old topology's child; it must not reach
+	// the new children. Each is called with 0 and resolves seriesB by labels.
+	require.Equal(t, storage.SeriesRef(0), child1.appender.appendRefs[1],
+		"child1 must be called with 0, not the stale passthrough ref")
+	require.Equal(t, storage.SeriesRef(0), child2.appender.appendRefs[1],
+		"child2 must be called with 0, not the stale passthrough ref")
 }


### PR DESCRIPTION
### Brief description of Pull Request

Correct series-ref handling unmapped-append path: it no longer forwards a ref that could misattribute a sample to the wrong series, and a single-destination series now gets a mapping instead of being left unmapped.

### Pull Request Details

Returning a downstream child ref to be reused later could land us in some really awkward edge cases if we reuse it in a later scenario. There are not a lot of valid combinations which do not allocate refs. `prometheus.write.queue` was one which is about to be removed and `prometheus.echo` is the other which is most likely used temporary or for local debugging.

### PR Checklist

- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
