### PR TITLE
perf(loki.process): Reduce pipeline latency with buffered inter-stage channels

### DIFF
--- a/internal/component/loki/process/stages/decolorize.go
+++ b/internal/component/loki/process/stages/decolorize.go
@@ -19,7 +19,7 @@ var ansiRegex = regexp.MustCompile(ansiPattern)
 
 // Run implements Stage
 func (m *decolorizeStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range in {

--- a/internal/component/loki/process/stages/drop.go
+++ b/internal/component/loki/process/stages/drop.go
@@ -106,7 +106,7 @@ type dropStage struct {
 }
 
 func (m *dropStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range in {

--- a/internal/component/loki/process/stages/eventlogmessage.go
+++ b/internal/component/loki/process/stages/eventlogmessage.go
@@ -45,7 +45,7 @@ func newEventLogMessageStage(logger *slog.Logger, cfg *EventLogMessageConfig) St
 }
 
 func (m *eventLogMessageStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	key := m.cfg.Source
 	go func() {
 		defer close(out)

--- a/internal/component/loki/process/stages/geoip.go
+++ b/internal/component/loki/process/stages/geoip.go
@@ -128,7 +128,7 @@ type geoIPStage struct {
 
 // Run implements Stage
 func (g *geoIPStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		defer g.close()

--- a/internal/component/loki/process/stages/json.go
+++ b/internal/component/loki/process/stages/json.go
@@ -90,7 +90,7 @@ func newJSONStage(logger *slog.Logger, cfg JSONConfig) (Stage, error) {
 }
 
 func (j *jsonStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range in {

--- a/internal/component/loki/process/stages/labels.go
+++ b/internal/component/loki/process/stages/labels.go
@@ -86,7 +86,7 @@ type labelStage struct {
 
 // Run implements Stage
 func (l *labelStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range in {

--- a/internal/component/loki/process/stages/limit.go
+++ b/internal/component/loki/process/stages/limit.go
@@ -99,7 +99,7 @@ func (m *limitStage) Stop() {
 }
 
 func (m *limitStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range in {

--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -139,8 +139,8 @@ func (m *matcherStage) Run(in chan Entry) chan Entry {
 }
 
 func (m *matcherStage) runKeep(in chan Entry) chan Entry {
-	next := make(chan Entry)
-	out := make(chan Entry)
+	next := newEntryChan()
+	out := newEntryChan()
 	outNext := m.pipeline.Run(next)
 	go func() {
 		defer close(out)
@@ -163,7 +163,7 @@ func (m *matcherStage) runKeep(in chan Entry) chan Entry {
 }
 
 func (m *matcherStage) runDrop(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range in {

--- a/internal/component/loki/process/stages/metric.go
+++ b/internal/component/loki/process/stages/metric.go
@@ -103,7 +103,7 @@ type metricStage struct {
 }
 
 func (m *metricStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 

--- a/internal/component/loki/process/stages/multiline.go
+++ b/internal/component/loki/process/stages/multiline.go
@@ -96,7 +96,7 @@ func newMultilineStage(logger *slog.Logger, config MultilineConfig) (Stage, erro
 }
 
 func (m *multilineStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 

--- a/internal/component/loki/process/stages/pack.go
+++ b/internal/component/loki/process/stages/pack.go
@@ -138,7 +138,7 @@ type packStage struct {
 }
 
 func (m *packStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range in {

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -12,6 +12,19 @@ import (
 	"github.com/grafana/alloy/internal/featuregate"
 )
 
+// entryChanBufferSize is the buffer size used for every inter-stage
+// channel. Experiment: does giving each stage-to-stage handoff some slack
+// (instead of requiring a synchronous unbuffered rendezvous) reduce the
+// goroutine park/wake cost that dominates a pipeline with many stages? 0
+// keeps the original unbuffered behavior.
+const entryChanBufferSize = 16
+
+// newEntryChan is the single place that creates an inter-stage channel, so
+// entryChanBufferSize can be swept without touching every call site.
+func newEntryChan() chan Entry {
+	return make(chan Entry, entryChanBufferSize)
+}
+
 // StageConfig defines a single stage in a processing pipeline.
 // We define these as pointers types so we can use reflection to check that
 // exactly one is set.
@@ -81,7 +94,7 @@ func NewPipeline(slogger *slog.Logger, stages []StageConfig, registerer promethe
 func (p *Pipeline) Start(in chan loki.Entry, out chan<- loki.Entry) loki.EntryHandler {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	pipelineIn := make(chan Entry)
+	pipelineIn := newEntryChan()
 	pipelineOut := p.Run(pipelineIn)
 
 	var (
@@ -162,7 +175,7 @@ func (p *Pipeline) Stop() {
 
 // RunWith will read from the input channel entries, mutate them with the process function and returns them via the output channel.
 func RunWith(input chan Entry, process func(e Entry) Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range input {
@@ -175,7 +188,7 @@ func RunWith(input chan Entry, process func(e Entry) Entry) chan Entry {
 // RunWithSkipOrSendMany same as RunWith, except it handles sending multiple entries at the same time and it wil skip
 // sending the batch to output channel, if `process` functions returns `skip` true.
 func RunWithSkipOrSendMany(input chan Entry, process func(e Entry) ([]Entry, bool)) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range input {

--- a/internal/component/loki/process/stages/sampling.go
+++ b/internal/component/loki/process/stages/sampling.go
@@ -57,7 +57,7 @@ type samplingStage struct {
 }
 
 func (m *samplingStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		counter := m.dropCount.WithLabelValues(m.cfg.DropReason)

--- a/internal/component/loki/process/stages/split_json.go
+++ b/internal/component/loki/process/stages/split_json.go
@@ -32,7 +32,7 @@ func newSplitJSONStage(logger *slog.Logger, cfg SplitJSONConfig) Stage {
 // becomes N entries. Every other entry passes through unchanged. The stage
 // sends each new entry as it builds it.
 func (s *splitJSONStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range in {

--- a/internal/component/loki/process/stages/truncate.go
+++ b/internal/component/loki/process/stages/truncate.go
@@ -81,7 +81,7 @@ type truncateStage struct {
 }
 
 func (m *truncateStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	go func() {
 		defer close(out)
 		for e := range in {

--- a/internal/component/loki/process/stages/windowsevent.go
+++ b/internal/component/loki/process/stages/windowsevent.go
@@ -52,7 +52,7 @@ func newWindowsEventStage(logger *slog.Logger, cfg *WindowsEventConfig) Stage {
 }
 
 func (w *WindowsEventStage) Run(in chan Entry) chan Entry {
-	out := make(chan Entry)
+	out := newEntryChan()
 	key := w.cfg.Source
 	go func() {
 		defer close(out)


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
    description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.

  **HUMANS**
  - Read and understand docs/developer/genai.md
  - Brief description / Issue(s) fixed: factual summary of the change (AI may
    help). Details, Notes, and Checklist: your motivations, trade-offs, and
    judgment — keep those human-owned.

  **AI AGENTS**
  - MANDATORY: Read, understand, and apply AGENTS.md
  - Use this template as the PR body structure. Do not invent a custom layout.
  - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
    that section's content. Leave it empty unless the human already filled it.
  - Sections without "HUMAN ONLY" may be filled by you (Brief description,
    Issue(s) fixed when known). Do not invent issue numbers or a PR title.
  - Checklist: leave unchecked unless the human explicitly confirmed; do not
    guess the AI-assistance disclosure box.
  - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
    point at docs/developer/genai.md.
-->

### Brief description of Pull Request

Alternative, smaller-diff approach to the same problem as #6873: `loki.process` gives every pipeline stage its own unbuffered channel, forcing a synchronous rendezvous (sender blocks until the receiver is scheduled) for every entry at every stage boundary. This PR keeps the existing goroutine-per-stage architecture entirely as-is and only changes channel construction: every inter-stage channel now goes through one helper, `newEntryChan()` (`pipeline.go`), with a buffer of 16 instead of 0. No stage logic, interfaces, or goroutine topology change.

This PR is now chained on top of #6879, which holds the shared benchmark commit as a common base (that commit also picked up a benchmark-harness fix: the drain goroutine wasn't awaited, so a sub-benchmark's leftover work could bleed CPU into the next one's timing). This branch itself contains only the one-constant change (`b79220f83`). `git checkout loki-process-benchmarks` vs `git checkout loki-process-buffered-channels` reproduces the numbers below.

`benchstat`, `GOMAXPROCS=2`, `-count=10`, re-run against the fixed benchmark harness (this supersedes the numbers previously posted here, which predated that fix):

```
                                                             │       base (#6879)        │        this branch (b79220f83)       │
                                                             │           sec/op          │    sec/op     vs base               │
PipelineManyRules/rules=1-2                                              708.3n ±  2%   549.8n ± 2%  -22.37% (p=0.000 n=10)
PipelineManyRules/rules=10-2                                            2299.5n ±  2%   628.2n ± 1%  -72.68% (p=0.000 n=10)
PipelineManyRules/rules=50-2                                             9.973µ ±  1%   1.874µ ± 1%  -81.21% (p=0.000 n=10)
PipelineManyRules/rules=100-2                                           19.051µ ±  1%   3.384µ ± 1%  -82.24% (p=0.000 n=10)
PipelineManyRules/rules=500-2                                            84.05µ ±  1%   13.63µ ± 3%  -83.79% (p=0.000 n=10)
PipelineManyRules/rules=1000-2                                          152.10µ ±  1%   24.43µ ± 4%  -83.94% (p=0.000 n=10)
PipelineOneMultilineAmongManyRules/all_sync-2                           149.30µ ±  1%   24.15µ ± 4%  -83.83% (p=0.000 n=10)
PipelineOneMultilineAmongManyRules/one_multiline_at_start-2             151.46µ ±  2%   24.65µ ± 3%  -83.73% (p=0.000 n=10)
PipelineOneMultilineAmongManyRules/one_multiline_in_middle-2            151.25µ ±  2%   24.47µ ± 3%  -83.82% (p=0.000 n=10)
PipelineOneMultilineAmongManyRules/one_multiline_at_end-2               148.66µ ±  2%   24.36µ ± 4%  -83.62% (p=0.000 n=10)
PipelineManyStreamsSaturated-2                                          173.68m ±  2%   71.66m ± 6%  -58.74% (p=0.000 n=10)
geomean                                                                  73.72µ         16.08µ       -78.19%

                               │       base (#6879)        │        this branch (b79220f83)        │
                               │        entries/sec        │  entries/sec    vs base                │
PipelineManyStreamsSaturated-2              9.212k ±  2%   22.332k ± 5%  +142.42% (p=0.000 n=10)

                               │       base (#6879)        │        this branch (b79220f83)        │
                               │        B/op / allocs/op   │      B/op / allocs/op   vs base        │
PipelineManyStreamsSaturated-2       6.612Mi / 88.37k     69.871Mi / 127.6k   +956.70% / +44.38% (p=0.000 n=10)
```

The single-stream latency win here is larger across the board than #6873's full redesign (e.g. -83.9% vs -77.1% at `rules=1000`), consistent with the original sweep. The concurrent-throughput win is real but smaller than the full redesign (+142% vs +577% `entries/sec`) — and this re-run also surfaces a real cost the earlier numbers didn't show: `PipelineManyStreamsSaturated` memory jumps **+957%** (6.6MiB → 69.9MiB per op) and allocations **+44%**, versus #6873's redesign which *cuts* both (-84% / -91%). Buffering trades memory for latency by letting more entries sit in flight at once; the full redesign avoids that trade-off entirely by removing the per-stage goroutines and channels rather than padding them.

Buffer size was swept (0/1/2/4/8/16/32/64) at several `GOMAXPROCS` levels before settling on 16: single-stream latency keeps improving monotonically at least to buffer=32 with no core-count-dependent downside found, but the concurrent-streams throughput benchmark has a real peak (varies by ~4-16 depending on `GOMAXPROCS`) and *loses* most of its gain by buffer=64. 16 balances both. (This sweep itself predates the harness fix and hasn't been re-run; the memory trade-off above means it's worth re-sweeping with `B/op` as a second axis, not just throughput.)

Verified with `go test -race` across `internal/component/loki/process/...` and `golangci-lint` (no new findings).

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))

