### PR TITLE
docs: Use api/v1 remote_write paths in prometheus-metrics guide

### DIFF
--- a/docs/sources/collect/prometheus-metrics.md
+++ b/docs/sources/collect/prometheus-metrics.md
@@ -76,11 +76,11 @@ The following example demonstrates configuring `prometheus.remote_write` with mu
 ```alloy
 prometheus.remote_write "default" {
   endpoint {
-    url = "http://localhost:9009/api/prom/push"
+    url = "http://localhost:9009/api/v1/push"
   }
 
   endpoint {
-    url = "https://prometheus-us-central1.grafana.net/api/prom/push"
+    url = "https://prometheus-us-central1.grafana.net/api/v1/write"
 
     // Get basic authentication based on environment variables.
     basic_auth {
@@ -221,7 +221,7 @@ prometheus.scrape "pods" {
 
 prometheus.remote_write "default" {
   endpoint {
-    url = "http://localhost:9009/api/prom/push"
+    url = "http://localhost:9009/api/v1/push"
   }
 }
 ```
@@ -347,7 +347,7 @@ prometheus.scrape "services" {
 
 prometheus.remote_write "default" {
   endpoint {
-    url = "http://localhost:9009/api/prom/push"
+    url = "http://localhost:9009/api/v1/push"
   }
 }
 ```
@@ -416,7 +416,7 @@ prometheus.scrape "custom_targets" {
 
 prometheus.remote_write "default" {
   endpoint {
-    url = "http://localhost:9009/api/prom/push"
+    url = "http://localhost:9009/api/v1/push"
   }
 }
 ```

--- a/docs/sources/collect/prometheus-metrics.md
+++ b/docs/sources/collect/prometheus-metrics.md
@@ -80,7 +80,7 @@ prometheus.remote_write "default" {
   }
 
   endpoint {
-    url = "https://prometheus-us-central1.grafana.net/api/v1/write"
+    url = "https://prometheus-us-central1.grafana.net/api/prom/push"
 
     // Get basic authentication based on environment variables.
     basic_auth {


### PR DESCRIPTION
The collect prometheus-metrics guide already says to use api/v1/write (Prometheus) and api/v1/push (Mimir), but several examples were still on api/prom/push.

Swapped those examples over so they match the current endpoints.

Fixes #4884