### PR TITLE
chore(loki.secretfilter): Add Interceptor and implement Consume and ConsumeEntry hooks

### DIFF
--- a/internal/component/loki/secretfilter/secretfilter.go
+++ b/internal/component/loki/secretfilter/secretfilter.go
@@ -315,7 +315,6 @@ func New(o component.Options, args Arguments) (*Component, error) {
 				))
 				*entry = newEntry
 				return true
-
 			})
 
 			return batch, terminalErr

--- a/internal/component/loki/secretfilter/secretfilter.go
+++ b/internal/component/loki/secretfilter/secretfilter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -59,6 +60,8 @@ type Exports struct {
 	Receiver loki.LogsReceiver `alloy:"receiver,attr"`
 }
 
+var errProcessingTimeout = errors.New("processing timeout exceeded")
+
 // defaultRate is the default sampling rate (1.0 = process all entries).
 const defaultRate = 1.0
 
@@ -96,10 +99,13 @@ type Component struct {
 	opts component.Options
 	log  *slog.Logger
 
+	receiver    loki.LogsReceiver
+	fanout      *loki.Fanout
+	interceptor *loki.InterceptorConsumer
+
 	mut      sync.RWMutex
+	stopped  bool
 	args     Arguments
-	receiver loki.LogsReceiver
-	fanout   *loki.Fanout
 	detector secretDetector
 
 	// redactPercent is the effective percentage (1-100) for gitleaks-style redaction when redact_with is not set. Set at build/update.
@@ -271,6 +277,77 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		"label_timed_out", args.LabelTimedOut,
 	)
 
+	c.interceptor = loki.NewInterceptorConsumer(
+		o.ID,
+		loki.NewNopConsumer(),
+		loki.WithConsumeHook(func(ctx context.Context, batch loki.Batch) (loki.Batch, error) {
+			c.mut.RLock()
+			defer c.mut.RUnlock()
+
+			if c.stopped {
+				return loki.Batch{}, loki.ErrConsumerStopped
+			}
+
+			var terminalErr error
+
+			batch.FilterMap(func(entry *loki.Entry) (keep bool) {
+				if terminalErr != nil {
+					return false
+				}
+
+				newEntry, err := c.processEntry(ctx, *entry)
+				if err != nil {
+					if errors.Is(err, errProcessingTimeout) {
+						return false
+					}
+
+					terminalErr = err
+					return false
+				}
+
+				c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
+					livedebugging.ComponentID(c.opts.ID),
+					livedebugging.LokiLog,
+					1,
+					func() string {
+						return fmt.Sprintf("%s => %s", entry.Line, newEntry.Line)
+					},
+				))
+				*entry = newEntry
+				return true
+
+			})
+
+			return batch, terminalErr
+		}),
+		loki.WithConsumeEntryHook(func(ctx context.Context, entry loki.Entry) (loki.Entry, bool, error) {
+			c.mut.RLock()
+			defer c.mut.RUnlock()
+
+			if c.stopped {
+				return loki.Entry{}, false, loki.ErrConsumerStopped
+			}
+
+			newEntry, err := c.processEntry(ctx, entry)
+			if err != nil {
+				if errors.Is(err, errProcessingTimeout) {
+					return loki.Entry{}, false, nil
+				}
+				return loki.Entry{}, false, err
+			}
+
+			c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
+				livedebugging.ComponentID(c.opts.ID),
+				livedebugging.LokiLog,
+				1,
+				func() string {
+					return fmt.Sprintf("%s => %s", entry.Line, newEntry.Line)
+				},
+			))
+			return newEntry, true, nil
+		}),
+	)
+
 	// Immediately export the receiver which remains the same for the component
 	// lifetime.
 	o.OnStateChange(Exports{Receiver: c.receiver})
@@ -280,32 +357,32 @@ func New(o component.Options, args Arguments) (*Component, error) {
 
 // Run implements component.Component.
 func (c *Component) Run(ctx context.Context) error {
-	componentID := livedebugging.ComponentID(c.opts.ID)
+	defer func() {
+		c.mut.Lock()
+		defer c.mut.Unlock()
+		c.stopped = true
+	}()
+
 	loki.ConsumeAndProcess(ctx, c.receiver, c.fanout, func(entry loki.Entry) (loki.Entry, bool) {
 		c.mut.RLock()
 		defer c.mut.RUnlock()
 
-		if c.shouldProcessEntry() {
-			newEntry, dropped := c.processEntry(ctx, entry)
-			if dropped {
-				c.log.Debug("entry dropped", "reason", "processing_timeout")
-				return loki.Entry{}, false
-			}
-			c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
-				componentID,
-				livedebugging.LokiLog,
-				1,
-				func() string {
-					return fmt.Sprintf("%s => %s", entry.Line, newEntry.Line)
-				},
-			))
-			return newEntry, true
+		newEntry, err := c.processEntry(ctx, entry)
+		if err != nil {
+			return loki.Entry{}, false
 		}
 
-		c.metrics.entriesBypassedTotal.Inc()
-		c.log.Debug("entry bypassed by sampling", "rate", c.args.Rate)
-		return entry, true
+		c.debugDataPublisher.PublishIfActive(livedebugging.NewData(
+			livedebugging.ComponentID(c.opts.ID),
+			livedebugging.LokiLog,
+			1,
+			func() string {
+				return fmt.Sprintf("%s => %s", entry.Line, newEntry.Line)
+			},
+		))
+		return newEntry, true
 	})
+
 	return nil
 }
 
@@ -317,50 +394,57 @@ func (c *Component) shouldProcessEntry() bool {
 	return c.sampler.ShouldSample()
 }
 
-// processEntry scans the log entry for secrets and redacts them. Returns the
-// processed entry and a boolean indicating whether the entry should be dropped.
-// If processing_timeout is exceeded and drop_on_timeout is false (default),
-// the original unredacted entry is forwarded. If processing_timeout is
-// exceeded and drop_on_timeout is true, the entry is dropped.
-func (c *Component) processEntry(ctx context.Context, entry loki.Entry) (loki.Entry, bool) {
+// processEntry scans the log entry for secrets and redacts any it finds.
+//
+// A nil error means the returned entry should be forwarded. errProcessingTimeout
+// means processing_timeout was exceeded with drop_on_timeout set and the entry
+// should be dropped, without drop_on_timeout the entry is returned with any
+// partial findings redacted. Any other error means the caller's context was
+// cancelled and the entry was never fully scanned.
+func (c *Component) processEntry(ctx context.Context, entry loki.Entry) (loki.Entry, error) {
+	if !c.shouldProcessEntry() {
+		c.metrics.entriesBypassedTotal.Inc()
+		c.log.Debug("entry bypassed by sampling", "rate", c.args.Rate)
+		return entry, nil
+	}
+
 	start := time.Now()
 	defer func() {
 		c.metrics.processingDuration.Observe(time.Since(start).Seconds())
 	}()
 
-	if timeout := c.args.ProcessingTimeout; timeout > 0 {
+	if c.args.ProcessingTimeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
+		ctx, cancel = context.WithTimeoutCause(ctx, c.args.ProcessingTimeout, errProcessingTimeout)
 		defer cancel()
 	}
 
 	//nolint:staticcheck // DetectContext still requires detect.Fragment in v8
 	findings := c.detector.DetectContext(ctx, detect.Fragment{Raw: entry.Line})
 
-	if ctx.Err() != nil {
+	if err := context.Cause(ctx); err != nil {
+		if !errors.Is(err, errProcessingTimeout) {
+			return loki.Entry{}, err
+		}
+
 		c.metrics.linesTimedOutTotal.Inc()
 		c.log.Debug("processing timeout exceeded", "drop_on_timeout", c.args.DropOnTimeout, "partial_findings", len(findings))
 		if c.args.DropOnTimeout {
+			c.log.Debug("entry dropped", "reason", "processing_timeout")
 			c.metrics.linesDroppedTotal.Inc()
-			return loki.Entry{}, true
+			return loki.Entry{}, err
 		}
 
 		if c.args.LabelTimedOut {
 			entry = withLabel(entry, "secretfilter", "timed-out")
 		}
-
-		// Redact any partial findings before forwarding, even if the timeout was hit.
-		if len(findings) > 0 {
-			return c.redactLine(entry, findings), false
-		}
-		return entry, false
 	}
 
 	if len(findings) == 0 {
-		return entry, false
+		return entry, nil
 	}
 	c.log.Debug("secrets detected in line", "findings", len(findings))
-	return c.redactLine(entry, findings), false
+	return c.redactLine(entry, findings), nil
 }
 
 // redactLine redacts each finding in the log line and records metrics.

--- a/internal/component/loki/secretfilter/secretfilter_test.go
+++ b/internal/component/loki/secretfilter/secretfilter_test.go
@@ -2,6 +2,7 @@ package secretfilter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -189,6 +190,7 @@ func TestRedactPercent_FullRedaction(t *testing.T) {
 	args := Arguments{
 		ForwardTo:     []loki.LogsReceiver{loki.NewLogsReceiver()},
 		RedactPercent: 100,
+		Rate:          1,
 	}
 	c, err := New(opts, args)
 	require.NoError(t, err)
@@ -197,7 +199,8 @@ func TestRedactPercent_FullRedaction(t *testing.T) {
 		Labels: model.LabelSet{},
 		Entry:  push.Entry{Timestamp: time.Now(), Line: testhelper.TestLogs["grafana_api_key"].Log},
 	}
-	processed, _ := c.processEntry(context.Background(), entry)
+	processed, err := c.processEntry(context.Background(), entry)
+	require.NoError(t, err)
 	require.Contains(t, processed.Entry.Line, "REDACTED", "expected full redaction to produce REDACTED placeholder")
 	require.NotContains(t, processed.Entry.Line, testhelper.FakeSecrets["grafana-api-key"].Value)
 }
@@ -208,6 +211,7 @@ func TestRedactPercent_Partial(t *testing.T) {
 	args := Arguments{
 		ForwardTo:     []loki.LogsReceiver{loki.NewLogsReceiver()},
 		RedactPercent: 80,
+		Rate:          1,
 	}
 	c, err := New(opts, args)
 	require.NoError(t, err)
@@ -233,6 +237,7 @@ func TestRedactWith_CustomPlaceholder(t *testing.T) {
 	args := Arguments{
 		ForwardTo:  []loki.LogsReceiver{loki.NewLogsReceiver()},
 		RedactWith: "***REDACTED***",
+		Rate:       1,
 	}
 	c, err := New(opts, args)
 	require.NoError(t, err)
@@ -253,6 +258,7 @@ func TestDefaultRedactPercent_usesEighty(t *testing.T) {
 	opts := newTestOptions(t, registry)
 	args := Arguments{
 		ForwardTo: []loki.LogsReceiver{loki.NewLogsReceiver()},
+		Rate:      1,
 		// RedactWith and RedactPercent left at zero values => effective 80%
 	}
 	c, err := New(opts, args)
@@ -401,6 +407,7 @@ func TestMetrics(t *testing.T) {
 			args := Arguments{
 				ForwardTo:   []loki.LogsReceiver{loki.NewLogsReceiver()},
 				OriginLabel: "job",
+				Rate:        1,
 			}
 
 			// Create options with the test registry
@@ -488,6 +495,7 @@ func TestMetrics_NoOriginLabel(t *testing.T) {
 	args := Arguments{
 		ForwardTo:   []loki.LogsReceiver{loki.NewLogsReceiver()},
 		OriginLabel: "",
+		Rate:        1,
 	}
 	opts := newTestOptions(t, registry)
 
@@ -524,6 +532,7 @@ func TestMetricsRegistration(t *testing.T) {
 	args := Arguments{
 		ForwardTo:   []loki.LogsReceiver{loki.NewLogsReceiver()},
 		OriginLabel: "job",
+		Rate:        1,
 	}
 
 	c, err := New(opts, args)
@@ -566,6 +575,7 @@ func TestMetricsMultipleEntries(t *testing.T) {
 	args := Arguments{
 		ForwardTo:   []loki.LogsReceiver{loki.NewLogsReceiver()},
 		OriginLabel: "job",
+		Rate:        1,
 	}
 
 	opts := newTestOptions(t, registry)
@@ -628,6 +638,7 @@ func TestArgumentsUpdate(t *testing.T) {
 	initialArgs := Arguments{
 		ForwardTo:   []loki.LogsReceiver{ch1},
 		OriginLabel: "",
+		Rate:        1,
 	}
 
 	// Create options with the test registry
@@ -653,6 +664,7 @@ func TestArgumentsUpdate(t *testing.T) {
 			args: Arguments{
 				ForwardTo:   []loki.LogsReceiver{ch1},
 				OriginLabel: "job",
+				Rate:        1,
 			},
 			inputLog: testhelper.TestLogs["gcp_api_key"].Log,
 		},
@@ -661,6 +673,7 @@ func TestArgumentsUpdate(t *testing.T) {
 			args: Arguments{
 				ForwardTo:   []loki.LogsReceiver{ch1},
 				OriginLabel: "instance",
+				Rate:        1,
 			},
 			inputLog: testhelper.TestLogs["stripe_key"].Log,
 		},
@@ -702,6 +715,7 @@ func TestProcessingTimeout_ForwardsUnredactedOnTimeout(t *testing.T) {
 	c, err := New(opts, Arguments{
 		ForwardTo:         []loki.LogsReceiver{loki.NewLogsReceiver()},
 		ProcessingTimeout: 10 * time.Millisecond,
+		Rate:              1,
 	})
 	require.NoError(t, err)
 	//nolint:staticcheck // DetectContext still requires detect.Fragment in gitleaks v8
@@ -714,9 +728,9 @@ func TestProcessingTimeout_ForwardsUnredactedOnTimeout(t *testing.T) {
 		Labels: model.LabelSet{},
 		Entry:  push.Entry{Timestamp: time.Now(), Line: line},
 	}
-	processed, dropped := c.processEntry(context.Background(), entry)
+	processed, err := c.processEntry(context.Background(), entry)
 
-	require.False(t, dropped, "entry should not be dropped when drop_on_timeout is false")
+	require.NoError(t, err, "entry should not be dropped when drop_on_timeout is false")
 	require.Equal(t, line, processed.Entry.Line, "original unredacted line should be forwarded on timeout")
 	require.Equal(t, float64(1), testutil.ToFloat64(c.metrics.linesTimedOutTotal))
 	require.Equal(t, float64(0), testutil.ToFloat64(c.metrics.linesDroppedTotal))
@@ -731,6 +745,7 @@ func TestProcessingTimeout_DropsOnTimeoutWhenEnabled(t *testing.T) {
 		ForwardTo:         []loki.LogsReceiver{loki.NewLogsReceiver()},
 		ProcessingTimeout: 10 * time.Millisecond,
 		DropOnTimeout:     true,
+		Rate:              1,
 	})
 	require.NoError(t, err)
 	//nolint:staticcheck // DetectContext still requires detect.Fragment in gitleaks v8
@@ -743,9 +758,9 @@ func TestProcessingTimeout_DropsOnTimeoutWhenEnabled(t *testing.T) {
 		Labels: model.LabelSet{},
 		Entry:  push.Entry{Timestamp: time.Now(), Line: line},
 	}
-	_, dropped := c.processEntry(context.Background(), entry)
+	_, err = c.processEntry(context.Background(), entry)
 
-	require.True(t, dropped, "entry should be dropped when drop_on_timeout is true")
+	require.ErrorIs(t, err, errProcessingTimeout)
 	require.Equal(t, float64(1), testutil.ToFloat64(c.metrics.linesTimedOutTotal))
 	require.Equal(t, float64(1), testutil.ToFloat64(c.metrics.linesDroppedTotal))
 }
@@ -758,6 +773,7 @@ func TestProcessingTimeout_NoTimeoutWhenDisabled(t *testing.T) {
 	c, err := New(opts, Arguments{
 		ForwardTo: []loki.LogsReceiver{loki.NewLogsReceiver()},
 		// ProcessingTimeout left at zero: disabled
+		Rate: 1,
 	})
 	require.NoError(t, err)
 
@@ -765,9 +781,9 @@ func TestProcessingTimeout_NoTimeoutWhenDisabled(t *testing.T) {
 		Labels: model.LabelSet{},
 		Entry:  push.Entry{Timestamp: time.Now(), Line: line},
 	}
-	processed, dropped := c.processEntry(context.Background(), entry)
+	processed, err := c.processEntry(context.Background(), entry)
 
-	require.False(t, dropped)
+	require.NoError(t, err)
 	require.NotEqual(t, line, processed.Entry.Line, "secret should be redacted when no timeout is set")
 	require.Equal(t, float64(0), testutil.ToFloat64(c.metrics.linesTimedOutTotal))
 	require.Equal(t, float64(0), testutil.ToFloat64(c.metrics.linesDroppedTotal))
@@ -782,7 +798,7 @@ func TestTimeoutLabel(t *testing.T) {
 		labelTimedOut bool
 		dropOnTimeout bool
 		wantLabel     bool
-		wantDropped   bool
+		wantErr       error
 		wantRedaction bool
 	}{
 		{
@@ -809,7 +825,7 @@ func TestTimeoutLabel(t *testing.T) {
 			findings:      nil,
 			labelTimedOut: true,
 			dropOnTimeout: true,
-			wantDropped:   true,
+			wantErr:       errProcessingTimeout,
 		},
 	}
 
@@ -821,6 +837,7 @@ func TestTimeoutLabel(t *testing.T) {
 				ProcessingTimeout: 10 * time.Millisecond,
 				LabelTimedOut:     tc.labelTimedOut,
 				DropOnTimeout:     tc.dropOnTimeout,
+				Rate:              1,
 			})
 			require.NoError(t, err)
 			findings := tc.findings
@@ -834,10 +851,10 @@ func TestTimeoutLabel(t *testing.T) {
 				Labels: model.LabelSet{"job": "myservice"},
 				Entry:  push.Entry{Timestamp: time.Now(), Line: line},
 			}
-			processed, dropped := c.processEntry(context.Background(), entry)
+			processed, err := c.processEntry(context.Background(), entry)
 
-			require.Equal(t, tc.wantDropped, dropped)
-			if !dropped {
+			require.ErrorIs(t, err, tc.wantErr)
+			if errors.Is(err, errProcessingTimeout) {
 				if tc.wantLabel {
 					require.Equal(t, model.LabelValue("timed-out"), processed.Labels["secretfilter"])
 					require.Equal(t, model.LabelValue("myservice"), processed.Labels["job"], "existing labels should be preserved")

--- a/internal/sampling/sampler.go
+++ b/internal/sampling/sampler.go
@@ -5,8 +5,7 @@ package sampling
 
 import (
 	"fmt"
-	"math/rand"
-	"time"
+	"math/rand/v2"
 )
 
 // maxRandomNumber is the maximum value used for the sampling boundary (0x7fffffffffffffff).
@@ -25,7 +24,6 @@ func ValidateRate(rate float64) error {
 type Sampler struct {
 	rate     float64
 	boundary uint64
-	source   rand.Source
 }
 
 // NewSampler returns a Sampler for the given rate. Rate must be in [0.0, 1.0];
@@ -40,35 +38,23 @@ func NewSampler(rate float64) *Sampler {
 // Rate must be in [0.0, 1.0]; call ValidateRate first or behavior is undefined.
 func (s *Sampler) Update(rate float64) {
 	s.rate = rate
-	if rate > 0 && rate < 1 {
-		s.boundary = uint64(float64(maxRandomNumber) * rate)
-		s.source = rand.NewSource(time.Now().UnixNano())
-	} else {
+	switch {
+	case rate <= 0:
 		s.boundary = 0
-		s.source = nil
+	case rate >= 1:
+		s.boundary = maxRandomNumber
+	default:
+		s.boundary = uint64(float64(maxRandomNumber) * rate)
 	}
 }
 
 // ShouldSample returns true with probability equal to the rate used to create or update the sampler.
 // Rate 0 → always false; rate 1 → always true; otherwise uses the same probabilistic algorithm as Jaeger's ProbabilisticSampler.
 func (s *Sampler) ShouldSample() bool {
-	if s.rate >= 1.0 {
-		return true
-	}
-	if s.rate <= 0.0 {
-		return false
-	}
-	return s.boundary >= s.randomID()&maxRandomNumber
+	return s.boundary >= s.randomID()
 }
 
 // randomID returns a random uint64 in [1, maxRandomNumber] for sampling.
 func (s *Sampler) randomID() uint64 {
-	if s.source == nil {
-		return maxRandomNumber
-	}
-	val := uint64(s.source.Int63())
-	for val == 0 {
-		val = uint64(s.source.Int63())
-	}
-	return val
+	return rand.Uint64N(maxRandomNumber) + 1
 }


### PR DESCRIPTION
### Pull Request Details

Add (unused) loki.InterceptorConsumer for `loki.secretfilter` and update sampler to be concurrency safe since it will be required when change the pipeline from channels to functions.

The sampler had its own rand.Source, which can't be used from more than one goroutine. It now uses the top-level functions in math/rand/v2, which can. rand.Uint64N(n) never returns n itself, so Uint64N(maxRandomNumber) + 1 gives a number from 1 to maxRandomNumber. The old code needed a retry loop to get that, and the & maxRandomNumber mask was doing nothing.

Another important change made in this pr is that we now return an error from `processEntry` instead of a boolean flag indicating if we should drop it. For the current processing loop nothing changes since a context.Cancelation will stop component and drop entry and the processing loop will take care of stopping itself.

For the interceptor this is important since if parent context was canceled we need to return this error to the caller. If processing timed out and we should drop we want to drop entry but not return an error.

### Issue(s) fixed by this Pull Request

Part of: https://github.com/grafana/alloy/issues/4953

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
