### PR TITLE
docs(loki.process): Clarify default log timestamp without stage.timestamp

### DIFF
--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1823,7 +1823,7 @@ stage.tenant {
 ### `stage.timestamp`
 
 The `stage.timestamp` inner block configures a processing stage that sets the timestamp of log entries before they're forwarded to the next component.
-When no timestamp stage is set, the log entry timestamp defaults to the time when the log entry was scraped.
+When no timestamp stage is set, `loki.process` keeps the timestamp already attached to the entry by the upstream component (for example a `loki.source.*` component). Many sources default that to the time the entry was received; others can use a timestamp embedded in the log when configured to do so. Leaving out `stage.timestamp` does not by itself rewrite or sanitize timestamps, and Loki may still reject entries that fall outside its configured acceptance window (for example far-future or out-of-order timestamps).
 
 The following arguments are supported:
 

--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1823,7 +1823,10 @@ stage.tenant {
 ### `stage.timestamp`
 
 The `stage.timestamp` inner block configures a processing stage that sets the timestamp of log entries before they're forwarded to the next component.
-When no timestamp stage is set, `loki.process` keeps the timestamp already attached to the entry by the upstream component (for example a `loki.source.*` component). Many sources default that to the time the entry was received; others can use a timestamp embedded in the log when configured to do so. Leaving out `stage.timestamp` does not by itself rewrite or sanitize timestamps, and Loki may still reject entries that fall outside its configured acceptance window (for example far-future or out-of-order timestamps).
+When no timestamp stage is set, `loki.process` keeps the timestamp that the upstream component already attached to the entry, for example a `loki.source.*` component.
+Many sources set that timestamp to the time they receive the entry by default.
+Other sources can use a timestamp embedded in the log when you enable incoming-timestamp options.
+If you leave out `stage.timestamp`, `loki.process` does not rewrite or sanitize timestamps by itself, and Loki may still reject entries that fall outside its configured acceptance window, for example far-future or out-of-order timestamps.
 
 The following arguments are supported:
 


### PR DESCRIPTION
The old note said the timestamp always defaults to scrape time if you skip `stage.timestamp`. That's not quite right — the entry keeps whatever the upstream source already set, and Loki can still drop out-of-window timestamps either way.

Fixes #6286