### PR TITLE
feat(release): attach SPDX SBOM to GitHub release assets

### DIFF
--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -41,6 +41,7 @@ jobs:
           echo "  - Publish Linux container images"
           echo "  - Publish Windows container image"
           echo "  - Build and sign Windows executables and installer"
+          echo "  - Generate SPDX SBOM for dist artifacts"
           echo "  - Upload release artifacts to GitHub"
           echo "  - Submit WinGet manifest"
           echo "::error::Set dry_run to false to publish."
@@ -278,6 +279,13 @@ jobs:
       run: make dist-alloy-mixin-zip
       env:
         RELEASE_TAG: ${{ env.RELEASE_TAG }}
+
+    # SPDX SBOM for release assets (https://github.com/grafana/alloy/issues/4307)
+    - name: Install syft
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+          | sh -s -- -b /usr/local/bin v1.27.1
+        syft version
 
     - name: Publish release artifacts
       run: ./scripts/publish-release-artifacts.sh

--- a/scripts/publish-release-artifacts.sh
+++ b/scripts/publish-release-artifacts.sh
@@ -43,7 +43,27 @@ find dist/ -type f \
   -name 'alloy-installer-windows-*.exe' \
   -exec zip -j "{}.zip" "{}" \;
 
-# Generate SHA256 checksums for all release assets.
+# Generate a static SPDX SBOM for the release dist tree (issue #4307).
+# Prefer syft when available in the build image; fall back to gh/syft install is not required
+# for local dry-runs of this script if syft is missing (release CI image should ship or install it).
+SBOM_FILE="dist/alloy-${RELEASE_TAG}.spdx.json"
+if command -v syft >/dev/null 2>&1; then
+  syft dir:dist -o spdx-json="${SBOM_FILE}"
+elif command -v docker >/dev/null 2>&1; then
+  # Pin a known syft image for reproducible SBOMs when the host has no syft binary.
+  docker run --rm -v "${PWD}/dist:/dist" anchore/syft:v1.27.1 \
+    dir:/dist -o spdx-json=/dist/"alloy-${RELEASE_TAG}.spdx.json"
+else
+  echo "Error: syft (or docker to run anchore/syft) is required to generate the release SBOM"
+  exit 1
+fi
+
+if [ ! -f "${SBOM_FILE}" ]; then
+  echo "Error: expected SBOM at ${SBOM_FILE}"
+  exit 1
+fi
+
+# Generate SHA256 checksums for all release assets (includes SBOM).
 pushd dist && sha256sum -- * > SHA256SUMS && popd
 
 # Upload all assets to the existing GitHub release.


### PR DESCRIPTION
## Description

Generates a static SPDX JSON SBOM for the release `dist/` tree during artifact publish and uploads it with the other GitHub release assets (filename `alloy-<tag>.spdx.json`). Checksums include the SBOM.

Implements the release-process improvement requested in #4307.

### Changes
- `scripts/publish-release-artifacts.sh`: run `syft` (or pinned `anchore/syft` via Docker) over `dist/`
- `release-publish-alloy-artifacts.yml`: install syft before publish; mention SBOM in dry-run output

## Testing

- Script syntax: bash `-n scripts/publish-release-artifacts.sh`
- Full publish path not run (needs release tag + secrets); dry-run message updated

Closes #4307