### PR TITLE
feat(otelcol.receiver.prometheus): Return stable refs

### DIFF
--- a/internal/component/otelcol/receiver/prometheus/internal/transaction.go
+++ b/internal/component/otelcol/receiver/prometheus/internal/transaction.go
@@ -103,7 +103,7 @@ func newTransaction(
 	}
 }
 
-// Append always returns 0 to disable label caching.
+// Append returns a stable series reference so Prometheus can track series staleness.
 func (t *transaction) Append(_ storage.SeriesRef, ls labels.Labels, atMs int64, val float64) (storage.SeriesRef, error) {
 	t.addingNativeHistogram = false
 	t.addingNHCB = false
@@ -179,6 +179,7 @@ func (t *transaction) Append(_ storage.SeriesRef, ls labels.Labels, atMs int64, 
 	curMF := t.getOrCreateMetricFamily(*rKey, scope, metricName)
 
 	seriesRef := t.getSeriesRef(ls, curMF.mtype)
+	cacheRef := ls.Hash()
 	err = curMF.addSeries(seriesRef, metricName, ls, atMs, val)
 	if err != nil {
 		t.logger.Warn("failed to add datapoint", zap.Error(err), zap.String("metric_name", metricName), zap.Any("labels", ls))
@@ -188,8 +189,8 @@ func (t *transaction) Append(_ storage.SeriesRef, ls labels.Labels, atMs int64, 
 	}
 
 	// never return errors, as that fails the whole scrape
-	// return ref==1 indicating that the series was added and needs staleness tracking
-	return 1, nil
+	// return a stable ref so Prometheus can track series staleness
+	return storage.SeriesRef(cacheRef), nil
 }
 
 // detectAndStoreNativeHistogramStaleness returns true if it detects
@@ -330,15 +331,17 @@ func (t *transaction) AppendHistogram(_ storage.SeriesRef, ls labels.Labels, atM
 	// thus we don't check for them here as opposed to the Append function.
 
 	curMF := t.getOrCreateMetricFamily(*rKey, getScopeID(ls), metricName)
+	seriesRef := t.getSeriesRef(ls, curMF.mtype)
+	cacheRef := ls.Hash()
 
 	if h != nil && h.CounterResetHint == histogram.GaugeType || fh != nil && fh.CounterResetHint == histogram.GaugeType {
 		t.logger.Warn("dropping unsupported gauge histogram datapoint", zap.String("metric_name", metricName), zap.Any("labels", ls))
 	}
 
 	if schema == histogram.CustomBucketsSchema {
-		err = curMF.addNHCBSeries(t.getSeriesRef(ls, curMF.mtype), metricName, ls, atMs, h, fh)
+		err = curMF.addNHCBSeries(seriesRef, metricName, ls, atMs, h, fh)
 	} else {
-		err = curMF.addExponentialHistogramSeries(t.getSeriesRef(ls, curMF.mtype), metricName, ls, atMs, h, fh)
+		err = curMF.addExponentialHistogramSeries(seriesRef, metricName, ls, atMs, h, fh)
 	}
 	if err != nil {
 		t.logger.Warn("failed to add histogram datapoint", zap.Error(err), zap.String("metric_name", metricName), zap.Any("labels", ls))
@@ -347,8 +350,8 @@ func (t *transaction) AppendHistogram(_ storage.SeriesRef, ls labels.Labels, atM
 		return 0, nil
 	}
 
-	// return ref==1 indicating that the series was added and needs staleness tracking
-	return 1, nil
+	// return a stable ref so Prometheus can track series staleness
+	return storage.SeriesRef(cacheRef), nil
 }
 
 func (t *transaction) AppendSTZeroSample(_ storage.SeriesRef, ls labels.Labels, atMs, ctMs int64) (storage.SeriesRef, error) {

--- a/internal/component/otelcol/receiver/prometheus/internal/transaction_test.go
+++ b/internal/component/otelcol/receiver/prometheus/internal/transaction_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/scrape"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -244,6 +245,74 @@ func testTransactionAppendDuplicateLabels(t *testing.T) {
 	assert.ErrorContains(t, err, `invalid sample: non-unique label names: "a"`)
 }
 
+func TestTransactionAppendReturnsStableSeriesRef(t *testing.T) {
+	sink := new(consumertest.MetricsSink)
+	tr := newTransaction(scrapeCtx, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
+
+	lsA := labels.FromStrings(
+		model.InstanceLabel, "localhost:8855",
+		model.JobLabel, "test",
+		model.MetricNameLabel, "counter_test",
+		"foo", "bar",
+	)
+	lsB := labels.FromStrings(
+		model.InstanceLabel, "localhost:8855",
+		model.JobLabel, "test",
+		model.MetricNameLabel, "counter_test",
+		"foo", "baz",
+	)
+
+	refA, err := tr.Append(0, lsA, ts, 1.0)
+	require.NoError(t, err)
+	require.Equal(t, storage.SeriesRef(lsA.Hash()), refA)
+
+	refB, err := tr.Append(0, lsB, ts, 1.0)
+	require.NoError(t, err)
+	require.Equal(t, storage.SeriesRef(lsB.Hash()), refB)
+
+	require.NotEqual(t, refA, refB)
+}
+
+func TestTransactionAppendStableSeriesRefEnablesSeriesDisappearanceTracking(t *testing.T) {
+	lsA := labels.FromStrings(
+		model.InstanceLabel, "localhost:8855",
+		model.JobLabel, "test",
+		model.MetricNameLabel, "counter_test",
+		"foo", "bar",
+	)
+	lsB := labels.FromStrings(
+		model.InstanceLabel, "localhost:8855",
+		model.JobLabel, "test",
+		model.MetricNameLabel, "counter_test",
+		"foo", "baz",
+	)
+
+	// Scrape #1: both series are present.
+	tr1 := newTransaction(scrapeCtx, new(consumertest.MetricsSink), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
+	refA1, err := tr1.Append(0, lsA, ts, 1.0)
+	require.NoError(t, err)
+	refB1, err := tr1.Append(0, lsB, ts, 1.0)
+	require.NoError(t, err)
+
+	// Scrape #2: only series A is present.
+	tr2 := newTransaction(scrapeCtx, new(consumertest.MetricsSink), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
+	refA2, err := tr2.Append(0, lsA, ts+interval, 1.0)
+	require.NoError(t, err)
+
+	prev := map[storage.SeriesRef]struct{}{refA1: {}, refB1: {}}
+	cur := map[storage.SeriesRef]struct{}{refA2: {}}
+
+	var missing []storage.SeriesRef
+	for ref := range prev {
+		if _, ok := cur[ref]; !ok {
+			missing = append(missing, ref)
+		}
+	}
+
+	require.Len(t, missing, 1)
+	require.Equal(t, refB1, missing[0])
+}
+
 func TestTransactionAppendHistogramNoLe(t *testing.T) {
 	testTransactionAppendHistogramNoLe(t)
 }
@@ -276,6 +345,74 @@ func testTransactionAppendHistogramNoLe(t *testing.T) {
 
 	assert.NoError(t, tr.Commit())
 	assert.Empty(t, sink.AllMetrics())
+}
+
+func TestTransactionAppendHistogramReturnsStableSeriesRef(t *testing.T) {
+	sink := new(consumertest.MetricsSink)
+	tr := newTransaction(scrapeCtx, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
+
+	lsA := labels.FromStrings(
+		model.InstanceLabel, "localhost:8855",
+		model.JobLabel, "test",
+		model.MetricNameLabel, "native_hist_test",
+		"foo", "bar",
+	)
+	lsB := labels.FromStrings(
+		model.InstanceLabel, "localhost:8855",
+		model.JobLabel, "test",
+		model.MetricNameLabel, "native_hist_test",
+		"foo", "baz",
+	)
+
+	refA, err := tr.AppendHistogram(0, lsA, ts, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+	require.Equal(t, storage.SeriesRef(lsA.Hash()), refA)
+
+	refB, err := tr.AppendHistogram(0, lsB, ts, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+	require.Equal(t, storage.SeriesRef(lsB.Hash()), refB)
+
+	require.NotEqual(t, refA, refB)
+}
+
+func TestTransactionAppendHistogramStableSeriesRefEnablesSeriesDisappearanceTracking(t *testing.T) {
+	lsA := labels.FromStrings(
+		model.InstanceLabel, "localhost:8855",
+		model.JobLabel, "test",
+		model.MetricNameLabel, "native_hist_test",
+		"foo", "bar",
+	)
+	lsB := labels.FromStrings(
+		model.InstanceLabel, "localhost:8855",
+		model.JobLabel, "test",
+		model.MetricNameLabel, "native_hist_test",
+		"foo", "baz",
+	)
+
+	// Scrape #1: both series are present.
+	tr1 := newTransaction(scrapeCtx, new(consumertest.MetricsSink), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
+	refA1, err := tr1.AppendHistogram(0, lsA, ts, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+	refB1, err := tr1.AppendHistogram(0, lsB, ts, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+
+	// Scrape #2: only series A is present.
+	tr2 := newTransaction(scrapeCtx, new(consumertest.MetricsSink), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
+	refA2, err := tr2.AppendHistogram(0, lsA, ts+interval, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+
+	prev := map[storage.SeriesRef]struct{}{refA1: {}, refB1: {}}
+	cur := map[storage.SeriesRef]struct{}{refA2: {}}
+
+	var missing []storage.SeriesRef
+	for ref := range prev {
+		if _, ok := cur[ref]; !ok {
+			missing = append(missing, ref)
+		}
+	}
+
+	require.Len(t, missing, 1)
+	require.Equal(t, refB1, missing[0])
 }
 
 func TestTransactionAppendSummaryNoQuantile(t *testing.T) {


### PR DESCRIPTION
### Brief description of Pull Request

Sync `Append`/`AppendHistogram` in the copied `prometheusreceiver` transaction.go so it returns a stable ref rather than a hardcoded `1`. 

### Pull Request Details

This mirrors [opentelemetry-collector-contrib#46589](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46589) and the AppenderV2 rewrite ([opentelemetry-collector-contrib#46426](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46426)). The AppenderV2 rewrite is what had Append return a stable ref which is mirrored here. 

### PR Checklist

- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))