### PR TITLE
docs: Fix table formatting in `loki.process.md` timestamp related block

### DIFF
--- a/docs/sources/reference/components/loki/loki.process.md
+++ b/docs/sources/reference/components/loki/loki.process.md
@@ -1828,7 +1828,7 @@ When no timestamp stage is set, the log entry timestamp defaults to the time whe
 The following arguments are supported:
 
 | Name                            | Type           | Description                                                 | Default   | Required |
-| ------------------- ------------| -------------- | ----------------------------------------------------------- | --------- | -------- |
+| ------------------------------- | -------------- | ----------------------------------------------------------- | --------- | -------- |
 | `format`                        | `string`       | Determines how to parse the source string.                  |           | yes      |
 | `source`                        | `string`       | Name from extracted values map to use for the timestamp.    |           | yes      |
 | `action_on_failure`             | `string`       | What to do when the timestamp can't be extracted or parsed. | `"fudge"` | no       |


### PR DESCRIPTION
### Brief description of Pull Request

Fix formatting issue present on the timestamp block in `loki.process` docs in `docs/sources/reference/components/loki/loki.process.md` file



### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->
Fix table formatting issue due to missing `-` 

