### PR TITLE
fix(fmt): Do not write a file if no formatter changes are needed

### DIFF
--- a/docs/sources/reference/cli/fmt.md
+++ b/docs/sources/reference/cli/fmt.md
@@ -29,6 +29,7 @@ Otherwise, `fmt` reads and formats the file from disk specified by the argument.
 
 The `--write` flag can be specified to replace the contents of the original file on disk with the formatted results.
 `--write` can only be provided when `fmt` isn't reading from standard input.
+If the formatted result is identical to the file contents, `--write` doesn't write to the file.
 
 The `--test` flag can be specified to test if the contents of the file are formatted correctly.
 

--- a/internal/alloycli/cmd_fmt.go
+++ b/internal/alloycli/cmd_fmt.go
@@ -66,6 +66,8 @@ type alloyFmt struct {
 	test  bool
 }
 
+type writeFileFunc func(filename string, fi os.FileInfo, r io.Reader) error
+
 func (ff *alloyFmt) Run(configFile string) error {
 	if ff.write && ff.test {
 		return fmt.Errorf("cannot use -w/--write and -t/--test at the same time")
@@ -76,7 +78,7 @@ func (ff *alloyFmt) Run(configFile string) error {
 		if ff.write {
 			return fmt.Errorf("cannot use -w with standard input")
 		}
-		return format("<stdin>", nil, os.Stdin, false, ff.test)
+		return format("<stdin>", nil, os.Stdin, false, ff.test, writeFile)
 
 	default:
 		fi, err := os.Stat(configFile)
@@ -92,11 +94,11 @@ func (ff *alloyFmt) Run(configFile string) error {
 			return err
 		}
 		defer f.Close()
-		return format(configFile, fi, f, ff.write, ff.test)
+		return format(configFile, fi, f, ff.write, ff.test, writeFile)
 	}
 }
 
-func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool) error {
+func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool, writeFile writeFileFunc) error {
 	bb, err := io.ReadAll(r)
 	if err != nil {
 		return err
@@ -115,9 +117,11 @@ func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool)
 	// Add a newline at the end of the file.
 	_, _ = buf.Write([]byte{'\n'})
 
-	// If -t/--test flag is check, only check if file is formatted correctly
+	unchanged := reflect.DeepEqual(bb, buf.Bytes())
+
+	// If -t/--test is set, only check if the file is formatted correctly.
 	if test {
-		if !reflect.DeepEqual(bb, buf.Bytes()) {
+		if !unchanged {
 			return fmt.Errorf("file %s is not formatted correctly", filename)
 		}
 		return nil
@@ -128,12 +132,20 @@ func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool)
 		return err
 	}
 
+	if unchanged {
+		return nil
+	}
+
+	return writeFile(filename, fi, &buf)
+}
+
+func writeFile(filename string, fi os.FileInfo, r io.Reader) error {
 	wf, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, fi.Mode().Perm())
 	if err != nil {
 		return err
 	}
 	defer wf.Close()
 
-	_, err = io.Copy(wf, &buf)
+	_, err = io.Copy(wf, r)
 	return err
 }

--- a/internal/alloycli/cmd_fmt.go
+++ b/internal/alloycli/cmd_fmt.go
@@ -98,7 +98,7 @@ func (ff *alloyFmt) Run(configFile string) error {
 	}
 }
 
-func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool, writeFile writeFileFunc) error {
+func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool, writeFileFn writeFileFunc) error {
 	bb, err := io.ReadAll(r)
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func format(filename string, fi os.FileInfo, r io.Reader, write bool, test bool,
 		return nil
 	}
 
-	return writeFile(filename, fi, &buf)
+	return writeFileFn(filename, fi, &buf)
 }
 
 func writeFile(filename string, fi os.FileInfo, r io.Reader) error {

--- a/internal/alloycli/cmd_fmt_test.go
+++ b/internal/alloycli/cmd_fmt_test.go
@@ -1,0 +1,73 @@
+package alloycli
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatWrite(t *testing.T) {
+	const (
+		formattedConfig   = "logging {\n\tlevel = \"debug\"\n}\n"
+		unformattedConfig = "logging { level = \"debug\" }"
+	)
+
+	writeErr := errors.New("write failed")
+
+	tests := []struct {
+		name        string
+		input       string
+		writeErr    error
+		wantWrites  int
+		wantContent string
+	}{
+		{
+			name:  "unchanged content",
+			input: formattedConfig,
+		},
+		{
+			name:        "changed content",
+			input:       unformattedConfig,
+			wantWrites:  1,
+			wantContent: formattedConfig,
+		},
+		{
+			name:        "write error",
+			input:       unformattedConfig,
+			writeErr:    writeErr,
+			wantWrites:  1,
+			wantContent: formattedConfig,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				writes  int
+				content []byte
+			)
+			writer := func(_ string, _ os.FileInfo, r io.Reader) error {
+				writes++
+
+				var err error
+				content, err = io.ReadAll(r)
+				require.NoError(t, err)
+				return tc.writeErr
+			}
+
+			err := format("test.alloy", nil, strings.NewReader(tc.input), true, false, writer)
+
+			if tc.writeErr != nil {
+				require.ErrorIs(t, err, tc.writeErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantWrites, writes)
+			require.Equal(t, tc.wantContent, string(content))
+		})
+	}
+}


### PR DESCRIPTION
### Brief description of Pull Request

Prevent `alloy fmt --write` from rewriting a file when its formatting resulted in no changes. Add unit tests.

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->

- This is to better support the [treefmt](https://treefmt.com/latest/) spec and potentially other tooling that tracks file changes.


### Issue(s) fixed by this Pull Request

Fixes #6495

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))