### PR TITLE
perf(loki.process): Run stages that implement the Processor interface together to reduce channel usage

### DIFF
--- a/internal/component/loki/process/stages/match.go
+++ b/internal/component/loki/process/stages/match.go
@@ -92,14 +92,26 @@ func newMatcherStage(slogger *slog.Logger, config MatchConfig, registerer promet
 		return nil, err
 	}
 
-	return &matcherStage{
+	m := &matcherStage{
 		dropReason: dropReason,
 		dropCount:  dropCount,
 		matchers:   selector.Matchers(),
 		pipeline:   pl,
 		action:     config.Action,
 		filter:     filter,
-	}, nil
+	}
+
+	// Cache the nested pipeline's narrowly-fused function once, if it has
+	// one: every stage nested under this "keep" match (including further
+	// nested match blocks) needs to itself qualify for narrow fusion (see
+	// trySyncNarrow) for the whole thing to collapse into a single function
+	// call. If it doesn't, syncNarrowFn stays nil and this match stage
+	// falls back to its existing channel-based runKeep.
+	if pl != nil {
+		m.syncNarrowFn, _ = pl.trySyncNarrow()
+	}
+
+	return m, nil
 }
 
 func getDropCountMetric(registerer prometheus.Registerer) (*prometheus.CounterVec, error) {
@@ -126,6 +138,11 @@ type matcherStage struct {
 	filter     logql.Filter
 	pipeline   *Pipeline
 	action     string
+
+	// syncNarrowFn is pipeline's narrowly-fused function, cached once at
+	// construction; nil if the nested pipeline doesn't qualify (see
+	// trySyncNarrow) or for MatchActionDrop, which has no nested pipeline.
+	syncNarrowFn func(Entry) (Entry, bool)
 }
 
 func (m *matcherStage) Run(in chan Entry) chan Entry {
@@ -175,6 +192,40 @@ func (m *matcherStage) runDrop(in chan Entry) chan Entry {
 		}
 	}()
 	return out
+}
+
+// trySyncNarrow implements syncNarrowCapable. A drop match always
+// qualifies (it has no nested pipeline); a keep match qualifies only if
+// its nested pipeline does, i.e. syncNarrowFn was successfully cached at
+// construction.
+func (m *matcherStage) trySyncNarrow() (func(Entry) (Entry, bool), bool) {
+	switch m.action {
+	case MatchActionDrop:
+		return m.processDropSync, true
+	case MatchActionKeep:
+		if m.syncNarrowFn == nil {
+			return nil, false
+		}
+		return m.processKeepSync, true
+	}
+	panic("unexpected action")
+}
+
+func (m *matcherStage) processDropSync(e Entry) (Entry, bool) {
+	e, matched := m.processLogQL(e)
+	if !matched {
+		return e, false
+	}
+	m.dropCount.WithLabelValues(m.dropReason).Inc()
+	return e, true
+}
+
+func (m *matcherStage) processKeepSync(e Entry) (Entry, bool) {
+	e, matched := m.processLogQL(e)
+	if !matched {
+		return e, false
+	}
+	return m.syncNarrowFn(e)
 }
 
 func (m *matcherStage) processLogQL(e Entry) (Entry, bool) {

--- a/internal/component/loki/process/stages/match_test.go
+++ b/internal/component/loki/process/stages/match_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -260,3 +261,149 @@ stage.match {
 func TestMatchNestedLimitShutdown(t *testing.T) {
 	assertPipelineStopsPromptly(t, testMatchNestedLimitAlloy)
 }
+
+// TestMatchNarrowFusionProcessorOnly checks that a keep match whose nested
+// pipeline is entirely Processor-wrapped stages (static_labels here)
+// qualifies for narrow fusion (syncNarrowFn gets set), and that its
+// behavior for both a matching and a non-matching entry is unaffected.
+//
+// This goes through a Pipeline (not a bare matcherStage.Run) because
+// that's the only path that actually uses trySyncNarrow/syncNarrowFn —
+// matcherStage.Run is untouched and always uses the old channel-based
+// runKeep/runDrop, regardless of whether syncNarrowFn is set. It's also
+// the only path with a strict per-entry ordering guarantee: the old
+// runKeep can reorder a matched entry (routed through an async nested
+// pipeline) relative to an unmatched one (sent directly), which is exactly
+// why a bare matcherStage.Run isn't the right thing to assert order
+// against.
+func TestMatchNarrowFusionProcessorOnly(t *testing.T) {
+	s, err := newMatcherStage(util.TestAlloyLogger(t).Slog(), MatchConfig{
+		Selector: `{app="loki"}`,
+		Action:   MatchActionKeep,
+		Stages: []StageConfig{
+			{StaticLabelsConfig: &StaticLabelsConfig{Values: map[string]*string{"tag": ptrStr("matched")}}},
+		},
+	}, prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
+	require.NoError(t, err)
+
+	ms := s.(*matcherStage)
+	require.NotNil(t, ms.syncNarrowFn, "nested pipeline is Processor-only, should qualify for narrow fusion")
+
+	pl := &Pipeline{stages: []Stage{s}}
+	out := processEntries(pl,
+		newEntry(nil, model.LabelSet{"app": "loki"}, "line1", time.Now()),
+		newEntry(nil, model.LabelSet{"app": "other"}, "line2", time.Now()),
+	)
+	require.Len(t, out, 2)
+	assert.Equal(t, model.LabelValue("matched"), out[0].Labels["tag"])
+	assert.NotContains(t, out[1].Labels, model.LabelName("tag"))
+}
+
+// TestMatchNarrowFusionHandRolledFallsBack checks that a keep match nesting
+// even one hand-rolled stage (stage.json here, which is common in the
+// motivating adaptive-logs use case) does NOT qualify for narrow fusion,
+// and that it still behaves correctly via the existing channel-based path.
+func TestMatchNarrowFusionHandRolledFallsBack(t *testing.T) {
+	s, err := newMatcherStage(util.TestAlloyLogger(t).Slog(), MatchConfig{
+		Selector: `{app="loki"}`,
+		Action:   MatchActionKeep,
+		Stages: []StageConfig{
+			{JSONConfig: &JSONConfig{Expressions: map[string]string{"msg": ""}}},
+		},
+	}, prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
+	require.NoError(t, err)
+
+	ms := s.(*matcherStage)
+	require.Nil(t, ms.syncNarrowFn, "nested pipeline has a hand-rolled stage, should not qualify")
+
+	out := processEntries(s, newEntry(nil, model.LabelSet{"app": "loki"}, `{"msg":"hello"}`, time.Now()))
+	require.Len(t, out, 1)
+	assert.Equal(t, "hello", out[0].Extracted["msg"])
+}
+
+// TestMatchNarrowFusionDropAlwaysQualifies checks that a drop match always
+// qualifies for narrow fusion (it never has a nested pipeline to disqualify
+// it) and preserves drop semantics.
+func TestMatchNarrowFusionDropAlwaysQualifies(t *testing.T) {
+	s, err := newMatcherStage(util.TestAlloyLogger(t).Slog(), MatchConfig{
+		Selector: `{app="loki"}`,
+		Action:   MatchActionDrop,
+	}, prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
+	require.NoError(t, err)
+
+	ms := s.(*matcherStage)
+	fn, ok := ms.trySyncNarrow()
+	require.True(t, ok)
+	require.NotNil(t, fn)
+
+	out := processEntries(s,
+		newEntry(nil, model.LabelSet{"app": "loki"}, "dropped", time.Now()),
+		newEntry(nil, model.LabelSet{"app": "other"}, "kept", time.Now()),
+	)
+	require.Len(t, out, 1)
+	assert.Equal(t, "kept", out[0].Line)
+}
+
+// testSequentialReinjectionAlloy has two independent top-level match
+// blocks, each with a Processor-only nested pipeline (so both should
+// qualify for narrow fusion and get fused into the same goroutine by
+// Pipeline.Run). The second match's selector only fires on a label the
+// first match's nested pipeline sets — this is exactly the property a
+// naive "shared drainer" fusion design would break: each match must see
+// the PREVIOUS match's output, not the original entry, or match 2 would
+// never fire.
+var testSequentialReinjectionAlloy = `
+stage.match {
+	selector = "{app=\"loki\"}"
+	action   = "keep"
+	stage.static_labels {
+		values = { stage1_ran = "true" }
+	}
+}
+stage.match {
+	selector = "{stage1_ran=\"true\"}"
+	action   = "keep"
+	stage.static_labels {
+		values = { stage2_ran = "true" }
+	}
+}`
+
+func TestMatchNarrowFusionSequentialReinjection(t *testing.T) {
+	pl, err := newPipelineFromConfig(testSequentialReinjectionAlloy)
+	require.NoError(t, err)
+
+	out := processEntries(pl, newEntry(nil, model.LabelSet{"app": "loki"}, "line", time.Now()))
+	require.Len(t, out, 1)
+	assert.Equal(t, model.LabelValue("true"), out[0].Labels["stage1_ran"])
+	assert.Equal(t, model.LabelValue("true"), out[0].Labels["stage2_ran"], "second match should have seen the first match's output, not the original entry")
+}
+
+// TestMatchNarrowFusionNestedMatch checks that narrow fusion propagates
+// recursively: a keep match nesting another keep match, both with
+// Processor-only content, should have the OUTER match's syncNarrowFn set
+// too.
+func TestMatchNarrowFusionNestedMatch(t *testing.T) {
+	pl, err := newPipelineFromConfig(`
+stage.match {
+	selector = "{app=\"loki\"}"
+	action   = "keep"
+	stage.match {
+		selector = "{app=\"loki\"}"
+		action   = "keep"
+		stage.static_labels {
+			values = { inner_ran = "true" }
+		}
+	}
+}`)
+	require.NoError(t, err)
+	require.Len(t, pl.stages, 1)
+	outer, ok := pl.stages[0].(*matcherStage)
+	require.True(t, ok)
+	require.NotNil(t, outer.syncNarrowFn, "outer match's nested pipeline is itself a fully-qualifying match, should be fused")
+
+	out := processEntries(pl, newEntry(nil, model.LabelSet{"app": "loki"}, "line", time.Now()))
+	require.Len(t, out, 1)
+	assert.Equal(t, model.LabelValue("true"), out[0].Labels["inner_ran"])
+}
+
+func ptrStr(s string) *string { return &s }

--- a/internal/component/loki/process/stages/match_test.go
+++ b/internal/component/loki/process/stages/match_test.go
@@ -406,4 +406,64 @@ stage.match {
 	assert.Equal(t, model.LabelValue("true"), out[0].Labels["inner_ran"])
 }
 
+// TestMatchNarrowFusionDropThenIndependentKeep checks composeNarrow's skip
+// semantics across two INDEPENDENT top-level match blocks: a drop followed
+// by a keep whose selector doesn't depend on the first match at all. This
+// exercises the same skip-short-circuit as TestMatchNarrowFusionDropAlwaysQualifies,
+// but through Pipeline.Run's real fuse chain (both blocks qualify and fuse
+// into one goroutine) rather than a bare matcherStage, and confirms a
+// dropped entry never reaches the second match's selector check.
+func TestMatchNarrowFusionDropThenIndependentKeep(t *testing.T) {
+	pl, err := newPipelineFromConfig(`
+stage.match {
+	selector = "{app=\"drop-me\"}"
+	action   = "drop"
+}
+stage.match {
+	selector = "{app=\"loki\"}"
+	action   = "keep"
+	stage.static_labels {
+		values = { tag = "matched" }
+	}
+}`)
+	require.NoError(t, err)
+
+	out := processEntries(pl,
+		newEntry(nil, model.LabelSet{"app": "drop-me"}, "line1", time.Now()),
+		newEntry(nil, model.LabelSet{"app": "loki"}, "line2", time.Now()),
+		newEntry(nil, model.LabelSet{"app": "other"}, "line3", time.Now()),
+	)
+	require.Len(t, out, 2, "the drop-me entry should never reach the second match, let alone the output")
+	assert.Equal(t, "line2", out[0].Line)
+	assert.Equal(t, model.LabelValue("matched"), out[0].Labels["tag"])
+	assert.Equal(t, "line3", out[1].Line)
+	assert.NotContains(t, out[1].Labels, model.LabelName("tag"))
+}
+
+// TestPipelineNarrowFusionBoundary checks Pipeline.Run's fuse/flush boundary
+// logic with qualifying stages on BOTH SIDES of a non-qualifying one in the
+// same top-level pipeline: static_labels (qualifies) -> json (doesn't) ->
+// static_labels (qualifies). The second fused segment needs its own new
+// channel/goroutine restarted after the flush, and the entry must still
+// flow correctly end to end.
+func TestPipelineNarrowFusionBoundary(t *testing.T) {
+	pl, err := newPipelineFromConfig(`
+stage.static_labels {
+	values = { s1 = "true" }
+}
+stage.json {
+	expressions = { msg = "" }
+}
+stage.static_labels {
+	values = { s3 = "true" }
+}`)
+	require.NoError(t, err)
+
+	out := processEntries(pl, newEntry(nil, model.LabelSet{}, `{"msg":"hi"}`, time.Now()))
+	require.Len(t, out, 1)
+	assert.Equal(t, model.LabelValue("true"), out[0].Labels["s1"])
+	assert.Equal(t, model.LabelValue("true"), out[0].Labels["s3"])
+	assert.Equal(t, "hi", out[0].Extracted["msg"])
+}
+
 func ptrStr(s string) *string { return &s }

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -122,21 +122,132 @@ func (p *Pipeline) Start(in chan loki.Entry, out chan<- loki.Entry) loki.EntryHa
 	})
 }
 
-// Run implements Stage
+// Run implements Stage.
+//
+// Naively, this chains every stage through its own channel and goroutine.
+// Run instead fuses a maximal run of narrowly-sync-capable stages (see
+// trySyncNarrow) into a single goroutine and channel hop, and only drops
+// into a stage's own Run (its own channel and goroutine) for stages that
+// don't qualify.
 func (p *Pipeline) Run(in chan Entry) chan Entry {
-	in = RunWith(in, func(e Entry) Entry {
-		// Initialize the extracted map with the initial labels (ie. "filename"),
-		// so that stages can operate on initial labels too
-		for labelName, labelValue := range e.Labels {
-			e.Extracted[string(labelName)] = string(labelValue)
+	var fused []func(Entry) (Entry, bool)
+	flush := func() {
+		if len(fused) == 0 {
+			return
 		}
-		return e
-	})
-	// chain all stages together.
-	for _, m := range p.stages {
-		in = m.Run(in)
+		in = RunWithSkip(in, composeNarrow(fused))
+		fused = nil
 	}
+
+	fused = append(fused, initEntryNarrow)
+	for _, s := range p.stages {
+		if fn, ok := trySyncNarrow(s); ok {
+			fused = append(fused, fn)
+			continue
+		}
+		flush()
+		in = s.Run(in)
+	}
+	flush()
 	return in
+}
+
+// initEntryNarrow initializes the extracted map with the initial labels
+// (ie. "filename"), so that stages can operate on initial labels too. It's
+// the first step of every pipeline, fused in like any other narrowly-sync
+// stage (see Run) instead of getting its own channel and goroutine.
+func initEntryNarrow(e Entry) (Entry, bool) {
+	for labelName, labelValue := range e.Labels {
+		e.Extracted[string(labelName)] = string(labelValue)
+	}
+	return e, false
+}
+
+// syncNarrowCapable is implemented by composite stages (Pipeline,
+// matcherStage) whose own eligibility for narrow fusion depends on what's
+// nested inside them. See trySyncNarrow.
+type syncNarrowCapable interface {
+	trySyncNarrow() (process func(Entry) (Entry, bool), ok bool)
+}
+
+// trySyncNarrow reports whether s can run as a plain function call within a
+// fused run instead of needing its own channel and goroutine, and if so
+// returns its process function (skip=true drops the entry, matching
+// RunWithSkip's convention).
+//
+// Only two kinds of stage qualify: stages wrapped by toStage (docker,
+// label_drop, label_keep, logfmt, luhn, output, pattern, replace,
+// static_labels, template, tenant, timestamp) via the Processor interface —
+// none of which can ever drop or fan an entry out, since Processor.Process
+// has no return value to signal either — and composite stages
+// (Pipeline, matcherStage) built entirely from stages that themselves
+// qualify. Every other stage (json, labels, structured_metadata, drop,
+// sampling, limit, metric, pack, truncate, windowsevent, decolorize,
+// eventlogmessage, geoip, structured_metadata_drop, multiline, cri,
+// split_json, and any match block nesting one of them) keeps its existing
+// Run()-based channel behavior untouched — deliberately: several of these
+// can drop or fan out an entry, which this narrow fast path doesn't attempt
+// to support.
+func trySyncNarrow(s Stage) (func(Entry) (Entry, bool), bool) {
+	if sp, ok := s.(*stageProcessor); ok {
+		return func(e Entry) (Entry, bool) {
+			sp.Process(e.Labels, e.Extracted, &e.Timestamp, &e.Line)
+			return e, false
+		}, true
+	}
+	if sn, ok := s.(syncNarrowCapable); ok {
+		return sn.trySyncNarrow()
+	}
+	return nil, false
+}
+
+// composeNarrow chains process functions (same skip convention as
+// RunWithSkip) into one.
+func composeNarrow(fns []func(Entry) (Entry, bool)) func(Entry) (Entry, bool) {
+	return func(e Entry) (Entry, bool) {
+		for _, fn := range fns {
+			var skip bool
+			e, skip = fn(e)
+			if skip {
+				return e, true
+			}
+		}
+		return e, false
+	}
+}
+
+// trySyncNarrow implements syncNarrowCapable, letting a Pipeline nested
+// inside a matcherStage's "keep" action be fused into its parent's chain
+// instead of requiring its own channels, as long as every one of its own
+// stages (and the synthetic initEntryNarrow step) themselves qualify.
+func (p *Pipeline) trySyncNarrow() (func(Entry) (Entry, bool), bool) {
+	fns := make([]func(Entry) (Entry, bool), 0, len(p.stages)+1)
+	fns = append(fns, initEntryNarrow)
+	for _, s := range p.stages {
+		fn, ok := trySyncNarrow(s)
+		if !ok {
+			return nil, false
+		}
+		fns = append(fns, fn)
+	}
+	return composeNarrow(fns), true
+}
+
+// RunWithSkip is RunWith for a process function that can also drop an entry
+// (skip=true) instead of forwarding it.
+func RunWithSkip(input chan Entry, process func(Entry) (Entry, bool)) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		for e := range input {
+			e, skip := process(e)
+			if skip {
+				continue
+			}
+			out <- e
+		}
+	}()
+	return out
 }
 
 // Cleanup implements Stage.

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -176,7 +176,7 @@ type syncNarrowCapable interface {
 // RunWithSkip's convention).
 //
 // Only two kinds of stage qualify: stages wrapped by toStage (docker,
-// label_drop, label_keep, logfmt, luhn, output, pattern, replace,
+// label_drop, label_keep, logfmt, luhn, output, pattern, regex, replace,
 // static_labels, template, tenant, timestamp) via the Processor interface —
 // none of which can ever drop or fan an entry out, since Processor.Process
 // has no return value to signal either — and composite stages


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
    description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.

  **HUMANS**
  - Read and understand docs/developer/genai.md
  - Brief description / Issue(s) fixed: factual summary of the change (AI may
    help). Details, Notes, and Checklist: your motivations, trade-offs, and
    judgment — keep those human-owned.

  **AI AGENTS**
  - MANDATORY: Read, understand, and apply AGENTS.md
  - Use this template as the PR body structure. Do not invent a custom layout.
  - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
    that section's content. Leave it empty unless the human already filled it.
  - Sections without "HUMAN ONLY" may be filled by you (Brief description,
    Issue(s) fixed when known). Do not invent issue numbers or a PR title.
  - Checklist: leave unchecked unless the human explicitly confirmed; do not
    guess the AI-assistance disclosure box.
  - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
    point at docs/developer/genai.md.
-->

### Brief description of Pull Request

Alternative, smaller-diff approach to the same problem as #6873 and #6875: `loki.process` gives every pipeline stage its own goroutine and unbuffered channel, even though most stages are pure synchronous single-entry transforms.

This PR doesn't introduce a new stage interface or touch any stage implementation. It recognizes stages already wrapped via the existing `Processor` interface (`docker`, `label_drop`, `label_keep`, `logfmt`, `luhn`, `output`, `pattern`, `regex`, `replace`, `static_labels`, `template`, `tenant`, `timestamp`) as safe to call directly as plain functions instead of through a channel, since `Processor.Process` has no return value to signal drop or fan-out. `Pipeline.Run` fuses maximal contiguous runs of these into one goroutine; `matcherStage` caches the same fusion for its nested pipeline at construction, recursing through further nested `match` blocks. Every other stage (`json`, `labels`, `drop`, `sampling`, `limit`, `metric`, `pack`, `truncate`, `windowsevent`, `decolorize`, `eventlogmessage`, `geoip`, `structured_metadata[_drop]`, `split_json`, `cri`, `multiline`) keeps its existing `Run()`-based channel behavior unchanged. Diff is two non-test files (`match.go`, `pipeline.go`).

This PR is chained on top of #6879 (shared benchmark commit). `git checkout loki-process-benchmarks` vs `git checkout loki-process-narrow-processor-fusion` reproduces the numbers below.

`benchstat`, `GOMAXPROCS=2`, `-count=10`:

```
                                                             │       base (#6879)        │   this branch (56a4a8c81/46664433c)  │
                                                             │           sec/op          │    sec/op     vs base                │
PipelineManyRules/rules=1-2                                              708.3n ±  2%   568.9n ± 1%  -19.69% (p=0.000 n=10)
PipelineManyRules/rules=10-2                                            2299.5n ±  2%   868.6n ± 1%  -62.23% (p=0.000 n=10)
PipelineManyRules/rules=50-2                                             9.973µ ±  1%   2.332µ ± 1%  -76.62% (p=0.000 n=10)
PipelineManyRules/rules=100-2                                           19.051µ ±  1%   3.892µ ± 2%  -79.57% (p=0.000 n=10)
PipelineManyRules/rules=500-2                                            84.05µ ±  1%   17.14µ ± 1%  -79.61% (p=0.000 n=10)
PipelineManyRules/rules=1000-2                                          152.10µ ±  1%   37.02µ ± 0%  -75.66% (p=0.000 n=10)
PipelineOneMultilineAmongManyRules/all_sync-2                           149.30µ ±  1%   36.00µ ± 1%  -75.88% (p=0.000 n=10)
PipelineOneMultilineAmongManyRules/one_multiline_at_start-2             151.46µ ±  2%   35.92µ ± 1%  -76.28% (p=0.000 n=10)
PipelineOneMultilineAmongManyRules/one_multiline_in_middle-2            151.25µ ±  2%   18.99µ ± 1%  -87.45% (p=0.000 n=10)
PipelineOneMultilineAmongManyRules/one_multiline_at_end-2               148.66µ ±  2%   35.44µ ± 1%  -76.16% (p=0.000 n=10)
PipelineManyStreamsSaturated-2                                          173.68m ±  2%   26.17m ± 2%  -84.93% (p=0.000 n=10)
geomean                                                                  73.72µ         18.01µ       -75.56%

                               │       base (#6879)        │   this branch (56a4a8c81/46664433c)   │
                               │        entries/sec        │  entries/sec    vs base                │
PipelineManyStreamsSaturated-2              9.212k ±  2%   61.132k ± 2%  +563.61% (p=0.000 n=10)

                               │       base (#6879)        │   this branch (56a4a8c81/46664433c)   │
                               │        B/op / allocs/op   │      B/op / allocs/op   vs base        │
PipelineManyStreamsSaturated-2       6.612Mi / 88.37k      1.309Mi / 16.15k    -80.20% / -81.72% (p=0.000 n=10)
```

`PipelineManyRules` is one stream, mostly idle. `PipelineOneMultilineAmongManyRules` checks that a single stage needing its own channel (nesting `stage.multiline`) doesn't drag the rest of a 1000-rule pipeline back to the old per-stage-channel cost. `PipelineManyStreamsSaturated` models many concurrent streams competing for the CPU, which is the throughput number that matters for a loaded instance: **+564% entries/sec**, with -80% memory and -82% allocs.

Directly against #6873 (same benchmarks, `GOMAXPROCS=2`, both branches diffed against the same #6879 base): latency and throughput are within noise of each other (geomean -0.11%) on this benchmark suite, because every rule here is `stage.static_labels`, which both PRs already fuse identically. This suite can't show the actual coverage difference: #6873 additionally fuses `stage.labels`, `drop`, `sampling`, `limit`, `json`, `metric`, `pack`, `truncate`, `windowsevent`, `decolorize`, `eventlogmessage`, `geoip`, and `structured_metadata[_drop]` by retrofitting those 13 stage implementations to a new `SyncStage` interface (a 25-file diff); this PR fuses only the pre-existing `Processor`-wrapped set and leaves every other stage's implementation untouched. On `PipelineManyStreamsSaturated`, this PR also shows ~24% more memory and ~2x the allocs/op of #6873 (16.15k vs 8.06k) — traced to `Pipeline.Run` recomputing which stages fuse on every call instead of caching that decision once at construction the way #6873's `syncFn` does; in production `Run` is only called once per component (re)configuration, so this doesn't scale with traffic, but it's a real, fixable gap relative to #6873's approach.

Verified with `go test -race` across `internal/component/loki/process/...` and `golangci-lint` (no new findings).

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
