### PR TITLE
POC: New structure for loki.process pipeline

### DIFF
--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -36,6 +36,15 @@ func (b *Batch) Add(stream Stream) {
 	b.entryLen += len(stream.Entries)
 }
 
+func (b *Batch) AddEntry(entry Entry) {
+	if b.created == 0 {
+		b.created = time.Now().UnixMicro()
+	}
+
+	b.add(entry.Labels, entry.Entry)
+	b.entryLen += 1
+}
+
 func (b *Batch) add(labels model.LabelSet, entries ...push.Entry) {
 	i := slices.IndexFunc(b.streams, func(s Stream) bool {
 		return s.Labels.Equal(labels)

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -36,12 +36,12 @@ func (b *Batch) Add(stream Stream) {
 	b.entryLen += len(stream.Entries)
 }
 
-func (b *Batch) AddEntry(entry Entry) {
+func (b *Batch) AddEntry(lbls model.LabelSet, entry push.Entry) {
 	if b.created == 0 {
 		b.created = time.Now().UnixMicro()
 	}
 
-	b.add(entry.Labels, entry.Entry)
+	b.add(lbls, entry)
 	b.entryLen += 1
 }
 

--- a/internal/component/loki/process/stages/pipeline_2.go
+++ b/internal/component/loki/process/stages/pipeline_2.go
@@ -15,15 +15,7 @@ import (
 	crip "github.com/grafana/alloy/internal/component/loki/process/stages/cri"
 )
 
-// Emitter receives entries produced by a stage or a chain of stages.
-type Emitter interface {
-	Emit(ctx context.Context, e Entry) error
-}
-
-// EmitterFunc adapts a function to an Emitter.
-type EmitterFunc func(ctx context.Context, e Entry) error
-
-func (f EmitterFunc) Emit(ctx context.Context, e Entry) error { return f(ctx, e) }
+type Emitter func(ctx context.Context, e Entry) error
 
 // Stage2 is a stage in a continuation-passing pipeline: given an entry
 // and an Emitter representing everything after it, Process decides
@@ -74,10 +66,10 @@ func NewPipeline2(stages []Stage2) *Pipeline2 {
 
 func (p *Pipeline2) ProcessEntry(ctx context.Context, entry loki.Entry) ([]Entry, error) {
 	var entries []Entry
-	err := p.Process(ctx, Entry{Extracted: make(map[string]any, len(entry.Labels)), Entry: entry}, EmitterFunc(func(ctx context.Context, e Entry) error {
+	err := p.Process(ctx, Entry{Extracted: make(map[string]any, len(entry.Labels)), Entry: entry}, func(ctx context.Context, e Entry) error {
 		entries = append(entries, e)
 		return nil
-	}))
+	})
 
 	return entries, err
 }
@@ -92,10 +84,10 @@ func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) (loki.Ba
 				Entry{
 					Extracted: make(map[string]any, len(stream.Labels)),
 					Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e)},
-				EmitterFunc(func(ctx context.Context, e Entry) error {
+				func(ctx context.Context, e Entry) error {
 					out.AddEntry(e.Labels, e.Entry.Entry)
 					return nil
-				}),
+				},
 			)
 
 			if err != nil {
@@ -112,7 +104,7 @@ func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) (loki.Ba
 // Process pushes a single entry through the pipeline, starting at the
 // first stage. Whatever the last stage emits is handed to next.
 func (p *Pipeline2) Process(ctx context.Context, e Entry, next Emitter) error {
-	return p.chainFrom(0, next).Emit(ctx, e)
+	return p.chainFrom(0, next)(ctx, e)
 }
 
 // NextDeadline reports the earliest deadline across every stage that
@@ -140,10 +132,10 @@ func (p *Pipeline2) Flush(ctx context.Context) ([]Entry, error) {
 		if dl.IsZero() || dl.After(now) {
 			continue
 		}
-		next := p.chainFrom(fl.idx+1, EmitterFunc(func(ctx context.Context, e Entry) error {
+		next := p.chainFrom(fl.idx+1, func(ctx context.Context, e Entry) error {
 			out = append(out, e)
 			return nil
-		}))
+		})
 		if err := fl.f.Flush(ctx, next); err != nil {
 			return nil, err
 		}
@@ -157,9 +149,9 @@ func (p *Pipeline2) chainFrom(from int, next Emitter) Emitter {
 	chain := next
 	for _, stage := range slices.Backward(p.stages[from:]) {
 		cur := chain
-		chain = EmitterFunc(func(ctx context.Context, e Entry) error {
+		chain = func(ctx context.Context, e Entry) error {
 			return stage.Process(ctx, e, cur)
-		})
+		}
 	}
 	return chain
 }
@@ -189,7 +181,7 @@ func newCRIStage2(maxPartialLines int) *criStage2 {
 func (c *criStage2) Process(ctx context.Context, e Entry, next Emitter) error {
 	parsed, ok := crip.ParseCRI(e.Line)
 	if !ok {
-		return next.Emit(ctx, e)
+		return next(ctx, e)
 	}
 	e.Line = parsed.Content
 
@@ -213,7 +205,7 @@ func (c *criStage2) Process(ctx context.Context, e Entry, next Emitter) error {
 		c.mu.Unlock()
 
 		for _, buffered := range entries {
-			if err := next.Emit(ctx, buffered); err != nil {
+			if err := next(ctx, buffered); err != nil {
 				return err
 			}
 		}
@@ -226,7 +218,7 @@ func (c *criStage2) Process(ctx context.Context, e Entry, next Emitter) error {
 	}
 	c.mu.Unlock()
 
-	return next.Emit(ctx, e)
+	return next(ctx, e)
 }
 
 func (c *criStage2) Cleanup() {}
@@ -276,7 +268,7 @@ func (m *multilineStage2) Process(ctx context.Context, e Entry, next Emitter) er
 	if !ok && !isFirstLine {
 		m.mu.Unlock()
 		// never part of a block: pass through
-		return next.Emit(ctx, e)
+		return next(ctx, e)
 	}
 
 	// A new entry arriving for a stream that's already gone stale
@@ -315,7 +307,7 @@ func (m *multilineStage2) Process(ctx context.Context, e Entry, next Emitter) er
 	m.mu.Unlock()
 
 	for _, r := range resolved {
-		if err := next.Emit(ctx, r); err != nil {
+		if err := next(ctx, r); err != nil {
 			return err
 		}
 	}
@@ -357,7 +349,7 @@ func (m *multilineStage2) Flush(ctx context.Context, next Emitter) error {
 	m.mu.Unlock()
 
 	for _, e := range resolved {
-		if err := next.Emit(ctx, e); err != nil {
+		if err := next(ctx, e); err != nil {
 			return err
 		}
 	}
@@ -394,7 +386,7 @@ func (s *staticLabelsStage2) Process(ctx context.Context, e Entry, next Emitter)
 	for i := 0; i < len(s.values); i += 2 {
 		e.Labels[model.LabelName(s.values[i])] = model.LabelValue(s.values[i+1])
 	}
-	return next.Emit(ctx, e)
+	return next(ctx, e)
 }
 
 func (s *staticLabelsStage2) Cleanup() {}
@@ -415,7 +407,7 @@ func newMatchStage2(match func(Entry) bool, action string, pipeline *Pipeline2) 
 
 func (m *matchStage2) Process(ctx context.Context, e Entry, next Emitter) error {
 	if !m.match(e) {
-		return next.Emit(ctx, e)
+		return next(ctx, e)
 	}
 
 	switch m.action {
@@ -424,7 +416,7 @@ func (m *matchStage2) Process(ctx context.Context, e Entry, next Emitter) error 
 	case MatchActionKeep:
 		return m.pipeline.Process(ctx, e, next)
 	default:
-		return next.Emit(ctx, e)
+		return next(ctx, e)
 	}
 }
 
@@ -453,7 +445,7 @@ func (m *matchStage2) Flush(ctx context.Context, next Emitter) error {
 	}
 
 	for _, e := range entries {
-		if err := next.Emit(ctx, e); err != nil {
+		if err := next(ctx, e); err != nil {
 			return err
 		}
 	}

--- a/internal/component/loki/process/stages/pipeline_2.go
+++ b/internal/component/loki/process/stages/pipeline_2.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/alloy/internal/component/common/loki"
 	crip "github.com/grafana/alloy/internal/component/loki/process/stages/cri"
 )
 
@@ -71,6 +72,43 @@ func NewPipeline2(stages []Stage2) *Pipeline2 {
 	return p
 }
 
+func (p *Pipeline2) ProcessEntry(ctx context.Context, entry loki.Entry) ([]Entry, error) {
+	var entries []Entry
+	err := p.Process(ctx, Entry{Extracted: make(map[string]any, len(entry.Labels)), Entry: entry}, EmitterFunc(func(ctx context.Context, e Entry) error {
+		entries = append(entries, e)
+		return nil
+	}))
+
+	return entries, err
+}
+
+func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) (loki.Batch, error) {
+	out := loki.NewBatchWithCreatedUnixMicro(batch.Created())
+
+	err := batch.ConsumeStreams(func(stream loki.Stream, created int64) error {
+		for _, e := range stream.Entries {
+			err := p.Process(
+				ctx,
+				Entry{
+					Extracted: make(map[string]any, len(stream.Labels)),
+					Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e)},
+				EmitterFunc(func(ctx context.Context, e Entry) error {
+					out.AddEntry(e.Labels, e.Entry.Entry)
+					return nil
+				}),
+			)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	return out, err
+}
+
 // Process pushes a single entry through the pipeline, starting at the
 // first stage. Whatever the last stage emits is handed to next.
 func (p *Pipeline2) Process(ctx context.Context, e Entry, next Emitter) error {
@@ -90,22 +128,27 @@ func (p *Pipeline2) NextDeadline() time.Time {
 	return nearest
 }
 
-// Flush flushes whichever Stage2WithFlush stages have a deadline that
-// has already passed, routing whatever each one emits through the rest
-// of the pipeline into next.
-func (p *Pipeline2) Flush(ctx context.Context, next Emitter) error {
+// Flush flushes whichever Stage3WithFlush stages have a deadline that has
+// already passed, running whatever each one returns through the rest of
+// the pipeline.
+// FIXME(maybe iterator)
+func (p *Pipeline2) Flush(ctx context.Context) ([]Entry, error) {
 	now := time.Now()
+	var out []Entry
 	for _, fl := range p.flushers {
 		dl := fl.f.NextDeadline()
 		if dl.IsZero() || dl.After(now) {
 			continue
 		}
-		next := p.chainFrom(fl.idx+1, next)
+		next := p.chainFrom(fl.idx+1, EmitterFunc(func(ctx context.Context, e Entry) error {
+			out = append(out, e)
+			return nil
+		}))
 		if err := fl.f.Flush(ctx, next); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return out, nil
 }
 
 // chainFrom builds an Emitter that runs stages[from:] in order before
@@ -403,5 +446,16 @@ func (m *matchStage2) Flush(ctx context.Context, next Emitter) error {
 	if m.pipeline == nil {
 		return nil
 	}
-	return m.pipeline.Flush(ctx, next)
+
+	entries, err := m.pipeline.Flush(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := next.Emit(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/component/loki/process/stages/pipeline_2.go
+++ b/internal/component/loki/process/stages/pipeline_2.go
@@ -77,20 +77,23 @@ func (p *Pipeline2) ProcessEntry(ctx context.Context, entry loki.Entry) ([]Entry
 func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) (loki.Batch, error) {
 	out := loki.NewBatchWithCreatedUnixMicro(batch.Created())
 
+	// collect and chain are built once for the whole batch, since the
+	// terminal destination and the stage topology are both constant
+	// across every entry -- Process alone can't assume that (a lone
+	// caller might never reuse next), but ProcessBatch knows it will.
+	collect := func(ctx context.Context, e Entry) error {
+		out.AddEntry(e.Labels, e.Entry.Entry)
+		return nil
+	}
+	chain := p.chainFrom(0, collect)
+
 	err := batch.ConsumeStreams(func(stream loki.Stream, created int64) error {
 		for _, e := range stream.Entries {
-			err := p.Process(
-				ctx,
-				Entry{
-					Extracted: make(map[string]any, len(stream.Labels)),
-					Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e)},
-				func(ctx context.Context, e Entry) error {
-					out.AddEntry(e.Labels, e.Entry.Entry)
-					return nil
-				},
-			)
-
-			if err != nil {
+			entry := Entry{
+				Extracted: make(map[string]any, len(stream.Labels)),
+				Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e),
+			}
+			if err := chain(ctx, entry); err != nil {
 				return err
 			}
 		}

--- a/internal/component/loki/process/stages/pipeline_2.go
+++ b/internal/component/loki/process/stages/pipeline_2.go
@@ -1,0 +1,407 @@
+package stages
+
+import (
+	"context"
+	"maps"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	crip "github.com/grafana/alloy/internal/component/loki/process/stages/cri"
+)
+
+// Emitter receives entries produced by a stage or a chain of stages.
+type Emitter interface {
+	Emit(ctx context.Context, e Entry) error
+}
+
+// EmitterFunc adapts a function to an Emitter.
+type EmitterFunc func(ctx context.Context, e Entry) error
+
+func (f EmitterFunc) Emit(ctx context.Context, e Entry) error { return f(ctx, e) }
+
+// Stage2 is a stage in a continuation-passing pipeline: given an entry
+// and an Emitter representing everything after it, Process decides
+// whether, how many times, and with what mutations to call next.
+type Stage2 interface {
+	Process(ctx context.Context, e Entry, next Emitter) error
+	Cleanup()
+}
+
+// Stage2WithFlush is a Stage2 that can also emit entries independent of
+// any Process call, on its own schedule (e.g. an idle timeout). Flush is
+// driven by something other than a caller -- a timer, most likely -- so
+// it must take whatever lock Process takes on the same stage, the same
+// way criStage2's mu already guards both paths.
+type Stage2WithFlush interface {
+	Stage2
+	// NextDeadline reports when this stage next has something ready to
+	// flush, or the zero Time if nothing is pending.
+	NextDeadline() time.Time
+	// Flush emits whatever is due to next.
+	Flush(ctx context.Context, next Emitter) error
+}
+
+// flusherEntry pairs a Stage2WithFlush with its position in stages, so a
+// flush can be routed through everything after it.
+type flusherEntry struct {
+	idx int
+	f   Stage2WithFlush
+}
+
+// Pipeline2 chains Stage2 stages together with direct function calls
+// instead of channels.
+type Pipeline2 struct {
+	stages   []Stage2
+	flushers []flusherEntry
+}
+
+// NewPipeline2 builds a Pipeline2 from stages, in order.
+func NewPipeline2(stages []Stage2) *Pipeline2 {
+	p := &Pipeline2{stages: stages}
+	for i, s := range stages {
+		if f, ok := s.(Stage2WithFlush); ok {
+			p.flushers = append(p.flushers, flusherEntry{idx: i, f: f})
+		}
+	}
+	return p
+}
+
+// Process pushes a single entry through the pipeline, starting at the
+// first stage. Whatever the last stage emits is handed to next.
+func (p *Pipeline2) Process(ctx context.Context, e Entry, next Emitter) error {
+	return p.chainFrom(0, next).Emit(ctx, e)
+}
+
+// NextDeadline reports the earliest deadline across every stage that
+// implements Stage2WithFlush, or the zero Time if nothing is pending
+// anywhere in the pipeline.
+func (p *Pipeline2) NextDeadline() time.Time {
+	var nearest time.Time
+	for _, fl := range p.flushers {
+		if dl := fl.f.NextDeadline(); !dl.IsZero() && (nearest.IsZero() || dl.Before(nearest)) {
+			nearest = dl
+		}
+	}
+	return nearest
+}
+
+// Flush flushes whichever Stage2WithFlush stages have a deadline that
+// has already passed, routing whatever each one emits through the rest
+// of the pipeline into next.
+func (p *Pipeline2) Flush(ctx context.Context, next Emitter) error {
+	now := time.Now()
+	for _, fl := range p.flushers {
+		dl := fl.f.NextDeadline()
+		if dl.IsZero() || dl.After(now) {
+			continue
+		}
+		next := p.chainFrom(fl.idx+1, next)
+		if err := fl.f.Flush(ctx, next); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// chainFrom builds an Emitter that runs stages[from:] in order before
+// handing whatever comes out to next.
+func (p *Pipeline2) chainFrom(from int, next Emitter) Emitter {
+	chain := next
+	for _, stage := range slices.Backward(p.stages[from:]) {
+		cur := chain
+		chain = EmitterFunc(func(ctx context.Context, e Entry) error {
+			return stage.Process(ctx, e, cur)
+		})
+	}
+	return chain
+}
+
+func (p *Pipeline2) Stop() {
+	// TODO: Implement Stop
+
+}
+
+// criStage2 is a simplified port of the real cri stage. Partial lines are
+// held across Process calls in instead of being forwarded, and a later call can
+// emit zero, one, or many entries once they're resolved or force-flushed.
+type criStage2 struct {
+	maxPartialLines int
+
+	mu           sync.Mutex
+	partialLines map[model.Fingerprint]Entry
+}
+
+func newCRIStage2(maxPartialLines int) *criStage2 {
+	return &criStage2{
+		maxPartialLines: maxPartialLines,
+		partialLines:    make(map[model.Fingerprint]Entry, maxPartialLines),
+	}
+}
+
+func (c *criStage2) Process(ctx context.Context, e Entry, next Emitter) error {
+	parsed, ok := crip.ParseCRI(e.Line)
+	if !ok {
+		return next.Emit(ctx, e)
+	}
+	e.Line = parsed.Content
+
+	fingerprint := e.Labels.Fingerprint()
+
+	c.mu.Lock()
+
+	if parsed.Flag == crip.FlagPartial {
+		var entries []Entry
+		if len(c.partialLines) >= c.maxPartialLines {
+			entries = make([]Entry, 0, len(c.partialLines))
+			for _, buffered := range c.partialLines {
+				entries = append(entries, buffered)
+			}
+			c.partialLines = make(map[model.Fingerprint]Entry, c.maxPartialLines)
+		}
+		if prev, ok := c.partialLines[fingerprint]; ok {
+			e.Line = prev.Line + e.Line
+		}
+		c.partialLines[fingerprint] = e
+		c.mu.Unlock()
+
+		for _, buffered := range entries {
+			if err := next.Emit(ctx, buffered); err != nil {
+				return err
+			}
+		}
+		return nil // held: e itself isn't emitted this call
+	}
+
+	if prev, ok := c.partialLines[fingerprint]; ok {
+		e.Line = prev.Line + e.Line
+		delete(c.partialLines, fingerprint)
+	}
+	c.mu.Unlock()
+
+	return next.Emit(ctx, e)
+}
+
+func (c *criStage2) Cleanup() {}
+
+type multilineState2 struct {
+	buffer       strings.Builder
+	startLine    Entry
+	currentLines int
+	lastSeen     time.Time
+}
+
+// multilineStage2 is a simplified port of the real multiline stage. Like
+// criStage2 it holds per-stream state across Process calls, but it also
+// implements Stage2WithFlush, since a block can become due with no new
+// entry ever arriving.
+type multilineStage2 struct {
+	regex        *regexp.Regexp
+	maxLines     int
+	maxWaitTime  time.Duration
+	trimNewlines bool
+
+	mu      sync.Mutex
+	streams map[model.Fingerprint]*multilineState2
+}
+
+func newMultilineStage2(regex *regexp.Regexp, maxLines int, maxWaitTime time.Duration, trimNewlines bool) *multilineStage2 {
+	return &multilineStage2{
+		regex:        regex,
+		maxLines:     maxLines,
+		maxWaitTime:  maxWaitTime,
+		trimNewlines: trimNewlines,
+		streams:      make(map[model.Fingerprint]*multilineState2),
+	}
+}
+
+func (m *multilineStage2) Process(ctx context.Context, e Entry, next Emitter) error {
+	fp := e.Labels.Fingerprint()
+
+	m.mu.Lock()
+
+	var (
+		resolved    []Entry
+		state, ok   = m.streams[fp]
+		isFirstLine = m.regex.MatchString(e.Line)
+	)
+
+	if !ok && !isFirstLine {
+		m.mu.Unlock()
+		// never part of a block: pass through
+		return next.Emit(ctx, e)
+	}
+
+	// A new entry arriving for a stream that's already gone stale
+	// resolves the old block now, without waiting for a Flush call.
+	if ok && state.currentLines > 0 && time.Since(state.lastSeen) >= m.maxWaitTime {
+		resolved = append(resolved, m.collapse(state))
+	}
+
+	if !ok {
+		state = &multilineState2{}
+		m.streams[fp] = state
+	} else if isFirstLine && state.currentLines > 0 {
+		// A new block is starting: flush whatever was accumulated so far.
+		resolved = append(resolved, m.collapse(state))
+	}
+
+	if isFirstLine {
+		state.startLine = e
+	}
+
+	line := e.Line
+	if m.trimNewlines {
+		line = strings.TrimRight(line, "\r\n")
+	}
+	if state.buffer.Len() > 0 {
+		state.buffer.WriteByte('\n')
+	}
+	state.buffer.WriteString(line)
+	state.currentLines++
+	state.lastSeen = time.Now()
+
+	if state.currentLines == m.maxLines {
+		resolved = append(resolved, m.collapse(state))
+	}
+
+	m.mu.Unlock()
+
+	for _, r := range resolved {
+		if err := next.Emit(ctx, r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NextDeadline implements Stage2WithFlush.
+func (m *multilineStage2) NextDeadline() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var nearest time.Time
+	for _, state := range m.streams {
+		if state.currentLines == 0 {
+			continue
+		}
+		if dl := state.lastSeen.Add(m.maxWaitTime); nearest.IsZero() || dl.Before(nearest) {
+			nearest = dl
+		}
+	}
+	return nearest
+}
+
+// Flush implements Stage2WithFlush, collapsing every stream past its
+// deadline.
+func (m *multilineStage2) Flush(ctx context.Context, next Emitter) error {
+	m.mu.Lock()
+	now := time.Now()
+	var resolved []Entry
+	for _, state := range m.streams {
+		if state.currentLines == 0 {
+			continue
+		}
+		if state.lastSeen.Add(m.maxWaitTime).After(now) {
+			continue
+		}
+		resolved = append(resolved, m.collapse(state))
+	}
+	m.mu.Unlock()
+
+	for _, e := range resolved {
+		if err := next.Emit(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// collapse emits the accumulated block and resets it. startLine isn't
+// reset, so Labels/Extracted are cloned here to keep a later mutation
+// from leaking into it.
+func (m *multilineStage2) collapse(state *multilineState2) Entry {
+	collapsed := state.startLine
+	collapsed.Labels = state.startLine.Labels.Clone()
+	collapsed.Extracted = maps.Clone(state.startLine.Extracted)
+	collapsed.Line = state.buffer.String()
+
+	state.buffer.Reset()
+	state.currentLines = 0
+	return collapsed
+}
+
+func (m *multilineStage2) Cleanup() {}
+
+// staticLabelsStage2 is the simplest kind of stage. It just processes the
+// current entry and always forwards it to next.
+type staticLabelsStage2 struct {
+	values []string
+}
+
+func newStaticLabelsStage2(values []string) *staticLabelsStage2 {
+	return &staticLabelsStage2{values: values}
+}
+
+func (s *staticLabelsStage2) Process(ctx context.Context, e Entry, next Emitter) error {
+	for i := 0; i < len(s.values); i += 2 {
+		e.Labels[model.LabelName(s.values[i])] = model.LabelValue(s.values[i+1])
+	}
+	return next.Emit(ctx, e)
+}
+
+func (s *staticLabelsStage2) Cleanup() {}
+
+// matchStage2 is a simplified port of matcherStage. Its unique
+// property is sub pipeline when using MatchActionKeep, a matched entry is handed
+// to a Pipeline2 with the same next, so whatever that pipeline
+// emits continues on as if this stage had emitted it directly.
+type matchStage2 struct {
+	match    func(Entry) bool
+	action   string // MatchActionKeep or MatchActionDrop
+	pipeline *Pipeline2
+}
+
+func newMatchStage2(match func(Entry) bool, action string, pipeline *Pipeline2) *matchStage2 {
+	return &matchStage2{match: match, action: action, pipeline: pipeline}
+}
+
+func (m *matchStage2) Process(ctx context.Context, e Entry, next Emitter) error {
+	if !m.match(e) {
+		return next.Emit(ctx, e)
+	}
+
+	switch m.action {
+	case MatchActionDrop:
+		return nil
+	case MatchActionKeep:
+		return m.pipeline.Process(ctx, e, next)
+	default:
+		return next.Emit(ctx, e)
+	}
+}
+
+func (m *matchStage2) Cleanup() {}
+
+// NextDeadline and Flush make matchStage2 itself a Stage2WithFlush by
+// delegating to the nested pipeline. Without this, a Stage2WithFlush
+// nested inside a match block (e.g. multilineStage2) would be invisible
+// to the outer Pipeline2's flush scan, since that scan only looks at its
+// own stages, not into each one's internals.
+func (m *matchStage2) NextDeadline() time.Time {
+	if m.pipeline == nil {
+		return time.Time{}
+	}
+	return m.pipeline.NextDeadline()
+}
+
+func (m *matchStage2) Flush(ctx context.Context, next Emitter) error {
+	if m.pipeline == nil {
+		return nil
+	}
+	return m.pipeline.Flush(ctx, next)
+}

--- a/internal/component/loki/process/stages/pipeline_2_test.go
+++ b/internal/component/loki/process/stages/pipeline_2_test.go
@@ -1,0 +1,91 @@
+package stages
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+)
+
+func TestPipeline2(t *testing.T) {
+	ctx := context.Background()
+
+	var (
+		cri   = newCRIStage2(10)
+		match = newMatchStage2(
+			func(e Entry) bool { return strings.Contains(e.Line, "World") },
+			MatchActionKeep,
+			NewPipeline2([]Stage2{
+				newStaticLabelsStage2([]string{"inner", "true"}),
+			}),
+		)
+		labels = newStaticLabelsStage2([]string{"outer", "test"})
+	)
+
+	pipeline := NewPipeline2([]Stage2{cri, match, labels})
+
+	criLabels := model.LabelSet{"app": "foo"}
+	plainLabels := model.LabelSet{"app": "bar"}
+
+	// Batch in, same as a Consumer boundary would receive: one stream
+	// carrying the CRI partial/full pair, one stream with a plain line.
+	in := loki.NewBatch()
+	in.Add(loki.NewStream(criLabels,
+		push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout P Hello "},
+		push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout F World"},
+	))
+	in.Add(loki.NewStream(plainLabels,
+		push.Entry{Line: "plain line"},
+	))
+
+	out := loki.NewBatch()
+	err := in.ConsumeStreams(func(stream loki.Stream, created int64) error {
+		collect := EmitterFunc(func(_ context.Context, e Entry) error {
+			out.Add(loki.NewStream(e.Labels, e.Entry.Entry))
+			return nil
+		})
+
+		for _, pe := range stream.Entries {
+			entry := Entry{
+				Extracted: map[string]any{},
+				Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, pe),
+			}
+			if err := pipeline.Process(ctx, entry, collect); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The partial line is held by criStage until the full line arrives,
+	// so three input entries produce two output entries.
+	require.Equal(t, 2, out.EntryLen())
+
+	var outStreams []loki.Stream
+	require.NoError(t, out.ConsumeStreams(func(s loki.Stream, _ int64) error {
+		outStreams = append(outStreams, s)
+		return nil
+	}))
+
+	// "Hello " + "World" merged by criStage; the merged line contains
+	// "World" so matchStage2 routed it through the nested pipeline
+	// (picking up inner=true), and every entry picks up outer=test from
+	// the outer stage.
+	require.Equal(t, model.LabelSet{"app": "foo", "inner": "true", "outer": "test"}, outStreams[0].Labels)
+	require.Len(t, outStreams[0].Entries, 1)
+	require.Equal(t, "Hello World", outStreams[0].Entries[0].Line)
+
+	// The plain line never parses as CRI, so criStage forwards it
+	// untouched; it doesn't contain "World", so matchStage2 sends it
+	// straight to next without the nested pipeline -- but it still picks
+	// up outer=test from the outer stage.
+	require.Equal(t, model.LabelSet{"app": "bar", "outer": "test"}, outStreams[1].Labels)
+	require.Len(t, outStreams[1].Entries, 1)
+	require.Equal(t, "plain line", outStreams[1].Entries[0].Line)
+}

--- a/internal/component/loki/process/stages/pipeline_2_test.go
+++ b/internal/component/loki/process/stages/pipeline_2_test.go
@@ -2,8 +2,10 @@ package stages
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/common/model"
@@ -24,16 +26,26 @@ func TestPipeline2(t *testing.T) {
 				newStaticLabelsStage2([]string{"inner", "true"}),
 			}),
 		)
+		multilineMatch = newMatchStage2(
+			func(e Entry) bool { return e.Labels["app"] == "multiline" },
+			MatchActionKeep,
+			NewPipeline2([]Stage2{
+				newMultilineStage2(regexp.MustCompile("^START"), 10, 50*time.Millisecond, true),
+			}),
+		)
 		labels = newStaticLabelsStage2([]string{"outer", "test"})
 	)
 
-	pipeline := NewPipeline2([]Stage2{cri, match, labels})
+	pipeline := NewPipeline2([]Stage2{cri, match, multilineMatch, labels})
 
 	criLabels := model.LabelSet{"app": "foo"}
 	plainLabels := model.LabelSet{"app": "bar"}
+	multilineLabels := model.LabelSet{"app": "multiline"}
 
 	// Batch in, same as a Consumer boundary would receive: one stream
-	// carrying the CRI partial/full pair, one stream with a plain line.
+	// carrying the CRI partial/full pair, one stream with a plain line,
+	// and one stream exercising multilineMatch: a start line, a
+	// continuation, and a second start line that begins a new block.
 	in := loki.NewBatch()
 	in.Add(loki.NewStream(criLabels,
 		push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout P Hello "},
@@ -42,14 +54,18 @@ func TestPipeline2(t *testing.T) {
 	in.Add(loki.NewStream(plainLabels,
 		push.Entry{Line: "plain line"},
 	))
+	in.Add(loki.NewStream(multilineLabels,
+		push.Entry{Line: "START of the line"},
+		push.Entry{Line: "continue"},
+		push.Entry{Line: "START of a new line"},
+	))
 
 	out := loki.NewBatch()
 	err := in.ConsumeStreams(func(stream loki.Stream, created int64) error {
 		collect := EmitterFunc(func(_ context.Context, e Entry) error {
-			out.Add(loki.NewStream(e.Labels, e.Entry.Entry))
+			out.AddEntry(e.Entry)
 			return nil
 		})
-
 		for _, pe := range stream.Entries {
 			entry := Entry{
 				Extracted: map[string]any{},
@@ -63,15 +79,13 @@ func TestPipeline2(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// The partial line is held by criStage until the full line arrives,
-	// so three input entries produce two output entries.
-	require.Equal(t, 2, out.EntryLen())
+	// The partial CRI line is held until its full line arrives, and the
+	// second "START" line is held until it's explicitly flushed below, so
+	// this batch's 6 input entries produce 3 output entries so far.
+	require.Equal(t, 3, out.EntryLen())
 
-	var outStreams []loki.Stream
-	require.NoError(t, out.ConsumeStreams(func(s loki.Stream, _ int64) error {
-		outStreams = append(outStreams, s)
-		return nil
-	}))
+	outStreams := collectStreams(out)
+	require.Len(t, outStreams, 3)
 
 	// "Hello " + "World" merged by criStage; the merged line contains
 	// "World" so matchStage2 routed it through the nested pipeline
@@ -88,4 +102,44 @@ func TestPipeline2(t *testing.T) {
 	require.Equal(t, model.LabelSet{"app": "bar", "outer": "test"}, outStreams[1].Labels)
 	require.Len(t, outStreams[1].Entries, 1)
 	require.Equal(t, "plain line", outStreams[1].Entries[0].Line)
+
+	// "START of the line" + "continue" were merged by multilineStage2,
+	// nested inside multilineMatch, and flushed synchronously the moment
+	// the second "START" line arrived and started a new block. That
+	// second block sat held until the Flush call above emitted it as its
+	// own entry, joining the same stream.
+	require.Equal(t, model.LabelSet{"app": "multiline", "outer": "test"}, outStreams[2].Labels)
+	require.Len(t, outStreams[2].Entries, 1)
+	require.Equal(t, "START of the line\ncontinue", outStreams[2].Entries[0].Line)
+
+	// Nothing is due yet: the second "START" block was just created.
+	require.True(t, pipeline.NextDeadline().After(time.Now()))
+
+	// Once maxWaitTime has passed, the held block becomes due.
+	time.Sleep(100 * time.Millisecond)
+
+	// asyncBatch are entries collected by a "async" flush.
+	asyncBatch := loki.NewBatch()
+	collect := EmitterFunc(func(ctx context.Context, e Entry) error {
+		asyncBatch.AddEntry(e.Entry)
+		return nil
+	})
+
+	require.NoError(t, pipeline.Flush(ctx, collect))
+	require.Equal(t, 1, asyncBatch.EntryLen())
+	require.Equal(t, 1, asyncBatch.StreamLen())
+	asyncStreams := collectStreams(asyncBatch)
+
+	require.Equal(t, model.LabelSet{"app": "multiline", "outer": "test"}, asyncStreams[0].Labels)
+	require.Equal(t, "START of a new line", asyncStreams[0].Entries[0].Line)
+
+}
+
+func collectStreams(b loki.Batch) []loki.Stream {
+	out := make([]loki.Stream, 0, b.StreamLen())
+	b.ConsumeStreams(func(stream loki.Stream, _ int64) error {
+		out = append(out, stream)
+		return nil
+	})
+	return out
 }

--- a/internal/component/loki/process/stages/pipeline_3.go
+++ b/internal/component/loki/process/stages/pipeline_3.go
@@ -426,6 +426,12 @@ func (m *matchStage3) Process(ctx context.Context, entries []Entry) ([]Entry, er
 	case MatchActionDrop:
 		return unmatched, nil
 	case MatchActionKeep:
+		if len(matched) == 0 {
+			// Nothing matched: skip the nested pipeline entirely, so a
+			// stateful stage nested inside it (e.g. multilineStage3)
+			// doesn't pay for its lock when there's nothing for it to do.
+			return unmatched, nil
+		}
 		kept, err := m.pipeline.Process(ctx, matched)
 		if err != nil {
 			return nil, err

--- a/internal/component/loki/process/stages/pipeline_3.go
+++ b/internal/component/loki/process/stages/pipeline_3.go
@@ -1,0 +1,455 @@
+package stages
+
+import (
+	"context"
+	"maps"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+	crip "github.com/grafana/alloy/internal/component/loki/process/stages/cri"
+)
+
+// Stage3 processes a whole slice of entries at once and returns whatever
+// should continue on: fewer entries to drop some, more to fan out, the
+// same entries mutated in place for a plain transform. There is no next
+// parameter -- a stage just returns what comes out, and Pipeline3 feeds
+// that into the next stage itself.
+type Stage3 interface {
+	Process(ctx context.Context, entries []Entry) ([]Entry, error)
+	Cleanup()
+}
+
+// Stage3WithFlush is a Stage3 that can also produce entries independent
+// of any Process call, on its own schedule (e.g. an idle timeout).
+type Stage3WithFlush interface {
+	Stage3
+	// NextDeadline reports when this stage next has something ready to
+	// flush, or the zero Time if nothing is pending.
+	NextDeadline() time.Time
+	// Flush returns whatever is due.
+	Flush(ctx context.Context) ([]Entry, error)
+}
+
+type AsyncStage interface {
+	Stage3
+
+	SetWaker(chan struct{})
+}
+
+// flusher3Entry pairs a Stage3WithFlush with its position in stages, so a
+// flush can be routed through everything after it.
+type flusher3Entry struct {
+	idx int
+	f   Stage3WithFlush
+}
+
+// Pipeline3 chains Stage3 stages together with direct function calls.
+type Pipeline3 struct {
+	stages   []Stage3
+	flushers []flusher3Entry
+}
+
+// NewPipeline3 builds a Pipeline3 from stages, in order.
+func NewPipeline3(stages []Stage3) *Pipeline3 {
+	p := &Pipeline3{stages: stages}
+	for i, s := range stages {
+		if f, ok := s.(Stage3WithFlush); ok {
+			p.flushers = append(p.flushers, flusher3Entry{idx: i, f: f})
+		}
+	}
+	return p
+}
+
+func (p *Pipeline3) ProcessEntry(ctx context.Context, entry loki.Entry) ([]Entry, error) {
+	return p.processFrom(ctx, 0, []Entry{
+		{
+			Extracted: make(map[string]any, len(entry.Labels)),
+			Entry:     entry,
+		},
+	})
+}
+
+func (p *Pipeline3) ProcessBatch(ctx context.Context, batch loki.Batch) (loki.Batch, error) {
+	out := loki.NewBatchWithCreatedUnixMicro(batch.Created())
+
+	var entries []Entry
+	err := batch.ConsumeStreams(func(stream loki.Stream, _ int64) error {
+		// Ensure we have enough capacity.
+		entries = slices.Grow(entries, len(stream.Entries))
+		// Reset lenght to ensure we don't reuse from previous runs.
+		entries = entries[:0]
+
+		for _, e := range stream.Entries {
+			entries = append(entries, Entry{
+				Extracted: make(map[string]any, len(stream.Labels)),
+				Entry: loki.Entry{
+					Labels: stream.Labels.Clone(),
+					Entry:  e,
+				},
+			})
+		}
+
+		var err error
+		entries, err = p.Process(ctx, entries)
+		if err != nil {
+			return err
+		}
+
+		for _, e := range entries {
+			out.AddEntry(e.Labels, e.Entry.Entry)
+		}
+
+		return nil
+	})
+
+	return out, err
+}
+
+// Process runs entries through every stage in order.
+func (p *Pipeline3) Process(ctx context.Context, entries []Entry) ([]Entry, error) {
+	return p.processFrom(ctx, 0, entries)
+}
+
+// processFrom runs entries through stages[from:] in order.
+func (p *Pipeline3) processFrom(ctx context.Context, from int, entries []Entry) ([]Entry, error) {
+	var err error
+	for _, stage := range p.stages[from:] {
+		entries, err = stage.Process(ctx, entries)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return entries, nil
+}
+
+// NextDeadline reports the earliest deadline across every stage that
+// implements Stage3WithFlush, or the zero Time if nothing is pending
+// anywhere in the pipeline.
+func (p *Pipeline3) NextDeadline() time.Time {
+	var nearest time.Time
+	for _, fl := range p.flushers {
+		if dl := fl.f.NextDeadline(); !dl.IsZero() && (nearest.IsZero() || dl.Before(nearest)) {
+			nearest = dl
+		}
+	}
+	return nearest
+}
+
+// Flush flushes whichever Stage3WithFlush stages have a deadline that has
+// already passed, running whatever each one returns through the rest of
+// the pipeline.
+// FIXME(maybe iterator)
+func (p *Pipeline3) Flush(ctx context.Context) ([]Entry, error) {
+	now := time.Now()
+	var out []Entry
+	for _, fl := range p.flushers {
+		dl := fl.f.NextDeadline()
+		if dl.IsZero() || dl.After(now) {
+			continue
+		}
+		flushed, err := fl.f.Flush(ctx)
+		if err != nil {
+			return nil, err
+		}
+		rest, err := p.processFrom(ctx, fl.idx+1, flushed)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rest...)
+	}
+	return out, nil
+}
+
+// criStage3 is the slice-based port of criStage2: partial lines are held
+// across Process calls, keyed by stream fingerprint, and a Process call
+// can return fewer, the same, or more entries than it was given.
+type criStage3 struct {
+	maxPartialLines int
+
+	mu           sync.Mutex
+	partialLines map[model.Fingerprint]Entry
+}
+
+func newCRIStage3(maxPartialLines int) *criStage3 {
+	return &criStage3{
+		maxPartialLines: maxPartialLines,
+		partialLines:    make(map[model.Fingerprint]Entry, maxPartialLines),
+	}
+}
+
+func (c *criStage3) Process(_ context.Context, entries []Entry) ([]Entry, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		parsed, ok := crip.ParseCRI(e.Line)
+		if !ok {
+			out = append(out, e)
+			continue
+		}
+		e.Line = parsed.Content
+
+		fingerprint := e.Labels.Fingerprint()
+
+		if parsed.Flag == crip.FlagPartial {
+			if len(c.partialLines) >= c.maxPartialLines {
+				// Held state has grown too large: flush everything now,
+				// then start over.
+				for _, buffered := range c.partialLines {
+					out = append(out, buffered)
+				}
+				c.partialLines = make(map[model.Fingerprint]Entry, c.maxPartialLines)
+			}
+			if prev, ok := c.partialLines[fingerprint]; ok {
+				e.Line = prev.Line + e.Line
+			}
+			c.partialLines[fingerprint] = e
+			continue // held: not part of this call's output
+		}
+
+		if prev, ok := c.partialLines[fingerprint]; ok {
+			e.Line = prev.Line + e.Line
+			delete(c.partialLines, fingerprint)
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func (c *criStage3) Cleanup() {}
+
+// multiline3State is per-stream state for multilineStage3.
+type multiline3State struct {
+	buffer       strings.Builder
+	startLine    Entry
+	currentLines int
+	lastSeen     time.Time
+}
+
+// multilineStage3 is the slice-based port of multilineStage2: like
+// criStage3 it holds per-stream state across Process calls, and it also
+// implements Stage3WithFlush, since a block can become due with no new
+// entry ever arriving.
+type multilineStage3 struct {
+	regex        *regexp.Regexp
+	maxLines     int
+	maxWaitTime  time.Duration
+	trimNewlines bool
+
+	mu      sync.Mutex
+	streams map[model.Fingerprint]*multiline3State
+}
+
+func newMultilineStage3(regex *regexp.Regexp, maxLines int, maxWaitTime time.Duration, trimNewlines bool) *multilineStage3 {
+	return &multilineStage3{
+		regex:        regex,
+		maxLines:     maxLines,
+		maxWaitTime:  maxWaitTime,
+		trimNewlines: trimNewlines,
+		streams:      make(map[model.Fingerprint]*multiline3State),
+	}
+}
+
+func (m *multilineStage3) Process(_ context.Context, entries []Entry) ([]Entry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	out := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, m.processEntry(e)...)
+	}
+	return out, nil
+}
+
+// processEntry is the same logic multilineStage2.Process has, just
+// returning the resolved entries instead of emitting them. Callers must
+// hold m.mu.
+func (m *multilineStage3) processEntry(e Entry) []Entry {
+	fp := e.Labels.Fingerprint()
+
+	var (
+		resolved    []Entry
+		state, ok   = m.streams[fp]
+		isFirstLine = m.regex.MatchString(e.Line)
+	)
+
+	if !ok && !isFirstLine {
+		return []Entry{e} // never part of a block: pass through
+	}
+
+	// A new entry arriving for a stream that's already gone stale
+	// resolves the old block now, without waiting for a Flush call.
+	if ok && state.currentLines > 0 && time.Since(state.lastSeen) >= m.maxWaitTime {
+		resolved = append(resolved, m.collapse(state))
+	}
+
+	if !ok {
+		state = &multiline3State{}
+		m.streams[fp] = state
+	} else if isFirstLine && state.currentLines > 0 {
+		// A new block is starting: flush whatever was accumulated so far.
+		resolved = append(resolved, m.collapse(state))
+	}
+
+	if isFirstLine {
+		state.startLine = e
+	}
+
+	line := e.Line
+	if m.trimNewlines {
+		line = strings.TrimRight(line, "\r\n")
+	}
+	if state.buffer.Len() > 0 {
+		state.buffer.WriteByte('\n')
+	}
+	state.buffer.WriteString(line)
+	state.currentLines++
+	state.lastSeen = time.Now()
+
+	if state.currentLines == m.maxLines {
+		resolved = append(resolved, m.collapse(state))
+	}
+
+	return resolved
+}
+
+// NextDeadline implements Stage3WithFlush.
+func (m *multilineStage3) NextDeadline() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var nearest time.Time
+	for _, state := range m.streams {
+		if state.currentLines == 0 {
+			continue
+		}
+		if dl := state.lastSeen.Add(m.maxWaitTime); nearest.IsZero() || dl.Before(nearest) {
+			nearest = dl
+		}
+	}
+	return nearest
+}
+
+// Flush implements Stage3WithFlush, collapsing every stream past its
+// deadline.
+func (m *multilineStage3) Flush(_ context.Context) ([]Entry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	var resolved []Entry
+	for _, state := range m.streams {
+		if state.currentLines == 0 {
+			continue
+		}
+		if state.lastSeen.Add(m.maxWaitTime).After(now) {
+			continue
+		}
+		resolved = append(resolved, m.collapse(state))
+	}
+	return resolved, nil
+}
+
+// collapse emits the accumulated block and resets it. startLine isn't
+// reset, so Labels/Extracted are cloned here to keep a later mutation
+// from leaking into it.
+func (m *multilineStage3) collapse(state *multiline3State) Entry {
+	collapsed := state.startLine
+	collapsed.Labels = state.startLine.Labels.Clone()
+	collapsed.Extracted = maps.Clone(state.startLine.Extracted)
+	collapsed.Line = state.buffer.String()
+
+	state.buffer.Reset()
+	state.currentLines = 0
+	return collapsed
+}
+
+func (m *multilineStage3) Cleanup() {}
+
+// staticLabelsStage3 is the simplest kind of stage: it mutates every
+// entry it's given in place and returns the same slice, unchanged in
+// length.
+type staticLabelsStage3 struct {
+	values []string
+}
+
+func newStaticLabelsStage3(values []string) *staticLabelsStage3 {
+	return &staticLabelsStage3{values: values}
+}
+
+func (s *staticLabelsStage3) Process(_ context.Context, entries []Entry) ([]Entry, error) {
+	for i := range entries {
+		for j := 0; j < len(s.values); j += 2 {
+			entries[i].Labels[model.LabelName(s.values[j])] = model.LabelValue(s.values[j+1])
+		}
+	}
+	return entries, nil
+}
+
+func (s *staticLabelsStage3) Cleanup() {}
+
+// matchStage3 is the slice-based port of matchStage2. Instead of forwarding
+// the same next into a nested pipeline, it partitions entries into
+// matched and unmatched, runs the nested pipeline on just the matched
+// ones, and appends the result to the unmatched ones. Relative order
+// between matched and unmatched entries isn't preserved -- the nested
+// pipeline can change how many matched entries there are, so there's no
+// single "right" position to splice them back into.
+type matchStage3 struct {
+	match    func(Entry) bool
+	action   string // MatchActionKeep or MatchActionDrop
+	pipeline *Pipeline3
+}
+
+func newMatchStage3(match func(Entry) bool, action string, pipeline *Pipeline3) *matchStage3 {
+	return &matchStage3{match: match, action: action, pipeline: pipeline}
+}
+
+func (m *matchStage3) Process(ctx context.Context, entries []Entry) ([]Entry, error) {
+	var unmatched, matched []Entry
+	for _, e := range entries {
+		if m.match(e) {
+			matched = append(matched, e)
+		} else {
+			unmatched = append(unmatched, e)
+		}
+	}
+
+	switch m.action {
+	case MatchActionDrop:
+		return unmatched, nil
+	case MatchActionKeep:
+		kept, err := m.pipeline.Process(ctx, matched)
+		if err != nil {
+			return nil, err
+		}
+		return append(unmatched, kept...), nil
+	default:
+		return entries, nil
+	}
+}
+
+func (m *matchStage3) Cleanup() {}
+
+// NextDeadline and Flush make matchStage3 itself a Stage3WithFlush by
+// delegating to the nested pipeline, the same way matchStage2 does.
+func (m *matchStage3) NextDeadline() time.Time {
+	if m.pipeline == nil {
+		return time.Time{}
+	}
+	return m.pipeline.NextDeadline()
+}
+
+func (m *matchStage3) Flush(ctx context.Context) ([]Entry, error) {
+	if m.pipeline == nil {
+		return nil, nil
+	}
+	return m.pipeline.Flush(ctx)
+}

--- a/internal/component/loki/process/stages/pipeline_3_test.go
+++ b/internal/component/loki/process/stages/pipeline_3_test.go
@@ -14,29 +14,29 @@ import (
 	"github.com/grafana/alloy/internal/component/common/loki"
 )
 
-func TestPipeline2(t *testing.T) {
+func TestPipeline3(t *testing.T) {
 	ctx := context.Background()
 
 	var (
-		cri   = newCRIStage2(10)
-		match = newMatchStage2(
+		cri   = newCRIStage3(10)
+		match = newMatchStage3(
 			func(e Entry) bool { return strings.Contains(e.Line, "World") },
 			MatchActionKeep,
-			NewPipeline2([]Stage2{
-				newStaticLabelsStage2([]string{"inner", "true"}),
+			NewPipeline3([]Stage3{
+				newStaticLabelsStage3([]string{"inner", "true"}),
 			}),
 		)
-		multilineMatch = newMatchStage2(
+		multilineMatch = newMatchStage3(
 			func(e Entry) bool { return e.Labels["app"] == "multiline" },
 			MatchActionKeep,
-			NewPipeline2([]Stage2{
-				newMultilineStage2(regexp.MustCompile("^START"), 10, 50*time.Millisecond, true),
+			NewPipeline3([]Stage3{
+				newMultilineStage3(regexp.MustCompile("^START"), 10, 50*time.Millisecond, true),
 			}),
 		)
-		labels = newStaticLabelsStage2([]string{"outer", "test"})
+		labels = newStaticLabelsStage3([]string{"outer", "test"})
 	)
 
-	pipeline := NewPipeline2([]Stage2{cri, match, multilineMatch, labels})
+	pipeline := NewPipeline3([]Stage3{cri, match, multilineMatch, labels})
 
 	criLabels := model.LabelSet{"app": "foo"}
 	plainLabels := model.LabelSet{"app": "bar"}
@@ -61,7 +61,6 @@ func TestPipeline2(t *testing.T) {
 	))
 
 	out, err := pipeline.ProcessBatch(ctx, in)
-	require.NoError(t, err)
 
 	// The partial CRI line is held until its full line arrives, and the
 	// second "START" line is held until it's explicitly flushed below, so
@@ -124,14 +123,13 @@ func TestPipeline2(t *testing.T) {
 	asyncStreams := collectStreams(asyncBatch)
 	require.Equal(t, model.LabelSet{"app": "multiline", "outer": "test"}, asyncStreams[0].Labels)
 	require.Equal(t, "START of a new line", asyncStreams[0].Entries[0].Line)
-
 }
 
-func collectStreams(b loki.Batch) []loki.Stream {
-	out := make([]loki.Stream, 0, b.StreamLen())
-	b.ConsumeStreams(func(stream loki.Stream, _ int64) error {
-		out = append(out, stream)
-		return nil
-	})
-	return out
+func findStream(streams []loki.Stream, labels model.LabelSet) (loki.Stream, bool) {
+	for _, s := range streams {
+		if s.Labels.Equal(labels) {
+			return s, true
+		}
+	}
+	return loki.Stream{}, false
 }

--- a/internal/component/loki/process/stages/pipeline_4.go
+++ b/internal/component/loki/process/stages/pipeline_4.go
@@ -1,0 +1,442 @@
+package stages
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+	crip "github.com/grafana/alloy/internal/component/loki/process/stages/cri"
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
+)
+
+type Emitter2 func(ctx context.Context, entries []Entry) error
+
+type Stage4 interface {
+	Process(ctx context.Context, entries []Entry) error
+	SetNext(next Emitter2)
+	Cleanup()
+}
+
+var _ Stage4 = (*Pipeline4)(nil)
+
+type Pipeline4 struct {
+	stages []Stage4
+}
+
+func NewPipeline4(stages []Stage4) *Pipeline4 {
+	return &Pipeline4{stages: stages}
+}
+
+func (p *Pipeline4) ProcessBatch(ctx context.Context, batch loki.Batch) error {
+	entries := make([]Entry, 0, batch.EntryLen())
+	_ = batch.ConsumeStreams(func(stream loki.Stream, created int64) error {
+		for _, e := range stream.Entries {
+			entries = append(entries, Entry{
+				Extracted: make(map[string]any, len(stream.Labels)),
+
+				Entry: loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e),
+			})
+		}
+		return nil
+	})
+
+	return p.stages[0].Process(ctx, entries)
+}
+
+func (p *Pipeline4) ProcessEntry(ctx context.Context, entry loki.Entry) error {
+	return p.stages[0].Process(ctx, []Entry{
+		{
+			Extracted: make(map[string]any, len(entry.Labels)),
+			Entry:     entry,
+		},
+	})
+}
+
+func (p *Pipeline4) Process(ctx context.Context, entries []Entry) error {
+	return p.stages[0].Process(ctx, entries)
+}
+
+func (p *Pipeline4) SetNext(next Emitter2) {
+	for i, s := range slices.Backward(p.stages) {
+		if i == len(p.stages)-1 {
+			s.SetNext(next)
+			continue
+		}
+
+		s.SetNext(p.stages[i+1].Process)
+	}
+}
+
+func (p *Pipeline4) Cleanup() {}
+
+var (
+	_ Stage4 = (*staticLabelsStage4)(nil)
+)
+
+func newStaticLabelsStage4(values []string) *staticLabelsStage4 {
+	return &staticLabelsStage4{values: values}
+}
+
+// staticLabelsStage4 is the simplest kind of stage. It just processes the
+// current entry and always forwards it to next.
+type staticLabelsStage4 struct {
+	next   Emitter2
+	values []string
+}
+
+// Process implements Stage4.
+func (s *staticLabelsStage4) Process(ctx context.Context, entries []Entry) error {
+	for i := range entries {
+		for j := 0; j < len(s.values); j += 2 {
+			entries[i].Labels[model.LabelName(s.values[j])] = model.LabelValue(s.values[j+1])
+		}
+	}
+
+	return s.next(ctx, entries)
+}
+
+// SetNext implements Stage4.
+func (s *staticLabelsStage4) SetNext(next Emitter2) {
+	s.next = next
+}
+
+func (s *staticLabelsStage4) Cleanup() {}
+
+var _ Stage4 = (*criStage4)(nil)
+
+func newCRIStage4(maxPartialLines int) *criStage4 {
+	return &criStage4{
+		maxPartialLines: maxPartialLines,
+		partialLines:    make(map[model.Fingerprint]Entry, maxPartialLines),
+	}
+}
+
+type criStage4 struct {
+	next            Emitter2
+	maxPartialLines int
+
+	mu           sync.Mutex
+	partialLines map[model.Fingerprint]Entry
+}
+
+func (c *criStage4) Process(ctx context.Context, entries []Entry) error {
+	c.mu.Lock()
+
+	out := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		parsed, ok := crip.ParseCRI(e.Line)
+		if !ok {
+			out = append(out, e)
+			continue
+		}
+		e.Line = parsed.Content
+
+		fingerprint := e.Labels.Fingerprint()
+
+		if parsed.Flag == crip.FlagPartial {
+			if len(c.partialLines) >= c.maxPartialLines {
+				// Held state has grown too large: flush everything now,
+				// then start over.
+				for _, buffered := range c.partialLines {
+					out = append(out, buffered)
+				}
+				c.partialLines = make(map[model.Fingerprint]Entry, c.maxPartialLines)
+			}
+			if prev, ok := c.partialLines[fingerprint]; ok {
+				e.Line = prev.Line + e.Line
+			}
+			c.partialLines[fingerprint] = e
+			continue // held: not part of this call's output
+		}
+
+		if prev, ok := c.partialLines[fingerprint]; ok {
+			e.Line = prev.Line + e.Line
+			delete(c.partialLines, fingerprint)
+		}
+		out = append(out, e)
+	}
+
+	c.mu.Unlock()
+
+	return c.next(ctx, out)
+
+}
+
+func (c *criStage4) SetNext(next Emitter2) {
+	c.next = next
+}
+
+func (c *criStage4) Cleanup() {}
+
+func newMatchStage4(match func(Entry) bool, action string, stages []Stage4) Stage4 {
+	switch action {
+	case MatchActionKeep:
+		return newMatchStageKeep4(match, stages)
+	default:
+		return newMatchStageDrop4(match)
+	}
+}
+
+var _ Stage4 = (*matchStageKeep4)(nil)
+
+func newMatchStageKeep4(match func(Entry) bool, stages []Stage4) *matchStageKeep4 {
+	return &matchStageKeep4{
+		match:    match,
+		pipeline: NewPipeline4(stages),
+	}
+}
+
+type matchStageKeep4 struct {
+	next  Emitter2
+	match func(Entry) bool
+
+	pipeline *Pipeline4
+}
+
+func (m *matchStageKeep4) Process(ctx context.Context, entries []Entry) error {
+	var matched, unmatched []Entry
+
+	for i := range entries {
+		if m.match(entries[i]) {
+			matched = append(matched, entries[i])
+			continue
+		}
+		unmatched = append(unmatched, entries[i])
+	}
+	if len(unmatched) > 0 {
+		if err := m.next(ctx, unmatched); err != nil {
+			return err
+		}
+	}
+
+	if len(matched) > 0 {
+		return m.pipeline.Process(ctx, matched)
+	}
+
+	return nil
+}
+
+func (m *matchStageKeep4) SetNext(next Emitter2) {
+	m.next = next
+	m.pipeline.SetNext(next)
+}
+
+func (m *matchStageKeep4) Cleanup() {
+	m.pipeline.Cleanup()
+}
+
+var _ Stage4 = (*matchStageDrop4)(nil)
+
+func newMatchStageDrop4(match func(Entry) bool) *matchStageDrop4 {
+	return &matchStageDrop4{match: match}
+}
+
+type matchStageDrop4 struct {
+	next  Emitter2
+	match func(Entry) bool
+}
+
+// Process implements Stage4.
+func (m *matchStageDrop4) Process(ctx context.Context, entries []Entry) error {
+	var dst int
+	for _, e := range entries {
+		if m.match(e) {
+			entries[dst] = e
+			dst++
+			continue
+		}
+	}
+
+	return m.next(ctx, entries[:dst])
+}
+
+// SetNext implements Stage4.
+func (m *matchStageDrop4) SetNext(next Emitter2) {
+	m.next = next
+}
+
+func (m *matchStageDrop4) Cleanup() {}
+
+var _ Stage4 = (*multilineStage4)(nil)
+
+func newMultilineStage4(cfg MultilineConfig) (*multilineStage4, error) {
+	regex, err := validateMultilineConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.MaxLines < 2 {
+		panic("useless")
+	}
+
+	m := &multilineStage4{
+		cfg:     cfg,
+		regex:   regex,
+		streams: make(map[model.Fingerprint]*multilineState),
+		stop:    make(chan struct{}),
+	}
+
+	// FIXME(kalleep): Start and Stop?
+	m.wg.Go(m.flushLoop)
+	return m, nil
+}
+
+type multilineStage4 struct {
+	next  Emitter2
+	cfg   MultilineConfig
+	regex *regexp.Regexp
+
+	mu      sync.Mutex
+	streams map[model.Fingerprint]*multilineState
+
+	stop chan struct{}
+	once sync.Once
+	wg   sync.WaitGroup
+}
+
+// Process implements Stage4.
+func (m *multilineStage4) Process(ctx context.Context, entries []Entry) error {
+	m.mu.Lock()
+	var dst int
+	for i := range entries {
+		key := entries[i].Labels.Fingerprint()
+		if flushed, ok := m.processEntry(key, entries[i]); ok {
+			entries[dst] = flushed
+			dst++
+		}
+	}
+	m.mu.Unlock()
+
+	if dst == 0 {
+		return nil
+	}
+	return m.next(ctx, entries[:dst])
+}
+
+func (m *multilineStage4) processEntry(key model.Fingerprint, e Entry) (Entry, bool) {
+	state, hasState := m.streams[key]
+
+	isFirstLine := m.regex.MatchString(e.Line)
+	if !hasState {
+		if !isFirstLine {
+			return e, true
+		}
+		state = &multilineState{buffer: new(bytes.Buffer)}
+		m.streams[key] = state
+	}
+
+	var (
+		flushed Entry
+		ok      bool
+	)
+	if isFirstLine && state.currentLines > 0 {
+		flushed, ok = m.flushState(state), true
+	}
+	if isFirstLine {
+		state.startLineEntry = e
+	}
+
+	if state.buffer.Len() > 0 {
+		state.buffer.WriteRune('\n')
+	}
+	line := e.Line
+	if m.cfg.TrimNewlines {
+		line = strings.TrimRight(line, "\r\n")
+	}
+	state.buffer.WriteString(line)
+	state.currentLines++
+	state.lastSeen = time.Now()
+
+	// Safe to overwrite flushed/ok here without checking ok first: if the
+	// new-start-line flush above fired, it reset currentLines to 0, so this
+	// entry can bring it to at most 1 -- which can only equal MaxLines if
+	// MaxLines were 1, ruled out by the MaxLines >= 2 check in
+	// newMultilineStage4. So the two flushes can never both fire for the
+	// same entry.
+	if state.currentLines == m.cfg.MaxLines {
+		flushed, ok = m.flushState(state), true
+	}
+
+	return flushed, ok
+}
+
+// flushState mirrors multilineStage.flushState. Must be called with mu held.
+func (m *multilineStage4) flushState(s *multilineState) Entry {
+	collapsed := Entry{
+		Extracted: maps.Clone(s.startLineEntry.Extracted),
+		Entry: loki.NewEntryWithCreatedUnixMicro(s.startLineEntry.Entry.Labels.Clone(), s.startLineEntry.Created(), push.Entry{
+			Timestamp:          s.startLineEntry.Entry.Entry.Timestamp,
+			Line:               s.buffer.String(),
+			StructuredMetadata: slices.Clone(s.startLineEntry.Entry.Entry.StructuredMetadata),
+		}),
+	}
+
+	s.buffer.Reset()
+	s.currentLines = 0
+
+	return collapsed
+}
+
+// SetNext implements Stage4.
+func (m *multilineStage4) SetNext(next Emitter2) {
+	m.next = next
+}
+
+func (m *multilineStage4) Cleanup() {
+	m.once.Do(func() { close(m.stop) })
+	m.wg.Wait()
+
+	m.mu.Lock()
+	out := make([]Entry, 0, len(m.streams))
+	for _, state := range m.streams {
+		if state.currentLines > 0 {
+			out = append(out, m.flushState(state))
+		}
+	}
+	m.streams = nil
+	m.mu.Unlock()
+
+	if len(out) > 0 && m.next != nil {
+		_ = m.next(context.Background(), out)
+	}
+}
+
+func (m *multilineStage4) flushLoop() {
+	ticker := time.NewTicker(m.cfg.MaxWaitTime)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.stop:
+			return
+		case <-ticker.C:
+			entries := m.expired()
+			if len(entries) > 0 {
+				_ = m.next(context.Background(), entries)
+			}
+		}
+	}
+}
+
+func (m *multilineStage4) expired() []Entry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	var out []Entry
+	for key, state := range m.streams {
+		if !state.lastSeen.Add(m.cfg.MaxWaitTime).After(now) {
+			if state.currentLines > 0 {
+				out = append(out, m.flushState(state))
+			}
+			delete(m.streams, key)
+		}
+	}
+	return out
+}

--- a/internal/component/loki/process/stages/pipeline_4_test.go
+++ b/internal/component/loki/process/stages/pipeline_4_test.go
@@ -1,0 +1,145 @@
+package stages
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+)
+
+type entrySink4 struct {
+	mu      sync.Mutex
+	calls   int
+	entries []Entry
+}
+
+func (s *entrySink4) emit(_ context.Context, entries []Entry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.entries = append(s.entries, entries...)
+	return nil
+}
+
+func (s *entrySink4) snapshot() (int, []Entry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Entry, len(s.entries))
+	copy(out, s.entries)
+	return s.calls, out
+}
+
+func TestPipeline4(t *testing.T) {
+	ctx := context.Background()
+
+	ml, err := newMultilineStage4(MultilineConfig{
+		Expression:   "^START",
+		MaxLines:     10,
+		MaxWaitTime:  50 * time.Millisecond,
+		TrimNewlines: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(ml.Cleanup)
+
+	var (
+		cri   = newCRIStage4(10)
+		match = newMatchStage4(
+			func(e Entry) bool { return strings.Contains(e.Line, "World") },
+			MatchActionKeep,
+			[]Stage4{newStaticLabelsStage4([]string{"inner", "true"})},
+		)
+		multilineMatch = newMatchStage4(
+			func(e Entry) bool { return e.Labels["app"] == "multiline" },
+			MatchActionKeep,
+			[]Stage4{ml},
+		)
+		labels = newStaticLabelsStage4([]string{"outer", "test"})
+	)
+
+	pipeline := NewPipeline4([]Stage4{cri, match, multilineMatch, labels})
+
+	sink := &entrySink4{}
+	pipeline.SetNext(sink.emit)
+
+	criLabels := model.LabelSet{"app": "foo"}
+	plainLabels := model.LabelSet{"app": "bar"}
+	multilineLabels := model.LabelSet{"app": "multiline"}
+
+	// Same input as TestPipeline2/TestPipeline3.
+	in := loki.NewBatch()
+	in.Add(loki.NewStream(criLabels,
+		push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout P Hello "},
+		push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout F World"},
+	))
+	in.Add(loki.NewStream(plainLabels,
+		push.Entry{Line: "plain line"},
+	))
+	in.Add(loki.NewStream(multilineLabels,
+		push.Entry{Line: "START of the line"},
+		push.Entry{Line: "continue"},
+		push.Entry{Line: "START of a new line"},
+	))
+
+	err = pipeline.ProcessBatch(ctx, in)
+	require.NoError(t, err)
+
+	calls, entries := sink.snapshot()
+	require.Equal(t, 3, calls)
+
+	// The partial CRI line is held until its full line arrives, and the
+	// second "START" line is held until the flush loop picks it up
+	// asynchronously below, so this batch's 6 input entries produce 3
+	// entries so far.
+	require.Len(t, entries, 3)
+
+	// "Hello " + "World" merged by criStage4; the merged line contains
+	// "World" so match routed it through its nested pipeline (picking up
+	// inner=true), and it picks up outer=test from the outer stage.
+	foo, ok := findEntry(entries, model.LabelSet{"app": "foo", "inner": "true", "outer": "test"})
+	require.True(t, ok)
+	require.Equal(t, "Hello World", foo.Line)
+
+	// The plain line never parses as CRI, so criStage4 forwards it
+	// untouched; it doesn't contain "World", so match leaves it unmatched
+	// -- but it still picks up outer=test from the outer stage.
+	bar, ok := findEntry(entries, model.LabelSet{"app": "bar", "outer": "test"})
+	require.True(t, ok)
+	require.Equal(t, "plain line", bar.Line)
+
+	// "START of the line" + "continue" were merged by the multilineStage4
+	// nested inside multilineMatch, flushed synchronously the moment the
+	// second "START" line arrived and started a new block.
+	block, ok := findEntry(entries, model.LabelSet{"app": "multiline", "outer": "test"})
+	require.True(t, ok)
+	require.Equal(t, "START of the line\ncontinue", block.Line)
+
+	// The second "START" block is still held. Unlike Pipeline2/Pipeline3,
+	// there's no NextDeadline/Flush to poll or call explicitly: the flush
+	// loop ticks on its own every MaxWaitTime and calls next directly once
+	// the block goes idle.
+	require.Eventually(t, func() bool {
+		_, entries := sink.snapshot()
+		return len(entries) == 4
+	}, time.Second, 10*time.Millisecond)
+
+	_, entries = sink.snapshot()
+	last := entries[3]
+	require.Equal(t, model.LabelSet{"app": "multiline", "outer": "test"}, last.Labels)
+	require.Equal(t, "START of a new line", last.Line)
+}
+
+func findEntry(entries []Entry, labels model.LabelSet) (Entry, bool) {
+	for _, e := range entries {
+		if e.Labels.Equal(labels) {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}

--- a/internal/component/loki/process/stages/pipeline_bench_test.go
+++ b/internal/component/loki/process/stages/pipeline_bench_test.go
@@ -14,45 +14,86 @@ import (
 	"github.com/grafana/alloy/internal/component/common/loki"
 )
 
-// Shape shared by both benchmarks: mostly plain lines that need none of the
-// stateful stages, plus a minority of CRI and multiline streams -- so the
-// "does a stateful stage always lock, even when nothing in the batch needs
-// it" question from notes.md is actually exercised, not just the happy
-// path where every entry needs special handling.
+// Shape shared by every benchmark: mostly plain streams that need none of
+// the stateful stages, plus a minority of CRI and multiline streams -- so
+// the "does a stateful stage always lock, even when nothing in the batch
+// needs it" question from notes.md is actually exercised, not just the
+// happy path where every entry needs special handling.
 const (
-	benchPlainStreams     = 80
+	benchPlainStreams     = 10
 	benchCRIStreams       = 10
 	benchMultilineStreams = 10
 )
 
-// newBenchBatch builds the same input batch for both pipelines. It's only
-// ever read by ProcessBatch (ConsumeStreams drains its own by-value copy
-// of the Batch struct, never the caller's), so it's safe to build once and
-// reuse across every iteration of both benchmarks.
-func newBenchBatch() loki.Batch {
+// newBenchBatch builds the shared input batch for both pipelines.
+// entriesPerStream controls how many lines go into every stream, plain,
+// CRI, and multiline alike, so the same builder produces either many
+// small streams (1-2 entries each, close to one line per file per poll)
+// or a handful of large ones (100s of entries each, like one high-volume
+// file) -- to test whether Pipeline3's per-stream slice allocation
+// amortizes better once there's more to spread it across, for every
+// stage's hold/merge logic, not just plain pass-through.
+//
+// CRI and multiline streams need at least 2 entries to still resolve one
+// held block plus start a second one, so entriesPerStream is clamped to 2
+// for those two regardless of what's passed in.
+//
+// The returned Batch is only ever read by ProcessBatch (ConsumeStreams
+// drains its own by-value copy of the Batch struct, never the caller's),
+// so it's safe to build once per benchmark and reuse across every
+// iteration.
+func newBenchBatch(entriesPerStream int) loki.Batch {
 	b := loki.NewBatch()
 
 	for i := 0; i < benchPlainStreams; i++ {
+		entries := make([]push.Entry, entriesPerStream)
+		for j := range entries {
+			entries[j] = push.Entry{Line: fmt.Sprintf("plain log line number %d", j)}
+		}
 		b.Add(loki.NewStream(
 			model.LabelSet{"app": "plain", "job": model.LabelValue(fmt.Sprintf("plain-%d", i))},
-			push.Entry{Line: fmt.Sprintf("plain log line number %d", i)},
+			entries...,
 		))
 	}
 
+	// Repeated partial+full pairs -- a busy CRI source splitting many
+	// separate lines over time, not one line fragmented absurdly far.
+	// entriesPerStream=2 is exactly today's single pair.
+	criPairs := max(entriesPerStream/2, 1)
 	for i := 0; i < benchCRIStreams; i++ {
+		entries := make([]push.Entry, 0, criPairs*2)
+		for p := 0; p < criPairs; p++ {
+			entries = append(entries,
+				push.Entry{Line: fmt.Sprintf("2024-01-01T00:00:00.000000000Z stdout P line%d ", p)},
+				push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout F World"},
+			)
+		}
 		b.Add(loki.NewStream(
 			model.LabelSet{"app": "cri", "job": model.LabelValue(fmt.Sprintf("cri-%d", i))},
-			push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout P Hello "},
-			push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout F World"},
+			entries...,
 		))
 	}
 
+	// Repeated 2-line blocks (start + 1 continuation) -- a source emitting
+	// many separate multi-line entries over time, not one enormous merge
+	// -- plus one trailing start line left held, so there's still
+	// something for Flush to pick up. entriesPerStream=3 is exactly
+	// today's single start/continue/new-start triple (1 block + 1
+	// trailing line).
+	const mlBlockSize = 2
+	mlBlocks := max(entriesPerStream/mlBlockSize, 1)
 	for i := 0; i < benchMultilineStreams; i++ {
+		entries := make([]push.Entry, 0, mlBlocks*mlBlockSize+1)
+		for blk := 0; blk < mlBlocks; blk++ {
+			entries = append(entries, push.Entry{Line: "START of the line"})
+			for c := 0; c < mlBlockSize-1; c++ {
+				entries = append(entries, push.Entry{Line: fmt.Sprintf("continue %d", c)})
+			}
+		}
+		entries = append(entries, push.Entry{Line: "START of a new line"})
 		b.Add(loki.NewStream(
 			model.LabelSet{"app": "multiline", "job": model.LabelValue(fmt.Sprintf("ml-%d", i))},
-			push.Entry{Line: "START of the line"},
-			push.Entry{Line: "continue"},
-			push.Entry{Line: "START of a new line"},
+			entries...,
 		))
 	}
 
@@ -74,9 +115,8 @@ func newBenchPipeline2() *Pipeline2 {
 		MatchActionKeep,
 		NewPipeline2([]Stage2{newMultilineStage2(regexp.MustCompile("^START"), 10, 50*time.Millisecond, true)}),
 	)
-	labels := newStaticLabelsStage2([]string{"outer", "test"})
 
-	return NewPipeline2([]Stage2{newCRIStage2(10), match, multilineMatch, labels})
+	return NewPipeline2([]Stage2{newCRIStage2(10), match, multilineMatch})
 }
 
 func newBenchPipeline3() *Pipeline3 {
@@ -99,10 +139,10 @@ func newBenchPipeline3() *Pipeline3 {
 // dead code.
 var benchOut loki.Batch
 
-func BenchmarkPipeline2(b *testing.B) {
+func runPipeline2Bench(b *testing.B, entriesPerStream int) {
 	ctx := context.Background()
 	pipeline := newBenchPipeline2()
-	in := newBenchBatch()
+	in := newBenchBatch(entriesPerStream)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -115,10 +155,10 @@ func BenchmarkPipeline2(b *testing.B) {
 	}
 }
 
-func BenchmarkPipeline3(b *testing.B) {
+func runPipeline3Bench(b *testing.B, entriesPerStream int) {
 	ctx := context.Background()
 	pipeline := newBenchPipeline3()
-	in := newBenchBatch()
+	in := newBenchBatch(entriesPerStream)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -128,5 +168,69 @@ func BenchmarkPipeline3(b *testing.B) {
 			b.Fatal(err)
 		}
 		benchOut = out
+	}
+}
+
+// Small: 1-2 entries per stream -- the shape already benchmarked.
+func BenchmarkPipeline2Small(b *testing.B) { runPipeline2Bench(b, 1) }
+func BenchmarkPipeline3Small(b *testing.B) { runPipeline3Bench(b, 1) }
+
+// Big: 200 entries per stream -- a handful of high-volume streams instead
+// of many small ones, to test amortization across every stage.
+func BenchmarkPipeline2Big(b *testing.B) { runPipeline2Bench(b, 200) }
+func BenchmarkPipeline3Big(b *testing.B) { runPipeline3Bench(b, 200) }
+
+// newBenchEntries returns a small, representative burst of entries meant
+// to be replayed repeatedly against ProcessEntry: a few plain lines, one
+// CRI partial+full pair, and the start of a multiline block. Each
+// repetition of the burst naturally resolves the previous repetition's
+// held multiline block -- a new "START" line always flushes whatever came
+// before it -- so cycling through this forever is stable: no unbounded
+// growth in criStage/multilineStage's held state.
+func newBenchEntries() []loki.Entry {
+	return []loki.Entry{
+		loki.NewEntry(model.LabelSet{"app": "plain", "job": "p0"}, push.Entry{Line: "plain log line"}),
+		loki.NewEntry(model.LabelSet{"app": "plain", "job": "p1"}, push.Entry{Line: "plain log line"}),
+		loki.NewEntry(model.LabelSet{"app": "plain", "job": "p2"}, push.Entry{Line: "plain log line"}),
+		loki.NewEntry(model.LabelSet{"app": "cri", "job": "c0"}, push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout P Hello "}),
+		loki.NewEntry(model.LabelSet{"app": "cri", "job": "c0"}, push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout F World"}),
+		loki.NewEntry(model.LabelSet{"app": "multiline", "job": "m0"}, push.Entry{Line: "START of the line"}),
+		loki.NewEntry(model.LabelSet{"app": "multiline", "job": "m0"}, push.Entry{Line: "continue"}),
+	}
+}
+
+// benchEntryOut keeps the compiler from eliminating ProcessEntry's result
+// as dead code.
+var benchEntryOut []Entry
+
+func BenchmarkPipelineEntry2(b *testing.B) {
+	ctx := context.Background()
+	pipeline := newBenchPipeline2()
+	entries := newBenchEntries()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := pipeline.ProcessEntry(ctx, entries[i%len(entries)])
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchEntryOut = out
+	}
+}
+
+func BenchmarkPipelineEntry3(b *testing.B) {
+	ctx := context.Background()
+	pipeline := newBenchPipeline3()
+	entries := newBenchEntries()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := pipeline.ProcessEntry(ctx, entries[i%len(entries)])
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchEntryOut = out
 	}
 }

--- a/internal/component/loki/process/stages/pipeline_bench_test.go
+++ b/internal/component/loki/process/stages/pipeline_bench_test.go
@@ -1,0 +1,132 @@
+package stages
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+)
+
+// Shape shared by both benchmarks: mostly plain lines that need none of the
+// stateful stages, plus a minority of CRI and multiline streams -- so the
+// "does a stateful stage always lock, even when nothing in the batch needs
+// it" question from notes.md is actually exercised, not just the happy
+// path where every entry needs special handling.
+const (
+	benchPlainStreams     = 80
+	benchCRIStreams       = 10
+	benchMultilineStreams = 10
+)
+
+// newBenchBatch builds the same input batch for both pipelines. It's only
+// ever read by ProcessBatch (ConsumeStreams drains its own by-value copy
+// of the Batch struct, never the caller's), so it's safe to build once and
+// reuse across every iteration of both benchmarks.
+func newBenchBatch() loki.Batch {
+	b := loki.NewBatch()
+
+	for i := 0; i < benchPlainStreams; i++ {
+		b.Add(loki.NewStream(
+			model.LabelSet{"app": "plain", "job": model.LabelValue(fmt.Sprintf("plain-%d", i))},
+			push.Entry{Line: fmt.Sprintf("plain log line number %d", i)},
+		))
+	}
+
+	for i := 0; i < benchCRIStreams; i++ {
+		b.Add(loki.NewStream(
+			model.LabelSet{"app": "cri", "job": model.LabelValue(fmt.Sprintf("cri-%d", i))},
+			push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout P Hello "},
+			push.Entry{Line: "2024-01-01T00:00:00.000000000Z stdout F World"},
+		))
+	}
+
+	for i := 0; i < benchMultilineStreams; i++ {
+		b.Add(loki.NewStream(
+			model.LabelSet{"app": "multiline", "job": model.LabelValue(fmt.Sprintf("ml-%d", i))},
+			push.Entry{Line: "START of the line"},
+			push.Entry{Line: "continue"},
+			push.Entry{Line: "START of a new line"},
+		))
+	}
+
+	return b
+}
+
+// Same 4-stage shape as TestPipeline2/TestPipeline3: cri -> match("World")
+// with a nested static-labels pipeline -> multilineMatch with a nested
+// multiline pipeline -> a final static-labels stage.
+
+func newBenchPipeline2() *Pipeline2 {
+	match := newMatchStage2(
+		func(e Entry) bool { return strings.Contains(e.Line, "World") },
+		MatchActionKeep,
+		NewPipeline2([]Stage2{newStaticLabelsStage2([]string{"inner", "true"})}),
+	)
+	multilineMatch := newMatchStage2(
+		func(e Entry) bool { return e.Labels["app"] == "multiline" },
+		MatchActionKeep,
+		NewPipeline2([]Stage2{newMultilineStage2(regexp.MustCompile("^START"), 10, 50*time.Millisecond, true)}),
+	)
+	labels := newStaticLabelsStage2([]string{"outer", "test"})
+
+	return NewPipeline2([]Stage2{newCRIStage2(10), match, multilineMatch, labels})
+}
+
+func newBenchPipeline3() *Pipeline3 {
+	match := newMatchStage3(
+		func(e Entry) bool { return strings.Contains(e.Line, "World") },
+		MatchActionKeep,
+		NewPipeline3([]Stage3{newStaticLabelsStage3([]string{"inner", "true"})}),
+	)
+	multilineMatch := newMatchStage3(
+		func(e Entry) bool { return e.Labels["app"] == "multiline" },
+		MatchActionKeep,
+		NewPipeline3([]Stage3{newMultilineStage3(regexp.MustCompile("^START"), 10, 50*time.Millisecond, true)}),
+	)
+	labels := newStaticLabelsStage3([]string{"outer", "test"})
+
+	return NewPipeline3([]Stage3{newCRIStage3(10), match, multilineMatch, labels})
+}
+
+// benchOut keeps the compiler from eliminating ProcessBatch's result as
+// dead code.
+var benchOut loki.Batch
+
+func BenchmarkPipeline2(b *testing.B) {
+	ctx := context.Background()
+	pipeline := newBenchPipeline2()
+	in := newBenchBatch()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := pipeline.ProcessBatch(ctx, in)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchOut = out
+	}
+}
+
+func BenchmarkPipeline3(b *testing.B) {
+	ctx := context.Background()
+	pipeline := newBenchPipeline3()
+	in := newBenchBatch()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := pipeline.ProcessBatch(ctx, in)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchOut = out
+	}
+}


### PR DESCRIPTION
Most loki components are trivial to change in order to support the new loki pipeline we are moving too but `loki.process` is not.

We have a couple of different types of stages:
1. Simple stages that just process entries and passes to next e.g. [stage.static_labels](https://github.com/grafana/alloy/blob/a7696d5565a78563a1f36714165ecaed1fa0794a/internal/component/loki/process/stages/static_labels.go#L63)
2. Stages that can drop labels e.g. [stage.drop](https://github.com/grafana/alloy/blob/a7696d5565a78563a1f36714165ecaed1fa0794a/internal/component/loki/process/stages/drop.go)
3. Stages that can produce multiple entries, [stage.split_json](https://github.com/grafana/alloy/blob/a7696d5565a78563a1f36714165ecaed1fa0794a/internal/component/loki/process/stages/split_json.go) and [stage.cri](https://github.com/grafana/alloy/blob/a7696d5565a78563a1f36714165ecaed1fa0794a/internal/component/loki/process/stages/cri.go#L98)
4. Stages that creates a sub pipeline, the only stage we have is [stage.match](https://github.com/grafana/alloy/blob/a7696d5565a78563a1f36714165ecaed1fa0794a/internal/component/loki/process/stages/match.go#L127)
5. Stages that can flush entries on it's own, the only one with this capability is [stage.multiline](https://github.com/grafana/alloy/blob/main/internal/component/loki/process/stages/multiline.go#L178)

I am pretty sure the last one is the reason why this component today is built up by starting each stage in it's own goroutine and chain them with channels.

This is problematic for the loki pipeline changes since with this structure a batch / entry sent down the pipeline would be disconnected from the original caller and this would still cause the same head-of-line blocking that exists today.

What we really want is for the stages them self just be function calls, just like component are going to be. In this pr I have experimented a bit with a new stage / pipeline interface. The best way to check how it would be used is to check the added test `TestPipeline2` where I have added these different kind of stages we have today (simple ports).

A couple of things I want to highlight:
1. All stages that carries internal state now needs to be safe to call concurrently, for this POC made them safe with a sync.Mutex but we need to review this stage by stage.
2. Since `stage.multiline` can flush entries on it's own we need an external trigger, this would most likely be up to the component to scan for nearest flush deadline from potentially several stages and call the flush function and forward the batch on it's own.
3. For this POC I opted to supply a `Emitter` interface to every Process call, this allows a stage to emit multiple entries during on call. Another solution instead of this would be to change the signature of each stage to work on slices of entries instead and loop on each stage.

