### PR TITLE
docs: Link Access and permissions from intro and configure

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -19,6 +19,8 @@ The default configuration file location for {{< param "PRODUCT_NAME" >}} is:
 
 This section includes information that helps you configure {{< param "PRODUCT_NAME" >}}.
 
+For process identity, network exposure, TLS, secrets, and platform permission models, refer to [Access and permissions](../access_permissions/).
+
 {{< section >}}
 
 [installed]: ../set-up/install/

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -19,8 +19,6 @@ The default configuration file location for {{< param "PRODUCT_NAME" >}} is:
 
 This section includes information that helps you configure {{< param "PRODUCT_NAME" >}}.
 
-For process identity, network exposure, TLS, secrets, and platform permission models, refer to [Access and permissions](../access_permissions/).
-
 {{< section >}}
 
 [installed]: ../set-up/install/

--- a/docs/sources/introduction/_index.md
+++ b/docs/sources/introduction/_index.md
@@ -35,6 +35,7 @@ This approach reduces operational complexity while giving you the flexibility to
 - [Requirements and expectations][Requirements]: Review deployment considerations and constraints
 - [Supported platforms][Supported platforms]: Check platform compatibility
 - [Estimate resource usage][Estimate resource usage]: Plan your deployment
+- [Access and permissions][Access and permissions]: Hardening, identity, network exposure, and secrets
 - [Migrate from other collectors][migrate]: Move from OpenTelemetry Collector, Prometheus Agent, or Grafana Agent
 
 [OpenTelemetry]: https://opentelemetry.io/docs/collector/distributions/

--- a/docs/sources/introduction/_index.md
+++ b/docs/sources/introduction/_index.md
@@ -48,6 +48,7 @@ This approach reduces operational complexity while giving you the flexibility to
 [Requirements]: ./requirements/
 [Supported platforms]: ../set-up/supported-platforms/
 [Estimate resource usage]: ../set-up/estimate-resource-usage/
+[Access and permissions]: ../access_permissions/
 [migrate]: ../set-up/migrate/
 [beginners]: https://github.com/grafana/Grafana-Alloy-for-Beginners
 [scenarios]: https://github.com/grafana/alloy-scenarios


### PR DESCRIPTION
We already have the access/permissions overview; it was just easy to miss after install.

Hooked it from Configure and the Introduction \"Learn more\" list.

Fixes #5922