### PR TITLE
docs: Remove please from tail_sampling note

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.tail_sampling.md
@@ -218,7 +218,7 @@ Each policy results in a decision, and the processor evaluates them to make a fi
 
 An "inverted" decision is the one made based on the `invert_match` attribute, such as the one from the string, numeric or boolean tag policy.
 There is an exception to this if the policy is within an and or composite policy, the resulting decision will be either sampled or not sampled.
-The "inverted" decisions have been deprecated, please make use of `drop` policy to explicitly not sample select traces.
+The "inverted" decisions are deprecated. Use a `drop` policy to explicitly not sample selected traces.
 
 ### `boolean_attribute`
 


### PR DESCRIPTION
Tiny docs cleanup on `otelcol.processor.tail_sampling`.

The inverted-decision note used "please make use of"; rewrote it to match the shorter voice used elsewhere in the component docs (same spirit as #5175).