### PR TITLE
fix(prometheus.operator.servicemonitors)!: Sync ServiceMonitor permission semantics with upstream

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -30,7 +30,7 @@ In these cases, the secrets are loaded and refreshed only when the ServiceMonito
 By default, `disallow_arbitrary_file_access` prevents ServiceMonitor endpoints from referencing files on the {{< param "PRODUCT_NAME" >}} filesystem through `bearerTokenFile`, `tlsConfig.caFile`, `tlsConfig.certFile`, or `tlsConfig.keyFile`.
 This is important in multi-tenant Kubernetes clusters where ServiceMonitor resources may be created by users who don't have the same permissions as {{< param "PRODUCT_NAME" >}}.
 
-Use `bearerTokenSecret`, `authorization`, or TLS secret and config map references in the ServiceMonitor instead of local file references.
+Use `bearerTokenSecret`, `authorization`, or TLS secret and `ConfigMap` references in the ServiceMonitor instead of local file references.
 
 ## Usage
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -25,6 +25,13 @@ You can run it from outside the cluster by supplying connection info in the `cli
 ServiceMonitors may reference secrets for authenticating to targets to scrape them.
 In these cases, the secrets are loaded and refreshed only when the ServiceMonitor is updated or when this component refreshes its' internal state, which happens on a 5-minute refresh cycle.
 
+## Security considerations
+
+By default, `disallow_arbitrary_file_access` prevents ServiceMonitor endpoints from referencing files on the {{< param "PRODUCT_NAME" >}} filesystem through `bearerTokenFile`, `tlsConfig.caFile`, `tlsConfig.certFile`, or `tlsConfig.keyFile`.
+This is important in multi-tenant Kubernetes clusters where ServiceMonitor resources may be created by users who don't have the same permissions as {{< param "PRODUCT_NAME" >}}.
+
+Use `bearerTokenSecret`, `authorization`, or TLS secret and config map references in the ServiceMonitor instead of local file references.
+
 ## Usage
 
 ```alloy
@@ -37,12 +44,13 @@ prometheus.operator.servicemonitors "<LABEL>" {
 
 You can use the following arguments with `prometheus.operator.servicemonitors`:
 
-| Name                    | Type                    | Description                                                                                               | Default       | Required |
-| ----------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- | ------------- | -------- |
-| `forward_to`            | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                             |               | yes      |
-| `informer_sync_timeout` | `duration`              | Timeout for initial sync of ServiceMonitor resources.                                                     | `"1m"`        | no       |
-| `kubernetes_role`       | `string`                | The Kubernetes role used for discovery. Supports `endpoints` or `endpointslice`.                          | `"endpoints"` | no       |
-| `namespaces`            | `list(string)`          | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces are searched. |               | no       |
+| Name                               | Type                    | Description                                                                                               | Default       | Required |
+| ---------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- | ------------- | -------- |
+| `disallow_arbitrary_file_access`   | `bool`                  | Disallow ServiceMonitor endpoints that reference arbitrary files on the {{< param "PRODUCT_NAME" >}} filesystem. | `true`        | no       |
+| `forward_to`                       | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                             |               | yes      |
+| `informer_sync_timeout`            | `duration`              | Timeout for initial sync of ServiceMonitor resources.                                                     | `"1m"`        | no       |
+| `kubernetes_role`                  | `string`                | The Kubernetes role used for discovery. Supports `endpoints` or `endpointslice`.                          | `"endpoints"` | no       |
+| `namespaces`                       | `list(string)`          | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces are searched. |               | no       |
 
 ## Blocks
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -40,21 +40,21 @@ You can use the following arguments with `prometheus.operator.servicemonitors`:
 | Name                               | Type                    | Description                                                                                               | Default       | Required |
 | ---------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- | ------------- | -------- |
 | `forward_to`                       | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                             |               | yes      |
-| `disallow_arbitrary_file_access`   | `bool`                  | Disallow ServiceMonitor endpoints that reference arbitrary files on the {{< param "PRODUCT_NAME" >}} filesystem. | `true`        | no       |
+| `allow_arbitrary_file_access`      | `bool`                  | Allow ServiceMonitor endpoints that reference arbitrary files on the {{< param "PRODUCT_NAME" >}} filesystem. | `false`       | no       |
 | `informer_sync_timeout`            | `duration`              | Timeout for initial sync of ServiceMonitor resources.                                                     | `"1m"`        | no       |
 | `kubernetes_role`                  | `string`                | The Kubernetes role used for discovery. Supports `endpoints` or `endpointslice`.                          | `"endpoints"` | no       |
 | `namespaces`                       | `list(string)`          | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces are searched. |               | no       |
 
-By default, `disallow_arbitrary_file_access` prevents ServiceMonitor endpoints from referencing files on the {{< param "PRODUCT_NAME" >}} filesystem through `bearerTokenFile`, `tlsConfig.caFile`, `tlsConfig.certFile`, or `tlsConfig.keyFile`.
+By default, `allow_arbitrary_file_access` prevents ServiceMonitor endpoints from referencing files on the {{< param "PRODUCT_NAME" >}} filesystem through `bearerTokenFile`, `tlsConfig.caFile`, `tlsConfig.certFile`, or `tlsConfig.keyFile`.
 This is important in multi-tenant Kubernetes clusters where ServiceMonitor resources may be created by users who don't have the same permissions as {{< param "PRODUCT_NAME" >}}.
 
-When `disallow_arbitrary_file_access` is `true`, {{< param "PRODUCT_NAME" >}} rejects the generated scrape configuration for a ServiceMonitor that references local files and records the reason in the component debug information.
+When `allow_arbitrary_file_access` is `false`, {{< param "PRODUCT_NAME" >}} rejects the generated scrape configuration for a ServiceMonitor that references local files and records the reason in the component debug information.
 Other ServiceMonitor resources and components continue to run.
 {{< param "PRODUCT_NAME" >}} also writes a warning log that includes the ServiceMonitor namespace, name, endpoint index, and field.
 
 {{< admonition type="caution" >}}
-Set `disallow_arbitrary_file_access` to `false` only for trusted ServiceMonitor resources that need local file references.
-When set to `false`, {{< param "PRODUCT_NAME" >}} allows the file references but still writes warning logs when it reconciles a changed ServiceMonitor that references local files.
+Set `allow_arbitrary_file_access` to `true` only for trusted ServiceMonitor resources that need local file references.
+When set to `true`, {{< param "PRODUCT_NAME" >}} allows the file references but still writes warning logs when it reconciles a changed ServiceMonitor that references local files.
 {{< /admonition >}}
 
 Use `bearerTokenSecret`, `authorization`, or TLS secret and `ConfigMap` references in the ServiceMonitor instead of local file references.

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -45,7 +45,6 @@ You can use the following arguments with `prometheus.operator.servicemonitors`:
 | `kubernetes_role`                  | `string`                | The Kubernetes role used for discovery. Supports `endpoints` or `endpointslice`.                          | `"endpoints"` | no       |
 | `namespaces`                       | `list(string)`          | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces are searched. |               | no       |
 
-{{< admonition type="caution" >}}
 By default, `disallow_arbitrary_file_access` prevents ServiceMonitor endpoints from referencing files on the {{< param "PRODUCT_NAME" >}} filesystem through `bearerTokenFile`, `tlsConfig.caFile`, `tlsConfig.certFile`, or `tlsConfig.keyFile`.
 This is important in multi-tenant Kubernetes clusters where ServiceMonitor resources may be created by users who don't have the same permissions as {{< param "PRODUCT_NAME" >}}.
 
@@ -53,11 +52,12 @@ When `disallow_arbitrary_file_access` is `true`, {{< param "PRODUCT_NAME" >}} re
 Other ServiceMonitor resources and components continue to run.
 {{< param "PRODUCT_NAME" >}} also writes a warning log that includes the ServiceMonitor namespace, name, endpoint index, and field.
 
+{{< admonition type="caution" >}}
 Set `disallow_arbitrary_file_access` to `false` only for trusted ServiceMonitor resources that need local file references.
 When set to `false`, {{< param "PRODUCT_NAME" >}} allows the file references but still writes warning logs when it reconciles a changed ServiceMonitor that references local files.
+{{< /admonition >}}
 
 Use `bearerTokenSecret`, `authorization`, or TLS secret and `ConfigMap` references in the ServiceMonitor instead of local file references.
-{{< /admonition >}}
 
 ## Blocks
 

--- a/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
+++ b/docs/sources/reference/components/prometheus/prometheus.operator.servicemonitors.md
@@ -25,13 +25,6 @@ You can run it from outside the cluster by supplying connection info in the `cli
 ServiceMonitors may reference secrets for authenticating to targets to scrape them.
 In these cases, the secrets are loaded and refreshed only when the ServiceMonitor is updated or when this component refreshes its' internal state, which happens on a 5-minute refresh cycle.
 
-## Security considerations
-
-By default, `disallow_arbitrary_file_access` prevents ServiceMonitor endpoints from referencing files on the {{< param "PRODUCT_NAME" >}} filesystem through `bearerTokenFile`, `tlsConfig.caFile`, `tlsConfig.certFile`, or `tlsConfig.keyFile`.
-This is important in multi-tenant Kubernetes clusters where ServiceMonitor resources may be created by users who don't have the same permissions as {{< param "PRODUCT_NAME" >}}.
-
-Use `bearerTokenSecret`, `authorization`, or TLS secret and `ConfigMap` references in the ServiceMonitor instead of local file references.
-
 ## Usage
 
 ```alloy
@@ -46,11 +39,25 @@ You can use the following arguments with `prometheus.operator.servicemonitors`:
 
 | Name                               | Type                    | Description                                                                                               | Default       | Required |
 | ---------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- | ------------- | -------- |
-| `disallow_arbitrary_file_access`   | `bool`                  | Disallow ServiceMonitor endpoints that reference arbitrary files on the {{< param "PRODUCT_NAME" >}} filesystem. | `true`        | no       |
 | `forward_to`                       | `list(MetricsReceiver)` | List of receivers to send scraped metrics to.                                                             |               | yes      |
+| `disallow_arbitrary_file_access`   | `bool`                  | Disallow ServiceMonitor endpoints that reference arbitrary files on the {{< param "PRODUCT_NAME" >}} filesystem. | `true`        | no       |
 | `informer_sync_timeout`            | `duration`              | Timeout for initial sync of ServiceMonitor resources.                                                     | `"1m"`        | no       |
 | `kubernetes_role`                  | `string`                | The Kubernetes role used for discovery. Supports `endpoints` or `endpointslice`.                          | `"endpoints"` | no       |
 | `namespaces`                       | `list(string)`          | List of namespaces to search for ServiceMonitor resources. If not specified, all namespaces are searched. |               | no       |
+
+{{< admonition type="caution" >}}
+By default, `disallow_arbitrary_file_access` prevents ServiceMonitor endpoints from referencing files on the {{< param "PRODUCT_NAME" >}} filesystem through `bearerTokenFile`, `tlsConfig.caFile`, `tlsConfig.certFile`, or `tlsConfig.keyFile`.
+This is important in multi-tenant Kubernetes clusters where ServiceMonitor resources may be created by users who don't have the same permissions as {{< param "PRODUCT_NAME" >}}.
+
+When `disallow_arbitrary_file_access` is `true`, {{< param "PRODUCT_NAME" >}} rejects the generated scrape configuration for a ServiceMonitor that references local files and records the reason in the component debug information.
+Other ServiceMonitor resources and components continue to run.
+{{< param "PRODUCT_NAME" >}} also writes a warning log that includes the ServiceMonitor namespace, name, endpoint index, and field.
+
+Set `disallow_arbitrary_file_access` to `false` only for trusted ServiceMonitor resources that need local file references.
+When set to `false`, {{< param "PRODUCT_NAME" >}} allows the file references but still writes warning logs when it reconciles a changed ServiceMonitor that references local files.
+
+Use `bearerTokenSecret`, `authorization`, or TLS secret and `ConfigMap` references in the ServiceMonitor instead of local file references.
+{{< /admonition >}}
 
 ## Blocks
 

--- a/internal/component/prometheus/operator/common/component.go
+++ b/internal/component/prometheus/operator/common/component.go
@@ -50,7 +50,8 @@ type Options struct {
 
 func DefaultOptions(kind string) Options {
 	return Options{
-		Kind: kind,
+		Kind:                   kind,
+		ServiceMonitorSettings: nil,
 	}
 }
 

--- a/internal/component/prometheus/operator/common/component.go
+++ b/internal/component/prometheus/operator/common/component.go
@@ -36,11 +36,11 @@ type Component struct {
 }
 
 type ServiceMonitorSettings struct {
-	DisallowArbitraryFileAccess bool
+	AllowArbitraryFileAccess bool
 }
 
 var DefaultServiceMonitorSettings = ServiceMonitorSettings{
-	DisallowArbitraryFileAccess: true,
+	AllowArbitraryFileAccess: false,
 }
 
 type Options struct {

--- a/internal/component/prometheus/operator/common/component.go
+++ b/internal/component/prometheus/operator/common/component.go
@@ -30,8 +30,22 @@ type Component struct {
 
 	crdManagerFactory crdManagerFactory
 
-	kind    string
-	cluster cluster.Cluster
+	kind                   string
+	cluster                cluster.Cluster
+	serviceMonitorSettings serviceMonitorSettings
+}
+
+type serviceMonitorArgumentProvider interface {
+	OperatorArguments() operator.Arguments
+	ServiceMonitorDisallowArbitraryFileAccess() bool
+}
+
+type serviceMonitorSettings struct {
+	disallowArbitraryFileAccess bool
+}
+
+var defaultServiceMonitorSettings = serviceMonitorSettings{
+	disallowArbitraryFileAccess: true,
 }
 
 func New(o component.Options, args component.Arguments, kind string) (*Component, error) {
@@ -91,7 +105,7 @@ func (c *Component) Run(ctx context.Context) error {
 			c.reportHealth(err)
 		case <-c.onUpdate:
 			c.mut.Lock()
-			manager := c.crdManagerFactory.New(c.opts, c.cluster, c.opts.Logger, c.config, c.kind, c.ls)
+			manager := c.crdManagerFactory.New(c.opts, c.cluster, c.opts.Logger, c.config, c.kind, c.ls, c.serviceMonitorSettings)
 			c.manager = manager
 
 			// Wait for the old manager to stop.
@@ -120,9 +134,14 @@ func (c *Component) Run(ctx context.Context) error {
 func (c *Component) Update(args component.Arguments) error {
 	// TODO(jcreixell): Initialize manager here so we can return errors back early to the caller.
 	// See https://github.com/grafana/agent/pull/2688#discussion_r1152384425
+	cfg, serviceMonitorSettings, err := convertArguments(args)
+	if err != nil {
+		return err
+	}
+
 	c.mut.Lock()
-	cfg := args.(operator.Arguments)
 	c.config = &cfg
+	c.serviceMonitorSettings = serviceMonitorSettings
 	c.mut.Unlock()
 
 	if cfg.Scrape.EnableTypeAndUnitLabels && !c.opts.MinStability.Permits(featuregate.StabilityExperimental) {
@@ -138,6 +157,19 @@ func (c *Component) Update(args component.Arguments) error {
 	default:
 	}
 	return nil
+}
+
+func convertArguments(args component.Arguments) (operator.Arguments, serviceMonitorSettings, error) {
+	switch args := args.(type) {
+	case operator.Arguments:
+		return args, defaultServiceMonitorSettings, nil
+	case serviceMonitorArgumentProvider:
+		return args.OperatorArguments(), serviceMonitorSettings{
+			disallowArbitraryFileAccess: args.ServiceMonitorDisallowArbitraryFileAccess(),
+		}, nil
+	default:
+		return operator.Arguments{}, serviceMonitorSettings{}, fmt.Errorf("unexpected prometheus operator arguments type %T", args)
+	}
 }
 
 // NotifyClusterChange implements component.ClusterComponent.

--- a/internal/component/prometheus/operator/common/component.go
+++ b/internal/component/prometheus/operator/common/component.go
@@ -32,23 +32,43 @@ type Component struct {
 
 	kind                   string
 	cluster                cluster.Cluster
-	serviceMonitorSettings serviceMonitorSettings
+	serviceMonitorSettings *ServiceMonitorSettings
 }
 
-type serviceMonitorArgumentProvider interface {
-	OperatorArguments() operator.Arguments
-	ServiceMonitorDisallowArbitraryFileAccess() bool
+type ServiceMonitorSettings struct {
+	DisallowArbitraryFileAccess bool
 }
 
-type serviceMonitorSettings struct {
-	disallowArbitraryFileAccess bool
+var DefaultServiceMonitorSettings = ServiceMonitorSettings{
+	DisallowArbitraryFileAccess: true,
 }
 
-var defaultServiceMonitorSettings = serviceMonitorSettings{
-	disallowArbitraryFileAccess: true,
+type Options struct {
+	Kind                   string
+	ServiceMonitorSettings *ServiceMonitorSettings
 }
 
-func New(o component.Options, args component.Arguments, kind string) (*Component, error) {
+func DefaultOptions(kind string) Options {
+	return Options{
+		Kind: kind,
+	}
+}
+
+// ServiceMonitorOptions marks Options as carrying ServiceMonitor-only settings.
+// Use it instead of DefaultOptions for ServiceMonitor components so settings such
+// as arbitrary file access cannot accidentally apply to other operator kinds.
+func ServiceMonitorOptions(settings ServiceMonitorSettings) Options {
+	return Options{
+		Kind:                   KindServiceMonitor,
+		ServiceMonitorSettings: &settings,
+	}
+}
+
+func New(o component.Options, args operator.Arguments, opts Options) (*Component, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+
 	data, err := o.GetServiceData(cluster.ServiceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get information about cluster service: %w", err)
@@ -63,12 +83,22 @@ func New(o component.Options, args component.Arguments, kind string) (*Component
 	c := &Component{
 		opts:              o,
 		onUpdate:          make(chan struct{}, 1),
-		kind:              kind,
+		kind:              opts.Kind,
 		cluster:           clusterData,
 		ls:                ls,
 		crdManagerFactory: realCrdManagerFactory{},
 	}
-	return c, c.Update(args)
+	return c, c.UpdateOperatorArguments(args, opts.ServiceMonitorSettings)
+}
+
+func (opts Options) Validate() error {
+	if opts.Kind == KindServiceMonitor && opts.ServiceMonitorSettings == nil {
+		return fmt.Errorf("serviceMonitor settings are required for %s", KindServiceMonitor)
+	}
+	if opts.Kind != KindServiceMonitor && opts.ServiceMonitorSettings != nil {
+		return fmt.Errorf("serviceMonitor settings are only supported for %s", KindServiceMonitor)
+	}
+	return nil
 }
 
 func (c *Component) CurrentHealth() component.Health {
@@ -134,11 +164,15 @@ func (c *Component) Run(ctx context.Context) error {
 func (c *Component) Update(args component.Arguments) error {
 	// TODO(jcreixell): Initialize manager here so we can return errors back early to the caller.
 	// See https://github.com/grafana/agent/pull/2688#discussion_r1152384425
-	cfg, serviceMonitorSettings, err := convertArguments(args)
-	if err != nil {
-		return err
+	cfg, ok := args.(operator.Arguments)
+	if !ok {
+		return fmt.Errorf("unexpected prometheus operator arguments type %T", args)
 	}
 
+	return c.UpdateOperatorArguments(cfg, c.serviceMonitorSettings)
+}
+
+func (c *Component) UpdateOperatorArguments(cfg operator.Arguments, serviceMonitorSettings *ServiceMonitorSettings) error {
 	c.mut.Lock()
 	c.config = &cfg
 	c.serviceMonitorSettings = serviceMonitorSettings
@@ -157,19 +191,6 @@ func (c *Component) Update(args component.Arguments) error {
 	default:
 	}
 	return nil
-}
-
-func convertArguments(args component.Arguments) (operator.Arguments, serviceMonitorSettings, error) {
-	switch args := args.(type) {
-	case operator.Arguments:
-		return args, defaultServiceMonitorSettings, nil
-	case serviceMonitorArgumentProvider:
-		return args.OperatorArguments(), serviceMonitorSettings{
-			disallowArbitraryFileAccess: args.ServiceMonitorDisallowArbitraryFileAccess(),
-		}, nil
-	default:
-		return operator.Arguments{}, serviceMonitorSettings{}, fmt.Errorf("unexpected prometheus operator arguments type %T", args)
-	}
 }
 
 // NotifyClusterChange implements component.ClusterComponent.

--- a/internal/component/prometheus/operator/common/component_test.go
+++ b/internal/component/prometheus/operator/common/component_test.go
@@ -29,7 +29,7 @@ type crdManagerFactoryHungRun struct {
 	stopRun         chan struct{}
 }
 
-func (m crdManagerFactoryHungRun) New(_ component.Options, _ cluster.Cluster, _ *slog.Logger, _ *operator.Arguments, _ string, _ labelstore.LabelStore) crdManagerInterface {
+func (m crdManagerFactoryHungRun) New(_ component.Options, _ cluster.Cluster, _ *slog.Logger, _ *operator.Arguments, _ string, _ labelstore.LabelStore, _ serviceMonitorSettings) crdManagerInterface {
 	return &crdManagerHungRun{m.running, m.contextCanceled, m.stopRun}
 }
 
@@ -56,6 +56,36 @@ func (c *crdManagerHungRun) DebugInfo() any {
 
 func (c *crdManagerHungRun) GetScrapeConfig(ns, name string) []*config.ScrapeConfig {
 	return nil
+}
+
+type testServiceMonitorArguments struct {
+	operator.Arguments
+	disallowArbitraryFileAccess bool
+}
+
+func (args testServiceMonitorArguments) OperatorArguments() operator.Arguments {
+	return args.Arguments
+}
+
+func (args testServiceMonitorArguments) ServiceMonitorDisallowArbitraryFileAccess() bool {
+	return args.disallowArbitraryFileAccess
+}
+
+func TestConvertArguments(t *testing.T) {
+	args := operator.DefaultArguments
+	cfg, settings, err := convertArguments(args)
+	require.NoError(t, err)
+	require.Equal(t, args, cfg)
+	require.True(t, settings.disallowArbitraryFileAccess)
+
+	serviceMonitorArgs := testServiceMonitorArguments{
+		Arguments:                   args,
+		disallowArbitraryFileAccess: false,
+	}
+	cfg, settings, err = convertArguments(serviceMonitorArgs)
+	require.NoError(t, err)
+	require.Equal(t, args, cfg)
+	require.False(t, settings.disallowArbitraryFileAccess)
 }
 
 func TestRunExit(t *testing.T) {

--- a/internal/component/prometheus/operator/common/component_test.go
+++ b/internal/component/prometheus/operator/common/component_test.go
@@ -58,7 +58,7 @@ func (c *crdManagerHungRun) GetScrapeConfig(ns, name string) []*config.ScrapeCon
 	return nil
 }
 
-func TestNewValidatesOptions(t *testing.T) {
+func TestValidation(t *testing.T) {
 	_, err := New(component.Options{}, operator.DefaultArguments, DefaultOptions(KindServiceMonitor))
 	require.ErrorContains(t, err, "serviceMonitor settings are required")
 

--- a/internal/component/prometheus/operator/common/component_test.go
+++ b/internal/component/prometheus/operator/common/component_test.go
@@ -29,7 +29,7 @@ type crdManagerFactoryHungRun struct {
 	stopRun         chan struct{}
 }
 
-func (m crdManagerFactoryHungRun) New(_ component.Options, _ cluster.Cluster, _ *slog.Logger, _ *operator.Arguments, _ string, _ labelstore.LabelStore, _ serviceMonitorSettings) crdManagerInterface {
+func (m crdManagerFactoryHungRun) New(_ component.Options, _ cluster.Cluster, _ *slog.Logger, _ *operator.Arguments, _ string, _ labelstore.LabelStore, _ *ServiceMonitorSettings) crdManagerInterface {
 	return &crdManagerHungRun{m.running, m.contextCanceled, m.stopRun}
 }
 
@@ -58,34 +58,18 @@ func (c *crdManagerHungRun) GetScrapeConfig(ns, name string) []*config.ScrapeCon
 	return nil
 }
 
-type testServiceMonitorArguments struct {
-	operator.Arguments
-	disallowArbitraryFileAccess bool
-}
+func TestNewValidatesOptions(t *testing.T) {
+	_, err := New(component.Options{}, operator.DefaultArguments, DefaultOptions(KindServiceMonitor))
+	require.ErrorContains(t, err, "serviceMonitor settings are required")
 
-func (args testServiceMonitorArguments) OperatorArguments() operator.Arguments {
-	return args.Arguments
-}
+	settings := DefaultServiceMonitorSettings
+	opts := DefaultOptions(KindProbe)
+	opts.ServiceMonitorSettings = &settings
 
-func (args testServiceMonitorArguments) ServiceMonitorDisallowArbitraryFileAccess() bool {
-	return args.disallowArbitraryFileAccess
-}
+	_, err = New(component.Options{}, operator.DefaultArguments, opts)
+	require.ErrorContains(t, err, "serviceMonitor settings are only supported")
 
-func TestConvertArguments(t *testing.T) {
-	args := operator.DefaultArguments
-	cfg, settings, err := convertArguments(args)
-	require.NoError(t, err)
-	require.Equal(t, args, cfg)
-	require.True(t, settings.disallowArbitraryFileAccess)
-
-	serviceMonitorArgs := testServiceMonitorArguments{
-		Arguments:                   args,
-		disallowArbitraryFileAccess: false,
-	}
-	cfg, settings, err = convertArguments(serviceMonitorArgs)
-	require.NoError(t, err)
-	require.Equal(t, args, cfg)
-	require.False(t, settings.disallowArbitraryFileAccess)
+	require.NoError(t, ServiceMonitorOptions(settings).Validate())
 }
 
 func TestRunExit(t *testing.T) {
@@ -119,7 +103,7 @@ func TestRunExit(t *testing.T) {
 	args.ForwardTo = nilReceivers
 
 	// Create a Component
-	c, err := New(opts, args, "")
+	c, err := New(opts, args, DefaultOptions(""))
 	require.NoError(t, err)
 
 	stopRun := make(chan struct{})
@@ -213,11 +197,11 @@ func TestExperimentalFeatures(t *testing.T) {
 			args.ForwardTo = nilReceivers
 			tc.setConfig(&args)
 
-			_, err := New(opts, args, "")
+			_, err := New(opts, args, DefaultOptions(""))
 			require.ErrorContains(t, err, tc.featureName, "component should return a feature gate error when stability level is StabilityGenerallyAvailable")
 
 			opts.MinStability = tc.minStability
-			_, err = New(opts, args, "")
+			_, err = New(opts, args, DefaultOptions(""))
 			require.NoErrorf(t, err, "component shouldn't return an error when stability level is %q", tc.minStability)
 		})
 	}

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -47,12 +47,12 @@ type crdManagerInterface interface {
 }
 
 type crdManagerFactory interface {
-	New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore, serviceMonitorSettings serviceMonitorSettings) crdManagerInterface
+	New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore, serviceMonitorSettings *ServiceMonitorSettings) crdManagerInterface
 }
 
 type realCrdManagerFactory struct{}
 
-func (realCrdManagerFactory) New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore, serviceMonitorSettings serviceMonitorSettings) crdManagerInterface {
+func (realCrdManagerFactory) New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore, serviceMonitorSettings *ServiceMonitorSettings) crdManagerInterface {
 	m := newCrdManager(opts, cluster, logger, args, kind, ls)
 	m.serviceMonitorSettings = serviceMonitorSettings
 	return m
@@ -122,7 +122,7 @@ type crdManager struct {
 	k8sFactory K8sFactory
 
 	kind                                      string
-	serviceMonitorSettings                    serviceMonitorSettings
+	serviceMonitorSettings                    *ServiceMonitorSettings
 	serviceMonitorArbitraryFileAccessWarnings map[string]string
 }
 
@@ -139,6 +139,12 @@ func newCrdManager(opts component.Options, cluster cluster.Cluster, logger *slog
 	default:
 		panic(fmt.Sprintf("Unknown kind for crdManager: %s", kind))
 	}
+	serviceMonitorSettings := (*ServiceMonitorSettings)(nil)
+	if kind == KindServiceMonitor {
+		settings := DefaultServiceMonitorSettings
+		serviceMonitorSettings = &settings
+	}
+
 	return &crdManager{
 		opts:                   opts,
 		logger:                 logger.With("kind", kind),
@@ -152,7 +158,7 @@ func newCrdManager(opts component.Options, cluster cluster.Cluster, logger *slog
 		clusteringUpdated:      make(chan struct{}, 1),
 		ls:                     ls,
 		k8sFactory:             defaultK8sFactory,
-		serviceMonitorSettings: defaultServiceMonitorSettings,
+		serviceMonitorSettings: serviceMonitorSettings,
 		serviceMonitorArbitraryFileAccessWarnings: map[string]string{},
 	}
 }
@@ -584,10 +590,15 @@ func (c *crdManager) onDeletePodMonitor(obj any) {
 
 func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 	var err error
+	serviceMonitorSettings := DefaultServiceMonitorSettings
+	if c.serviceMonitorSettings != nil {
+		serviceMonitorSettings = *c.serviceMonitorSettings
+	}
+
 	gen := configgen.ConfigGenerator{
 		Secrets:                     configgen.NewSecretManager(c.client),
 		Client:                      &c.args.Client,
-		DisallowArbitraryFileAccess: c.serviceMonitorSettings.disallowArbitraryFileAccess,
+		DisallowArbitraryFileAccess: serviceMonitorSettings.DisallowArbitraryFileAccess,
 		AdditionalRelabelConfigs:    c.args.RelabelConfigs,
 		ScrapeOptions:               c.args.Scrape,
 	}
@@ -634,7 +645,7 @@ func (c *crdManager) observeServiceMonitorArbitraryFileAccess(sm *promopv1.Servi
 		return
 	}
 
-	if !c.shouldLogServiceMonitorArbitraryFileAccessWarning(sm, endpointIndex, field) {
+	if !c.recordServiceMonitorArbitraryFileAccessWarning(sm, endpointIndex, field) {
 		return
 	}
 
@@ -648,7 +659,7 @@ func (c *crdManager) observeServiceMonitorArbitraryFileAccess(sm *promopv1.Servi
 	)
 }
 
-func (c *crdManager) shouldLogServiceMonitorArbitraryFileAccessWarning(sm *promopv1.ServiceMonitor, endpointIndex int, field string) bool {
+func (c *crdManager) recordServiceMonitorArbitraryFileAccessWarning(sm *promopv1.ServiceMonitor, endpointIndex int, field string) bool {
 	key := fmt.Sprintf("%s/%s/%d/%s", sm.Namespace, sm.Name, endpointIndex, field)
 
 	c.mut.Lock()

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -47,13 +47,15 @@ type crdManagerInterface interface {
 }
 
 type crdManagerFactory interface {
-	New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore) crdManagerInterface
+	New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore, serviceMonitorSettings serviceMonitorSettings) crdManagerInterface
 }
 
 type realCrdManagerFactory struct{}
 
-func (realCrdManagerFactory) New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore) crdManagerInterface {
-	return newCrdManager(opts, cluster, logger, args, kind, ls)
+func (realCrdManagerFactory) New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore, serviceMonitorSettings serviceMonitorSettings) crdManagerInterface {
+	m := newCrdManager(opts, cluster, logger, args, kind, ls)
+	m.serviceMonitorSettings = serviceMonitorSettings
+	return m
 }
 
 // CacheFactory creates controller-runtime caches with the given options.
@@ -119,7 +121,9 @@ type crdManager struct {
 	client     kubernetes.Interface
 	k8sFactory K8sFactory
 
-	kind string
+	kind                                      string
+	serviceMonitorSettings                    serviceMonitorSettings
+	serviceMonitorArbitraryFileAccessWarnings map[string]string
 }
 
 const (
@@ -136,18 +140,20 @@ func newCrdManager(opts component.Options, cluster cluster.Cluster, logger *slog
 		panic(fmt.Sprintf("Unknown kind for crdManager: %s", kind))
 	}
 	return &crdManager{
-		opts:              opts,
-		logger:            logger.With("kind", kind),
-		args:              args,
-		cluster:           cluster,
-		discoveryConfigs:  map[string]discovery.Configs{},
-		scrapeConfigs:     map[string]*config.ScrapeConfig{},
-		crdsToMapKeys:     map[string][]string{},
-		debugInfo:         map[string]*operator.DiscoveredResource{},
-		kind:              kind,
-		clusteringUpdated: make(chan struct{}, 1),
-		ls:                ls,
-		k8sFactory:        defaultK8sFactory,
+		opts:                   opts,
+		logger:                 logger.With("kind", kind),
+		args:                   args,
+		cluster:                cluster,
+		discoveryConfigs:       map[string]discovery.Configs{},
+		scrapeConfigs:          map[string]*config.ScrapeConfig{},
+		crdsToMapKeys:          map[string][]string{},
+		debugInfo:              map[string]*operator.DiscoveredResource{},
+		kind:                   kind,
+		clusteringUpdated:      make(chan struct{}, 1),
+		ls:                     ls,
+		k8sFactory:             defaultK8sFactory,
+		serviceMonitorSettings: defaultServiceMonitorSettings,
+		serviceMonitorArbitraryFileAccessWarnings: map[string]string{},
 	}
 }
 
@@ -581,7 +587,7 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 	gen := configgen.ConfigGenerator{
 		Secrets:                     configgen.NewSecretManager(c.client),
 		Client:                      &c.args.Client,
-		DisallowArbitraryFileAccess: c.args.DisallowArbitraryFileAccess,
+		DisallowArbitraryFileAccess: c.serviceMonitorSettings.disallowArbitraryFileAccess,
 		AdditionalRelabelConfigs:    c.args.RelabelConfigs,
 		ScrapeOptions:               c.args.Scrape,
 	}
@@ -628,6 +634,10 @@ func (c *crdManager) observeServiceMonitorArbitraryFileAccess(sm *promopv1.Servi
 		return
 	}
 
+	if !c.shouldLogServiceMonitorArbitraryFileAccessWarning(sm, endpointIndex, field) {
+		return
+	}
+
 	c.logger.Warn(
 		"serviceMonitor endpoint references an arbitrary file from Alloy's filesystem",
 		"namespace", sm.Namespace,
@@ -636,6 +646,18 @@ func (c *crdManager) observeServiceMonitorArbitraryFileAccess(sm *promopv1.Servi
 		"field", field,
 		"mitigation", "remove the file reference or set disallow_arbitrary_file_access to false to opt out",
 	)
+}
+
+func (c *crdManager) shouldLogServiceMonitorArbitraryFileAccessWarning(sm *promopv1.ServiceMonitor, endpointIndex int, field string) bool {
+	key := fmt.Sprintf("%s/%s/%d/%s", sm.Namespace, sm.Name, endpointIndex, field)
+
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	if lastResourceVersion, ok := c.serviceMonitorArbitraryFileAccessWarnings[key]; ok && lastResourceVersion == sm.ResourceVersion {
+		return false
+	}
+	c.serviceMonitorArbitraryFileAccessWarnings[key] = sm.ResourceVersion
+	return true
 }
 
 func (c *crdManager) onAddServiceMonitor(obj any) {
@@ -653,8 +675,21 @@ func (c *crdManager) onUpdateServiceMonitor(oldObj, newObj any) {
 func (c *crdManager) onDeleteServiceMonitor(obj any) {
 	pm := obj.(*promopv1.ServiceMonitor)
 	c.clearConfigs(pm.Namespace, pm.Name)
+	c.clearServiceMonitorArbitraryFileAccessWarnings(pm.Namespace, pm.Name)
 	if err := c.apply(); err != nil {
 		c.logger.Error("error applying scrape configs after deleting", "name", pm.Name, "err", err)
+	}
+}
+
+func (c *crdManager) clearServiceMonitorArbitraryFileAccessWarnings(namespace, name string) {
+	prefix := fmt.Sprintf("%s/%s/", namespace, name)
+
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	for key := range c.serviceMonitorArbitraryFileAccessWarnings {
+		if strings.HasPrefix(key, prefix) {
+			delete(c.serviceMonitorArbitraryFileAccessWarnings, key)
+		}
 	}
 }
 

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -617,7 +617,7 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 }
 
 func (c *crdManager) observeServiceMonitorArbitraryFileAccess(sm *promopv1.ServiceMonitor, endpointIndex int, ep promopv1.Endpoint) {
-	field := serviceMonitorEndpointArbitraryFileField(ep)
+	field := configgen.ServiceMonitorEndpointArbitraryFileField(ep)
 	if field == "" {
 		return
 	}
@@ -630,25 +630,6 @@ func (c *crdManager) observeServiceMonitorArbitraryFileAccess(sm *promopv1.Servi
 		"field", field,
 		"mitigation", "remove the file reference or set disallow_arbitrary_file_access to false to opt out",
 	)
-}
-
-func serviceMonitorEndpointArbitraryFileField(ep promopv1.Endpoint) string {
-	if ep.BearerTokenFile != "" { //nolint:staticcheck
-		return "bearerTokenFile"
-	}
-	if ep.TLSConfig == nil {
-		return ""
-	}
-	if ep.TLSConfig.CAFile != "" {
-		return "tlsConfig.caFile"
-	}
-	if ep.TLSConfig.CertFile != "" {
-		return "tlsConfig.certFile"
-	}
-	if ep.TLSConfig.KeyFile != "" {
-		return "tlsConfig.keyFile"
-	}
-	return ""
 }
 
 func (c *crdManager) onAddServiceMonitor(obj any) {

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -587,6 +587,8 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 	}
 
 	mapKeys := []string{}
+	discoveryConfigs := map[string]discovery.Configs{}
+	scrapeConfigs := map[string]*config.ScrapeConfig{}
 	for i, ep := range sm.Spec.Endpoints {
 		c.observeServiceMonitorArbitraryFileAccess(sm, i, ep)
 
@@ -598,16 +600,20 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 			break
 		}
 		mapKeys = append(mapKeys, scrapeConfig.JobName)
-		c.mut.Lock()
-		c.discoveryConfigs[scrapeConfig.JobName] = scrapeConfig.ServiceDiscoveryConfigs
-		c.scrapeConfigs[scrapeConfig.JobName] = scrapeConfig
-		c.mut.Unlock()
+		discoveryConfigs[scrapeConfig.JobName] = scrapeConfig.ServiceDiscoveryConfigs
+		scrapeConfigs[scrapeConfig.JobName] = scrapeConfig
 	}
 	if err != nil {
 		c.addDebugInfo(sm.Namespace, sm.Name, err)
 		return
 	}
 	c.mut.Lock()
+	for k, v := range discoveryConfigs {
+		c.discoveryConfigs[k] = v
+	}
+	for k, v := range scrapeConfigs {
+		c.scrapeConfigs[k] = v
+	}
 	c.crdsToMapKeys[fmt.Sprintf("%s/%s", sm.Namespace, sm.Name)] = mapKeys
 	c.mut.Unlock()
 	if err = c.apply(); err != nil {

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -596,11 +596,11 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 	}
 
 	gen := configgen.ConfigGenerator{
-		Secrets:                     configgen.NewSecretManager(c.client),
-		Client:                      &c.args.Client,
-		DisallowArbitraryFileAccess: serviceMonitorSettings.DisallowArbitraryFileAccess,
-		AdditionalRelabelConfigs:    c.args.RelabelConfigs,
-		ScrapeOptions:               c.args.Scrape,
+		Secrets:                  configgen.NewSecretManager(c.client),
+		Client:                   &c.args.Client,
+		AllowArbitraryFileAccess: serviceMonitorSettings.AllowArbitraryFileAccess,
+		AdditionalRelabelConfigs: c.args.RelabelConfigs,
+		ScrapeOptions:            c.args.Scrape,
 	}
 
 	for i, ep := range sm.Spec.Endpoints {
@@ -657,7 +657,7 @@ func (c *crdManager) observeServiceMonitorArbitraryFileAccess(sm *promopv1.Servi
 		"name", sm.Name,
 		"endpoint", endpointIndex,
 		"field", field,
-		"mitigation", "remove the file reference or set disallow_arbitrary_file_access to false to opt out",
+		"mitigation", "remove the file reference or set allow_arbitrary_file_access to true to opt out",
 	)
 }
 

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -139,10 +139,10 @@ func newCrdManager(opts component.Options, cluster cluster.Cluster, logger *slog
 	default:
 		panic(fmt.Sprintf("Unknown kind for crdManager: %s", kind))
 	}
-	serviceMonitorSettings := (*ServiceMonitorSettings)(nil)
+	defaultServiceMonitorSettings := (*ServiceMonitorSettings)(nil)
 	if kind == KindServiceMonitor {
 		settings := DefaultServiceMonitorSettings
-		serviceMonitorSettings = &settings
+		defaultServiceMonitorSettings = &settings
 	}
 
 	return &crdManager{
@@ -158,7 +158,7 @@ func newCrdManager(opts component.Options, cluster cluster.Cluster, logger *slog
 		clusteringUpdated:      make(chan struct{}, 1),
 		ls:                     ls,
 		k8sFactory:             defaultK8sFactory,
-		serviceMonitorSettings: serviceMonitorSettings,
+		serviceMonitorSettings: defaultServiceMonitorSettings,
 		serviceMonitorArbitraryFileAccessWarnings: map[string]string{},
 	}
 }

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -603,12 +603,14 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 		ScrapeOptions:               c.args.Scrape,
 	}
 
+	for i, ep := range sm.Spec.Endpoints {
+		c.observeServiceMonitorArbitraryFileAccess(sm, i, ep)
+	}
+
 	mapKeys := []string{}
 	discoveryConfigs := map[string]discovery.Configs{}
 	scrapeConfigs := map[string]*config.ScrapeConfig{}
 	for i, ep := range sm.Spec.Endpoints {
-		c.observeServiceMonitorArbitraryFileAccess(sm, i, ep)
-
 		var scrapeConfig *config.ScrapeConfig
 		scrapeConfig, err = gen.GenerateServiceMonitorConfig(sm, ep, i, promk8s.Role(c.args.KubernetesRole))
 		if err != nil {

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -579,14 +579,17 @@ func (c *crdManager) onDeletePodMonitor(obj any) {
 func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 	var err error
 	gen := configgen.ConfigGenerator{
-		Secrets:                  configgen.NewSecretManager(c.client),
-		Client:                   &c.args.Client,
-		AdditionalRelabelConfigs: c.args.RelabelConfigs,
-		ScrapeOptions:            c.args.Scrape,
+		Secrets:                     configgen.NewSecretManager(c.client),
+		Client:                      &c.args.Client,
+		DisallowArbitraryFileAccess: c.args.DisallowArbitraryFileAccess,
+		AdditionalRelabelConfigs:    c.args.RelabelConfigs,
+		ScrapeOptions:               c.args.Scrape,
 	}
 
 	mapKeys := []string{}
 	for i, ep := range sm.Spec.Endpoints {
+		c.observeServiceMonitorArbitraryFileAccess(sm, i, ep)
+
 		var scrapeConfig *config.ScrapeConfig
 		scrapeConfig, err = gen.GenerateServiceMonitorConfig(sm, ep, i, promk8s.Role(c.args.KubernetesRole))
 		if err != nil {
@@ -611,6 +614,41 @@ func (c *crdManager) addServiceMonitor(sm *promopv1.ServiceMonitor) {
 		c.logger.Error("error applying scrape configs", "name", sm.Name, "err", err)
 	}
 	c.addDebugInfo(sm.Namespace, sm.Name, err)
+}
+
+func (c *crdManager) observeServiceMonitorArbitraryFileAccess(sm *promopv1.ServiceMonitor, endpointIndex int, ep promopv1.Endpoint) {
+	field := serviceMonitorEndpointArbitraryFileField(ep)
+	if field == "" {
+		return
+	}
+
+	c.logger.Warn(
+		"serviceMonitor endpoint references an arbitrary file from Alloy's filesystem",
+		"namespace", sm.Namespace,
+		"name", sm.Name,
+		"endpoint", endpointIndex,
+		"field", field,
+		"mitigation", "remove the file reference or set disallow_arbitrary_file_access to false to opt out",
+	)
+}
+
+func serviceMonitorEndpointArbitraryFileField(ep promopv1.Endpoint) string {
+	if ep.BearerTokenFile != "" { //nolint:staticcheck
+		return "bearerTokenFile"
+	}
+	if ep.TLSConfig == nil {
+		return ""
+	}
+	if ep.TLSConfig.CAFile != "" {
+		return "tlsConfig.caFile"
+	}
+	if ep.TLSConfig.CertFile != "" {
+		return "tlsConfig.certFile"
+	}
+	if ep.TLSConfig.KeyFile != "" {
+		return "tlsConfig.keyFile"
+	}
+	return ""
 }
 
 func (c *crdManager) onAddServiceMonitor(obj any) {

--- a/internal/component/prometheus/operator/common/crdmanager_test.go
+++ b/internal/component/prometheus/operator/common/crdmanager_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"golang.org/x/exp/maps"
@@ -115,8 +116,8 @@ func TestAddServiceMonitorArbitraryFileAccessWarning(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&logs, nil))
 	reg := prometheus.NewRegistry()
 	args := operator.DefaultArguments
-	args.DisallowArbitraryFileAccess = false
 	m := newTestCrdManager(t, logger, &args, KindServiceMonitor, reg)
+	m.serviceMonitorSettings.disallowArbitraryFileAccess = false
 
 	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -144,6 +145,38 @@ func TestAddServiceMonitorArbitraryFileAccessWarning(t *testing.T) {
 	require.Contains(t, logs.String(), "field=bearerTokenFile")
 	require.Contains(t, logs.String(), "endpoint=1")
 	require.Contains(t, logs.String(), "field=tlsConfig.caFile")
+}
+
+func TestAddServiceMonitorArbitraryFileAccessWarningDeduplicatesResourceVersion(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	args := operator.DefaultArguments
+	m := newTestCrdManager(t, logger, &args, KindServiceMonitor, prometheus.NewRegistry())
+	m.serviceMonitorSettings.disallowArbitraryFileAccess = false
+
+	sm := &promopv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "monitoring",
+			Name:            "svcmonitor",
+			ResourceVersion: "1",
+		},
+		Spec: promopv1.ServiceMonitorSpec{
+			Endpoints: []promopv1.Endpoint{
+				{BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"}, //nolint:staticcheck
+			},
+		},
+	}
+
+	m.onAddServiceMonitor(sm)
+	m.onAddServiceMonitor(sm)
+
+	require.Equal(t, 1, strings.Count(logs.String(), "field=bearerTokenFile"))
+
+	updated := sm.DeepCopy()
+	updated.ResourceVersion = "2"
+	m.onUpdateServiceMonitor(sm, updated)
+
+	require.Equal(t, 2, strings.Count(logs.String(), "field=bearerTokenFile"))
 }
 
 func TestAddServiceMonitorDisallowArbitraryFileAccessThreadsThrough(t *testing.T) {

--- a/internal/component/prometheus/operator/common/crdmanager_test.go
+++ b/internal/component/prometheus/operator/common/crdmanager_test.go
@@ -169,6 +169,33 @@ func TestAddServiceMonitorDisallowArbitraryFileAccessThreadsThrough(t *testing.T
 	require.Contains(t, debugInfo.ReconcileError, "disallowed by disallow_arbitrary_file_access")
 }
 
+func TestAddServiceMonitorDoesNotStorePartialConfigsOnError(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	args := operator.DefaultArguments
+	m := newTestCrdManager(t, logger, &args, KindServiceMonitor, prometheus.NewRegistry())
+
+	targetPort := intstr.FromInt(9090)
+	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "monitoring",
+			Name:      "svcmonitor",
+		},
+		Spec: promopv1.ServiceMonitorSpec{
+			Endpoints: []promopv1.Endpoint{
+				{TargetPort: &targetPort},
+				{BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"}, //nolint:staticcheck
+			},
+		},
+	})
+
+	require.Empty(t, m.discoveryConfigs)
+	require.Empty(t, m.scrapeConfigs)
+	require.Empty(t, m.crdsToMapKeys)
+	debugInfo := m.debugInfo["serviceMonitor/monitoring/svcmonitor"]
+	require.NotNil(t, debugInfo)
+	require.Contains(t, debugInfo.ReconcileError, "disallowed by disallow_arbitrary_file_access")
+}
+
 func TestClearConfigsProbe(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	m := newCrdManager(

--- a/internal/component/prometheus/operator/common/crdmanager_test.go
+++ b/internal/component/prometheus/operator/common/crdmanager_test.go
@@ -117,7 +117,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarning(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	args := operator.DefaultArguments
 	m := newTestCrdManager(t, logger, &args, reg)
-	m.serviceMonitorSettings.disallowArbitraryFileAccess = false
+	m.serviceMonitorSettings.DisallowArbitraryFileAccess = false
 
 	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -152,7 +152,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarningDeduplicatesResourceVersion(
 	logger := slog.New(slog.NewTextHandler(&logs, nil))
 	args := operator.DefaultArguments
 	m := newTestCrdManager(t, logger, &args, prometheus.NewRegistry())
-	m.serviceMonitorSettings.disallowArbitraryFileAccess = false
+	m.serviceMonitorSettings.DisallowArbitraryFileAccess = false
 
 	sm := &promopv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/component/prometheus/operator/common/crdmanager_test.go
+++ b/internal/component/prometheus/operator/common/crdmanager_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"log/slog"
 	"testing"
 
@@ -23,6 +24,26 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func newTestCrdManager(t *testing.T, logger *slog.Logger, args *operator.Arguments, kind string, reg prometheus.Registerer) *crdManager {
+	t.Helper()
+
+	m := newCrdManager(
+		component.Options{
+			Logger:         logger,
+			Registerer:     reg,
+			GetServiceData: func(name string) (any, error) { return nil, nil },
+		},
+		cluster.Mock(),
+		logger,
+		args,
+		kind,
+		labelstore.New(logger, prometheus.NewRegistry()),
+	)
+	m.discoveryManager = newMockDiscoveryManager()
+	m.scrapeManager = newMockScrapeManager()
+	return m
+}
 
 func TestClearConfigsSameNsSamePrefix(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
@@ -87,6 +108,65 @@ func TestClearConfigsSameNsSamePrefix(t *testing.T) {
 	require.ElementsMatch(t, []string{"monitoring/svcmonitor", "monitoring/svcmonitor-another"}, maps.Keys(m.crdsToMapKeys))
 	require.ElementsMatch(t, []string{"serviceMonitor/monitoring/svcmonitor-another/0"}, maps.Keys(m.discoveryConfigs))
 	require.ElementsMatch(t, []string{"serviceMonitor/monitoring/svcmonitor-another"}, maps.Keys(m.debugInfo))
+}
+
+func TestAddServiceMonitorArbitraryFileAccessWarning(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	reg := prometheus.NewRegistry()
+	args := operator.DefaultArguments
+	args.DisallowArbitraryFileAccess = false
+	m := newTestCrdManager(t, logger, &args, KindServiceMonitor, reg)
+
+	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "monitoring",
+			Name:      "svcmonitor",
+		},
+		Spec: promopv1.ServiceMonitorSpec{
+			Endpoints: []promopv1.Endpoint{
+				{BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"}, //nolint:staticcheck
+				{
+					HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
+						HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
+							TLSConfig: &promopv1.TLSConfig{
+								TLSFilesConfig: promopv1.TLSFilesConfig{CAFile: "/etc/prometheus/ca.crt"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Contains(t, logs.String(), "serviceMonitor endpoint references an arbitrary file")
+	require.Contains(t, logs.String(), "endpoint=0")
+	require.Contains(t, logs.String(), "field=bearerTokenFile")
+	require.Contains(t, logs.String(), "endpoint=1")
+	require.Contains(t, logs.String(), "field=tlsConfig.caFile")
+}
+
+func TestAddServiceMonitorDisallowArbitraryFileAccessThreadsThrough(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	args := operator.DefaultArguments
+	m := newTestCrdManager(t, logger, &args, KindServiceMonitor, prometheus.NewRegistry())
+
+	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "monitoring",
+			Name:      "svcmonitor",
+		},
+		Spec: promopv1.ServiceMonitorSpec{
+			Endpoints: []promopv1.Endpoint{
+				{BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"}, //nolint:staticcheck
+			},
+		},
+	})
+
+	require.Empty(t, m.scrapeConfigs)
+	debugInfo := m.debugInfo["serviceMonitor/monitoring/svcmonitor"]
+	require.NotNil(t, debugInfo)
+	require.Contains(t, debugInfo.ReconcileError, "disallowed by disallow_arbitrary_file_access")
 }
 
 func TestClearConfigsProbe(t *testing.T) {

--- a/internal/component/prometheus/operator/common/crdmanager_test.go
+++ b/internal/component/prometheus/operator/common/crdmanager_test.go
@@ -117,7 +117,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarning(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	args := operator.DefaultArguments
 	m := newTestCrdManager(t, logger, &args, reg)
-	m.serviceMonitorSettings.DisallowArbitraryFileAccess = false
+	m.serviceMonitorSettings.AllowArbitraryFileAccess = true
 
 	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -153,7 +153,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarningLogsAllEndpointsWhenDisallow
 	reg := prometheus.NewRegistry()
 	args := operator.DefaultArguments
 	m := newTestCrdManager(t, logger, &args, reg)
-	m.serviceMonitorSettings.DisallowArbitraryFileAccess = true
+	m.serviceMonitorSettings.AllowArbitraryFileAccess = false
 
 	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -184,7 +184,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarningLogsAllEndpointsWhenDisallow
 
 	debugInfo := m.debugInfo["serviceMonitor/monitoring/svcmonitor"]
 	require.NotNil(t, debugInfo)
-	require.Contains(t, debugInfo.ReconcileError, "disallowed by disallow_arbitrary_file_access")
+	require.Contains(t, debugInfo.ReconcileError, "disallowed because allow_arbitrary_file_access is false")
 	require.Empty(t, m.scrapeConfigs)
 }
 
@@ -193,7 +193,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarningDeduplicatesResourceVersion(
 	logger := slog.New(slog.NewTextHandler(&logs, nil))
 	args := operator.DefaultArguments
 	m := newTestCrdManager(t, logger, &args, prometheus.NewRegistry())
-	m.serviceMonitorSettings.DisallowArbitraryFileAccess = false
+	m.serviceMonitorSettings.AllowArbitraryFileAccess = true
 
 	sm := &promopv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -220,7 +220,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarningDeduplicatesResourceVersion(
 	require.Equal(t, 2, strings.Count(logs.String(), "field=bearerTokenFile"))
 }
 
-func TestAddServiceMonitorDisallowArbitraryFileAccessThreadsThrough(t *testing.T) {
+func TestAddServiceMonitorAllowArbitraryFileAccessThreadsThrough(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	args := operator.DefaultArguments
 	m := newTestCrdManager(t, logger, &args, prometheus.NewRegistry())
@@ -240,7 +240,7 @@ func TestAddServiceMonitorDisallowArbitraryFileAccessThreadsThrough(t *testing.T
 	require.Empty(t, m.scrapeConfigs)
 	debugInfo := m.debugInfo["serviceMonitor/monitoring/svcmonitor"]
 	require.NotNil(t, debugInfo)
-	require.Contains(t, debugInfo.ReconcileError, "disallowed by disallow_arbitrary_file_access")
+	require.Contains(t, debugInfo.ReconcileError, "disallowed because allow_arbitrary_file_access is false")
 }
 
 func TestAddServiceMonitorDoesNotStorePartialConfigsOnError(t *testing.T) {
@@ -267,7 +267,7 @@ func TestAddServiceMonitorDoesNotStorePartialConfigsOnError(t *testing.T) {
 	require.Empty(t, m.crdsToMapKeys)
 	debugInfo := m.debugInfo["serviceMonitor/monitoring/svcmonitor"]
 	require.NotNil(t, debugInfo)
-	require.Contains(t, debugInfo.ReconcileError, "disallowed by disallow_arbitrary_file_access")
+	require.Contains(t, debugInfo.ReconcileError, "disallowed because allow_arbitrary_file_access is false")
 }
 
 func TestClearConfigsProbe(t *testing.T) {

--- a/internal/component/prometheus/operator/common/crdmanager_test.go
+++ b/internal/component/prometheus/operator/common/crdmanager_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestCrdManager(t *testing.T, logger *slog.Logger, args *operator.Arguments, kind string, reg prometheus.Registerer) *crdManager {
+func newTestCrdManager(t *testing.T, logger *slog.Logger, args *operator.Arguments, reg prometheus.Registerer) *crdManager {
 	t.Helper()
 
 	m := newCrdManager(
@@ -38,7 +38,7 @@ func newTestCrdManager(t *testing.T, logger *slog.Logger, args *operator.Argumen
 		cluster.Mock(),
 		logger,
 		args,
-		kind,
+		KindServiceMonitor,
 		labelstore.New(logger, prometheus.NewRegistry()),
 	)
 	m.discoveryManager = newMockDiscoveryManager()
@@ -116,7 +116,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarning(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&logs, nil))
 	reg := prometheus.NewRegistry()
 	args := operator.DefaultArguments
-	m := newTestCrdManager(t, logger, &args, KindServiceMonitor, reg)
+	m := newTestCrdManager(t, logger, &args, reg)
 	m.serviceMonitorSettings.disallowArbitraryFileAccess = false
 
 	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
@@ -151,7 +151,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarningDeduplicatesResourceVersion(
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, nil))
 	args := operator.DefaultArguments
-	m := newTestCrdManager(t, logger, &args, KindServiceMonitor, prometheus.NewRegistry())
+	m := newTestCrdManager(t, logger, &args, prometheus.NewRegistry())
 	m.serviceMonitorSettings.disallowArbitraryFileAccess = false
 
 	sm := &promopv1.ServiceMonitor{
@@ -182,7 +182,7 @@ func TestAddServiceMonitorArbitraryFileAccessWarningDeduplicatesResourceVersion(
 func TestAddServiceMonitorDisallowArbitraryFileAccessThreadsThrough(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	args := operator.DefaultArguments
-	m := newTestCrdManager(t, logger, &args, KindServiceMonitor, prometheus.NewRegistry())
+	m := newTestCrdManager(t, logger, &args, prometheus.NewRegistry())
 
 	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -205,7 +205,7 @@ func TestAddServiceMonitorDisallowArbitraryFileAccessThreadsThrough(t *testing.T
 func TestAddServiceMonitorDoesNotStorePartialConfigsOnError(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	args := operator.DefaultArguments
-	m := newTestCrdManager(t, logger, &args, KindServiceMonitor, prometheus.NewRegistry())
+	m := newTestCrdManager(t, logger, &args, prometheus.NewRegistry())
 
 	targetPort := intstr.FromInt(9090)
 	m.onAddServiceMonitor(&promopv1.ServiceMonitor{

--- a/internal/component/prometheus/operator/common/crdmanager_test.go
+++ b/internal/component/prometheus/operator/common/crdmanager_test.go
@@ -147,6 +147,47 @@ func TestAddServiceMonitorArbitraryFileAccessWarning(t *testing.T) {
 	require.Contains(t, logs.String(), "field=tlsConfig.caFile")
 }
 
+func TestAddServiceMonitorArbitraryFileAccessWarningLogsAllEndpointsWhenDisallowed(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	reg := prometheus.NewRegistry()
+	args := operator.DefaultArguments
+	m := newTestCrdManager(t, logger, &args, reg)
+	m.serviceMonitorSettings.DisallowArbitraryFileAccess = true
+
+	m.onAddServiceMonitor(&promopv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "monitoring",
+			Name:      "svcmonitor",
+		},
+		Spec: promopv1.ServiceMonitorSpec{
+			Endpoints: []promopv1.Endpoint{
+				{BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"}, //nolint:staticcheck
+				{
+					HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
+						HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
+							TLSConfig: &promopv1.TLSConfig{
+								TLSFilesConfig: promopv1.TLSFilesConfig{CAFile: "/etc/prometheus/ca.crt"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// Generation rejects and breaks at endpoint 0, but both endpoints should still have been observed.
+	require.Contains(t, logs.String(), "endpoint=0")
+	require.Contains(t, logs.String(), "field=bearerTokenFile")
+	require.Contains(t, logs.String(), "endpoint=1")
+	require.Contains(t, logs.String(), "field=tlsConfig.caFile")
+
+	debugInfo := m.debugInfo["serviceMonitor/monitoring/svcmonitor"]
+	require.NotNil(t, debugInfo)
+	require.Contains(t, debugInfo.ReconcileError, "disallowed by disallow_arbitrary_file_access")
+	require.Empty(t, m.scrapeConfigs)
+}
+
 func TestAddServiceMonitorArbitraryFileAccessWarningDeduplicatesResourceVersion(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, nil))

--- a/internal/component/prometheus/operator/common/testing.go
+++ b/internal/component/prometheus/operator/common/testing.go
@@ -230,8 +230,9 @@ type TestCrdManagerFactory struct {
 }
 
 // New implements crdManagerFactory.
-func (f *TestCrdManagerFactory) New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore) crdManagerInterface {
+func (f *TestCrdManagerFactory) New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore, serviceMonitorSettings serviceMonitorSettings) crdManagerInterface {
 	m := newCrdManager(opts, cluster, logger, args, kind, ls)
+	m.serviceMonitorSettings = serviceMonitorSettings
 
 	// Create and inject the FakeK8sFactory
 	f.mu.Lock()

--- a/internal/component/prometheus/operator/common/testing.go
+++ b/internal/component/prometheus/operator/common/testing.go
@@ -230,7 +230,7 @@ type TestCrdManagerFactory struct {
 }
 
 // New implements crdManagerFactory.
-func (f *TestCrdManagerFactory) New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore, serviceMonitorSettings serviceMonitorSettings) crdManagerInterface {
+func (f *TestCrdManagerFactory) New(opts component.Options, cluster cluster.Cluster, logger *slog.Logger, args *operator.Arguments, kind string, ls labelstore.LabelStore, serviceMonitorSettings *ServiceMonitorSettings) crdManagerInterface {
 	m := newCrdManager(opts, cluster, logger, args, kind, ls)
 	m.serviceMonitorSettings = serviceMonitorSettings
 

--- a/internal/component/prometheus/operator/configgen/config_gen.go
+++ b/internal/component/prometheus/operator/configgen/config_gen.go
@@ -21,8 +21,10 @@ import (
 )
 
 type ConfigGenerator struct {
-	Client                   *k8sConfig.ClientArguments
-	Secrets                  SecretFetcher
+	Client                      *k8sConfig.ClientArguments
+	Secrets                     SecretFetcher
+	DisallowArbitraryFileAccess bool
+
 	AdditionalRelabelConfigs []*alloy_relabel.Config
 	ScrapeOptions            operator.ScrapeOptions
 }

--- a/internal/component/prometheus/operator/configgen/config_gen.go
+++ b/internal/component/prometheus/operator/configgen/config_gen.go
@@ -21,9 +21,9 @@ import (
 )
 
 type ConfigGenerator struct {
-	Client                      *k8sConfig.ClientArguments
-	Secrets                     SecretFetcher
-	DisallowArbitraryFileAccess bool
+	Client                   *k8sConfig.ClientArguments
+	Secrets                  SecretFetcher
+	AllowArbitraryFileAccess bool
 
 	AdditionalRelabelConfigs []*alloy_relabel.Config
 	ScrapeOptions            operator.ScrapeOptions

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
@@ -21,6 +21,12 @@ func (cg *ConfigGenerator) GenerateServiceMonitorConfig(m *promopv1.ServiceMonit
 	cfg = cg.generateDefaultScrapeConfig()
 
 	cfg.JobName = fmt.Sprintf("serviceMonitor/%s/%s/%d", m.Namespace, m.Name, i)
+	if cg.DisallowArbitraryFileAccess {
+		if field := serviceMonitorEndpointArbitraryFileField(ep); field != "" {
+			return nil, fmt.Errorf("serviceMonitor %s/%s endpoint %d uses %s, which is disallowed by disallow_arbitrary_file_access; use secret or authorization fields instead", m.Namespace, m.Name, i, field)
+		}
+	}
+
 	cfg.HonorLabels = ep.HonorLabels
 	if ep.HonorTimestamps != nil {
 		cfg.HonorTimestamps = *ep.HonorTimestamps
@@ -323,4 +329,23 @@ func (cg *ConfigGenerator) GenerateServiceMonitorConfig(m *promopv1.ServiceMonit
 	}
 
 	return cfg, cfg.Validate(cg.ScrapeOptions.GlobalConfig())
+}
+
+func serviceMonitorEndpointArbitraryFileField(ep promopv1.Endpoint) string {
+	if ep.BearerTokenFile != "" { //nolint:staticcheck
+		return "bearerTokenFile"
+	}
+	if ep.TLSConfig == nil {
+		return ""
+	}
+	if ep.TLSConfig.CAFile != "" {
+		return "tlsConfig.caFile"
+	}
+	if ep.TLSConfig.CertFile != "" {
+		return "tlsConfig.certFile"
+	}
+	if ep.TLSConfig.KeyFile != "" {
+		return "tlsConfig.keyFile"
+	}
+	return ""
 }

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
@@ -22,7 +22,7 @@ func (cg *ConfigGenerator) GenerateServiceMonitorConfig(m *promopv1.ServiceMonit
 
 	cfg.JobName = fmt.Sprintf("serviceMonitor/%s/%s/%d", m.Namespace, m.Name, i)
 	if cg.DisallowArbitraryFileAccess {
-		if field := serviceMonitorEndpointArbitraryFileField(ep); field != "" {
+		if field := ServiceMonitorEndpointArbitraryFileField(ep); field != "" {
 			return nil, fmt.Errorf("serviceMonitor %s/%s endpoint %d uses %s, which is disallowed by disallow_arbitrary_file_access; use secret or authorization fields instead", m.Namespace, m.Name, i, field)
 		}
 	}
@@ -331,7 +331,8 @@ func (cg *ConfigGenerator) GenerateServiceMonitorConfig(m *promopv1.ServiceMonit
 	return cfg, cfg.Validate(cg.ScrapeOptions.GlobalConfig())
 }
 
-func serviceMonitorEndpointArbitraryFileField(ep promopv1.Endpoint) string {
+// ServiceMonitorEndpointArbitraryFileField returns the first arbitrary file field set on a ServiceMonitor endpoint.
+func ServiceMonitorEndpointArbitraryFileField(ep promopv1.Endpoint) string {
 	if ep.BearerTokenFile != "" { //nolint:staticcheck
 		return "bearerTokenFile"
 	}

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
@@ -23,7 +23,7 @@ func (cg *ConfigGenerator) GenerateServiceMonitorConfig(m *promopv1.ServiceMonit
 	cfg.JobName = fmt.Sprintf("serviceMonitor/%s/%s/%d", m.Namespace, m.Name, i)
 	if !cg.AllowArbitraryFileAccess {
 		if field := ServiceMonitorEndpointArbitraryFileField(ep); field != "" {
-			return nil, fmt.Errorf("serviceMonitor %s/%s endpoint %d uses %s, which is disallowed because allow_arbitrary_file_access is false; use secret or authorization fields instead", m.Namespace, m.Name, i, field)
+			return nil, fmt.Errorf("serviceMonitor %s/%s endpoint %d uses %s, which is disallowed because allow_arbitrary_file_access is false; use %s instead", m.Namespace, m.Name, i, field, arbitraryFileFieldReplacement(field))
 		}
 	}
 
@@ -349,4 +349,21 @@ func ServiceMonitorEndpointArbitraryFileField(ep promopv1.Endpoint) string {
 		return "tlsConfig.keyFile"
 	}
 	return ""
+}
+
+// arbitraryFileFieldReplacement returns the ServiceMonitor field that should be used instead
+// of the given arbitrary file field returned by ServiceMonitorEndpointArbitraryFileField.
+func arbitraryFileFieldReplacement(field string) string {
+	switch field {
+	case "bearerTokenFile":
+		return "bearerTokenSecret or authorization"
+	case "tlsConfig.caFile":
+		return "tlsConfig.ca"
+	case "tlsConfig.certFile":
+		return "tlsConfig.cert"
+	case "tlsConfig.keyFile":
+		return "tlsConfig.keySecret"
+	default:
+		return "secret or authorization fields"
+	}
 }

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor.go
@@ -21,9 +21,9 @@ func (cg *ConfigGenerator) GenerateServiceMonitorConfig(m *promopv1.ServiceMonit
 	cfg = cg.generateDefaultScrapeConfig()
 
 	cfg.JobName = fmt.Sprintf("serviceMonitor/%s/%s/%d", m.Namespace, m.Name, i)
-	if cg.DisallowArbitraryFileAccess {
+	if !cg.AllowArbitraryFileAccess {
 		if field := ServiceMonitorEndpointArbitraryFileField(ep); field != "" {
-			return nil, fmt.Errorf("serviceMonitor %s/%s endpoint %d uses %s, which is disallowed by disallow_arbitrary_file_access; use secret or authorization fields instead", m.Namespace, m.Name, i, field)
+			return nil, fmt.Errorf("serviceMonitor %s/%s endpoint %d uses %s, which is disallowed because allow_arbitrary_file_access is false; use secret or authorization fields instead", m.Namespace, m.Name, i, field)
 		}
 	}
 

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
@@ -682,22 +682,24 @@ func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                        string
-		disallowArbitraryFileAccess bool
-		ep                          promopv1.Endpoint
-		expectedBearerTokenFile     string
-		expectedTLSConfig           commonConfig.TLSConfig
-		expectedErr                 string
+		name                     string
+		allowArbitraryFileAccess bool
+		ep                       promopv1.Endpoint
+		expectedBearerTokenFile  string
+		expectedTLSConfig        commonConfig.TLSConfig
+		expectedErr              string
 	}{
 		{
-			name: "flag off honors bearer token file",
+			name:                     "flag on honors bearer token file",
+			allowArbitraryFileAccess: true,
 			ep: promopv1.Endpoint{
 				BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token", //nolint:staticcheck
 			},
 			expectedBearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 		},
 		{
-			name: "flag off honors tls file fields",
+			name:                     "flag on honors tls file fields",
+			allowArbitraryFileAccess: true,
 			ep: promopv1.Endpoint{
 				HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
 					HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
@@ -718,16 +720,14 @@ func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
 			},
 		},
 		{
-			name:                        "flag on rejects bearer token file",
-			disallowArbitraryFileAccess: true,
+			name: "flag off rejects bearer token file",
 			ep: promopv1.Endpoint{
 				BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token", //nolint:staticcheck
 			},
-			expectedErr: "bearerTokenFile, which is disallowed by disallow_arbitrary_file_access",
+			expectedErr: "bearerTokenFile, which is disallowed because allow_arbitrary_file_access is false",
 		},
 		{
-			name:                        "flag on rejects tls ca file",
-			disallowArbitraryFileAccess: true,
+			name: "flag off rejects tls ca file",
 			ep: promopv1.Endpoint{
 				HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
 					HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
@@ -737,11 +737,10 @@ func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "tlsConfig.caFile, which is disallowed by disallow_arbitrary_file_access",
+			expectedErr: "tlsConfig.caFile, which is disallowed because allow_arbitrary_file_access is false",
 		},
 		{
-			name:                        "flag on rejects tls cert file",
-			disallowArbitraryFileAccess: true,
+			name: "flag off rejects tls cert file",
 			ep: promopv1.Endpoint{
 				HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
 					HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
@@ -751,11 +750,10 @@ func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "tlsConfig.certFile, which is disallowed by disallow_arbitrary_file_access",
+			expectedErr: "tlsConfig.certFile, which is disallowed because allow_arbitrary_file_access is false",
 		},
 		{
-			name:                        "flag on rejects tls key file",
-			disallowArbitraryFileAccess: true,
+			name: "flag off rejects tls key file",
 			ep: promopv1.Endpoint{
 				HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
 					HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
@@ -765,20 +763,19 @@ func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "tlsConfig.keyFile, which is disallowed by disallow_arbitrary_file_access",
+			expectedErr: "tlsConfig.keyFile, which is disallowed because allow_arbitrary_file_access is false",
 		},
 		{
-			name:                        "flag on allows endpoints without file fields",
-			disallowArbitraryFileAccess: true,
-			ep:                          promopv1.Endpoint{},
+			name: "flag off allows endpoints without file fields",
+			ep:   promopv1.Endpoint{},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cg := &ConfigGenerator{
-				Client:                      &kubernetes.ClientArguments{},
-				DisallowArbitraryFileAccess: tc.disallowArbitraryFileAccess,
+				Client:                   &kubernetes.ClientArguments{},
+				AllowArbitraryFileAccess: tc.allowArbitraryFileAccess,
 			}
 
 			cfg, err := cg.GenerateServiceMonitorConfig(serviceMonitor, tc.ep, 0, promk8s.RoleEndpoint)

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
@@ -724,7 +724,7 @@ func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
 			ep: promopv1.Endpoint{
 				BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token", //nolint:staticcheck
 			},
-			expectedErr: "bearerTokenFile, which is disallowed because allow_arbitrary_file_access is false",
+			expectedErr: "bearerTokenFile, which is disallowed because allow_arbitrary_file_access is false; use bearerTokenSecret or authorization instead",
 		},
 		{
 			name: "flag off rejects tls ca file",
@@ -737,7 +737,7 @@ func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "tlsConfig.caFile, which is disallowed because allow_arbitrary_file_access is false",
+			expectedErr: "tlsConfig.caFile, which is disallowed because allow_arbitrary_file_access is false; use tlsConfig.ca instead",
 		},
 		{
 			name: "flag off rejects tls cert file",
@@ -750,7 +750,7 @@ func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "tlsConfig.certFile, which is disallowed because allow_arbitrary_file_access is false",
+			expectedErr: "tlsConfig.certFile, which is disallowed because allow_arbitrary_file_access is false; use tlsConfig.cert instead",
 		},
 		{
 			name: "flag off rejects tls key file",
@@ -763,7 +763,7 @@ func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "tlsConfig.keyFile, which is disallowed because allow_arbitrary_file_access is false",
+			expectedErr: "tlsConfig.keyFile, which is disallowed because allow_arbitrary_file_access is false; use tlsConfig.keySecret instead",
 		},
 		{
 			name: "flag off allows endpoints without file fields",

--- a/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
+++ b/internal/component/prometheus/operator/configgen/config_gen_servicemonitor_test.go
@@ -672,3 +672,124 @@ func TestGenerateServiceMonitorConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateServiceMonitorConfigArbitraryFileAccess(t *testing.T) {
+	serviceMonitor := &promopv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "operator",
+			Name:      "svcmonitor",
+		},
+	}
+
+	tests := []struct {
+		name                        string
+		disallowArbitraryFileAccess bool
+		ep                          promopv1.Endpoint
+		expectedBearerTokenFile     string
+		expectedTLSConfig           commonConfig.TLSConfig
+		expectedErr                 string
+	}{
+		{
+			name: "flag off honors bearer token file",
+			ep: promopv1.Endpoint{
+				BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token", //nolint:staticcheck
+			},
+			expectedBearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		},
+		{
+			name: "flag off honors tls file fields",
+			ep: promopv1.Endpoint{
+				HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
+					HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
+						TLSConfig: &promopv1.TLSConfig{
+							TLSFilesConfig: promopv1.TLSFilesConfig{
+								CAFile:   "/etc/prometheus/ca.crt",
+								CertFile: "/etc/prometheus/client.crt",
+								KeyFile:  "/etc/prometheus/client.key",
+							},
+						},
+					},
+				},
+			},
+			expectedTLSConfig: commonConfig.TLSConfig{
+				CAFile:   "/etc/prometheus/ca.crt",
+				CertFile: "/etc/prometheus/client.crt",
+				KeyFile:  "/etc/prometheus/client.key",
+			},
+		},
+		{
+			name:                        "flag on rejects bearer token file",
+			disallowArbitraryFileAccess: true,
+			ep: promopv1.Endpoint{
+				BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token", //nolint:staticcheck
+			},
+			expectedErr: "bearerTokenFile, which is disallowed by disallow_arbitrary_file_access",
+		},
+		{
+			name:                        "flag on rejects tls ca file",
+			disallowArbitraryFileAccess: true,
+			ep: promopv1.Endpoint{
+				HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
+					HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
+						TLSConfig: &promopv1.TLSConfig{
+							TLSFilesConfig: promopv1.TLSFilesConfig{CAFile: "/etc/prometheus/ca.crt"},
+						},
+					},
+				},
+			},
+			expectedErr: "tlsConfig.caFile, which is disallowed by disallow_arbitrary_file_access",
+		},
+		{
+			name:                        "flag on rejects tls cert file",
+			disallowArbitraryFileAccess: true,
+			ep: promopv1.Endpoint{
+				HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
+					HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
+						TLSConfig: &promopv1.TLSConfig{
+							TLSFilesConfig: promopv1.TLSFilesConfig{CertFile: "/etc/prometheus/client.crt"},
+						},
+					},
+				},
+			},
+			expectedErr: "tlsConfig.certFile, which is disallowed by disallow_arbitrary_file_access",
+		},
+		{
+			name:                        "flag on rejects tls key file",
+			disallowArbitraryFileAccess: true,
+			ep: promopv1.Endpoint{
+				HTTPConfigWithProxyAndTLSFiles: promopv1.HTTPConfigWithProxyAndTLSFiles{
+					HTTPConfigWithTLSFiles: promopv1.HTTPConfigWithTLSFiles{
+						TLSConfig: &promopv1.TLSConfig{
+							TLSFilesConfig: promopv1.TLSFilesConfig{KeyFile: "/etc/prometheus/client.key"},
+						},
+					},
+				},
+			},
+			expectedErr: "tlsConfig.keyFile, which is disallowed by disallow_arbitrary_file_access",
+		},
+		{
+			name:                        "flag on allows endpoints without file fields",
+			disallowArbitraryFileAccess: true,
+			ep:                          promopv1.Endpoint{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cg := &ConfigGenerator{
+				Client:                      &kubernetes.ClientArguments{},
+				DisallowArbitraryFileAccess: tc.disallowArbitraryFileAccess,
+			}
+
+			cfg, err := cg.GenerateServiceMonitorConfig(serviceMonitor, tc.ep, 0, promk8s.RoleEndpoint)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedBearerTokenFile, cfg.HTTPClientConfig.BearerTokenFile)
+			require.Equal(t, tc.expectedTLSConfig, cfg.HTTPClientConfig.TLSConfig)
+		})
+	}
+}

--- a/internal/component/prometheus/operator/podmonitors/operator.go
+++ b/internal/component/prometheus/operator/podmonitors/operator.go
@@ -14,7 +14,7 @@ func init() {
 		Args:      operator.Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
-			return common.New(opts, args, common.KindPodMonitor)
+			return common.New(opts, args.(operator.Arguments), common.DefaultOptions(common.KindPodMonitor))
 		},
 	})
 }

--- a/internal/component/prometheus/operator/probes/probes.go
+++ b/internal/component/prometheus/operator/probes/probes.go
@@ -14,7 +14,7 @@ func init() {
 		Args:      operator.Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
-			return common.New(opts, args, common.KindProbe)
+			return common.New(opts, args.(operator.Arguments), common.DefaultOptions(common.KindProbe))
 		},
 	})
 }

--- a/internal/component/prometheus/operator/scrapeconfigs/operator.go
+++ b/internal/component/prometheus/operator/scrapeconfigs/operator.go
@@ -14,7 +14,7 @@ func init() {
 		Args:      operator.Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
-			return common.New(opts, args, common.KindScrapeConfig)
+			return common.New(opts, args.(operator.Arguments), common.DefaultOptions(common.KindScrapeConfig))
 		},
 	})
 }

--- a/internal/component/prometheus/operator/servicemonitors/arguments.go
+++ b/internal/component/prometheus/operator/servicemonitors/arguments.go
@@ -23,11 +23,3 @@ func (args *Arguments) SetToDefault() {
 func (args *Arguments) Validate() error {
 	return args.Arguments.Validate()
 }
-
-func (args Arguments) OperatorArguments() operator.Arguments {
-	return args.Arguments
-}
-
-func (args Arguments) ServiceMonitorDisallowArbitraryFileAccess() bool {
-	return args.DisallowArbitraryFileAccess
-}

--- a/internal/component/prometheus/operator/servicemonitors/arguments.go
+++ b/internal/component/prometheus/operator/servicemonitors/arguments.go
@@ -5,13 +5,13 @@ import "github.com/grafana/alloy/internal/component/prometheus/operator"
 type Arguments struct {
 	Arguments operator.Arguments `alloy:",squash"`
 
-	// DisallowArbitraryFileAccess disallows arbitrary file access on ServiceMonitor endpoints.
-	DisallowArbitraryFileAccess bool `alloy:"disallow_arbitrary_file_access,attr,optional"`
+	// AllowArbitraryFileAccess allows arbitrary file access on ServiceMonitor endpoints.
+	AllowArbitraryFileAccess bool `alloy:"allow_arbitrary_file_access,attr,optional"`
 }
 
 var DefaultArguments = Arguments{
-	Arguments:                   operator.DefaultArguments,
-	DisallowArbitraryFileAccess: true,
+	Arguments:                operator.DefaultArguments,
+	AllowArbitraryFileAccess: false,
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/prometheus/operator/servicemonitors/arguments.go
+++ b/internal/component/prometheus/operator/servicemonitors/arguments.go
@@ -3,7 +3,7 @@ package servicemonitors
 import "github.com/grafana/alloy/internal/component/prometheus/operator"
 
 type Arguments struct {
-	operator.Arguments `alloy:",squash"`
+	Arguments operator.Arguments `alloy:",squash"`
 
 	// DisallowArbitraryFileAccess disallows arbitrary file access on ServiceMonitor endpoints.
 	DisallowArbitraryFileAccess bool `alloy:"disallow_arbitrary_file_access,attr,optional"`

--- a/internal/component/prometheus/operator/servicemonitors/arguments.go
+++ b/internal/component/prometheus/operator/servicemonitors/arguments.go
@@ -1,0 +1,33 @@
+package servicemonitors
+
+import "github.com/grafana/alloy/internal/component/prometheus/operator"
+
+type Arguments struct {
+	operator.Arguments `alloy:",squash"`
+
+	// DisallowArbitraryFileAccess disallows arbitrary file access on ServiceMonitor endpoints.
+	DisallowArbitraryFileAccess bool `alloy:"disallow_arbitrary_file_access,attr,optional"`
+}
+
+var DefaultArguments = Arguments{
+	Arguments:                   operator.DefaultArguments,
+	DisallowArbitraryFileAccess: true,
+}
+
+// SetToDefault implements syntax.Defaulter.
+func (args *Arguments) SetToDefault() {
+	*args = DefaultArguments
+}
+
+// Validate implements syntax.Validator.
+func (args *Arguments) Validate() error {
+	return args.Arguments.Validate()
+}
+
+func (args Arguments) OperatorArguments() operator.Arguments {
+	return args.Arguments
+}
+
+func (args Arguments) ServiceMonitorDisallowArbitraryFileAccess() bool {
+	return args.DisallowArbitraryFileAccess
+}

--- a/internal/component/prometheus/operator/servicemonitors/servicemonitors.go
+++ b/internal/component/prometheus/operator/servicemonitors/servicemonitors.go
@@ -13,7 +13,28 @@ func init() {
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
-			return common.New(opts, args, common.KindServiceMonitor)
+			arguments := args.(Arguments)
+			commonComponent, err := common.New(opts, arguments.Arguments, common.ServiceMonitorOptions(settingsFromArguments(arguments)))
+			if err != nil {
+				return nil, err
+			}
+			return &Component{Component: commonComponent}, nil
 		},
 	})
+}
+
+type Component struct {
+	*common.Component
+}
+
+func (c *Component) Update(args component.Arguments) error {
+	arguments := args.(Arguments)
+	settings := settingsFromArguments(arguments)
+	return c.Component.UpdateOperatorArguments(arguments.Arguments, &settings)
+}
+
+func settingsFromArguments(args Arguments) common.ServiceMonitorSettings {
+	return common.ServiceMonitorSettings{
+		DisallowArbitraryFileAccess: args.DisallowArbitraryFileAccess,
+	}
 }

--- a/internal/component/prometheus/operator/servicemonitors/servicemonitors.go
+++ b/internal/component/prometheus/operator/servicemonitors/servicemonitors.go
@@ -35,6 +35,6 @@ func (c *Component) Update(args component.Arguments) error {
 
 func settingsFromArguments(args Arguments) common.ServiceMonitorSettings {
 	return common.ServiceMonitorSettings{
-		DisallowArbitraryFileAccess: args.DisallowArbitraryFileAccess,
+		AllowArbitraryFileAccess: args.AllowArbitraryFileAccess,
 	}
 }

--- a/internal/component/prometheus/operator/servicemonitors/servicemonitors.go
+++ b/internal/component/prometheus/operator/servicemonitors/servicemonitors.go
@@ -2,7 +2,6 @@ package servicemonitors
 
 import (
 	"github.com/grafana/alloy/internal/component"
-	"github.com/grafana/alloy/internal/component/prometheus/operator"
 	"github.com/grafana/alloy/internal/component/prometheus/operator/common"
 	"github.com/grafana/alloy/internal/featuregate"
 )
@@ -11,7 +10,7 @@ func init() {
 	component.Register(component.Registration{
 		Name:      "prometheus.operator.servicemonitors",
 		Stability: featuregate.StabilityGenerallyAvailable,
-		Args:      operator.Arguments{},
+		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			return common.New(opts, args, common.KindServiceMonitor)

--- a/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
+++ b/internal/component/prometheus/operator/servicemonitors/servicemonitors_test.go
@@ -131,7 +131,7 @@ func TestServiceMonitorEndToEnd(t *testing.T) {
 			args.Scrape.HonorMetadata = tc.honorMetadata
 
 			// Create the component
-			comp, err := common.New(opts, args, common.KindServiceMonitor)
+			comp, err := common.New(opts, args, common.ServiceMonitorOptions(common.DefaultServiceMonitorSettings))
 			require.NoError(t, err)
 
 			// Create a test factory that provides access to internal components

--- a/internal/component/prometheus/operator/types.go
+++ b/internal/component/prometheus/operator/types.go
@@ -27,9 +27,6 @@ type Arguments struct {
 	// Namespaces to search for monitor resources. Empty implies All namespaces
 	Namespaces []string `alloy:"namespaces,attr,optional"`
 
-	// DisallowArbitraryFileAccess disallows arbitrary file access on ServiceMonitor endpoints.
-	DisallowArbitraryFileAccess bool `alloy:"disallow_arbitrary_file_access,attr,optional"`
-
 	KubernetesRole string `alloy:"kubernetes_role,attr,optional"`
 
 	// LabelSelector allows filtering discovered monitor resources by labels
@@ -100,9 +97,8 @@ var DefaultArguments = Arguments{
 	Client: kubernetes.ClientArguments{
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	},
-	DisallowArbitraryFileAccess: true,
-	KubernetesRole:              string(promk8s.RoleEndpoint),
-	InformerSyncTimeout:         time.Minute,
+	KubernetesRole:      string(promk8s.RoleEndpoint),
+	InformerSyncTimeout: time.Minute,
 }
 
 // SetToDefault implements syntax.Defaulter.

--- a/internal/component/prometheus/operator/types.go
+++ b/internal/component/prometheus/operator/types.go
@@ -27,6 +27,9 @@ type Arguments struct {
 	// Namespaces to search for monitor resources. Empty implies All namespaces
 	Namespaces []string `alloy:"namespaces,attr,optional"`
 
+	// DisallowArbitraryFileAccess disallows arbitrary file access on ServiceMonitor endpoints.
+	DisallowArbitraryFileAccess bool `alloy:"disallow_arbitrary_file_access,attr,optional"`
+
 	KubernetesRole string `alloy:"kubernetes_role,attr,optional"`
 
 	// LabelSelector allows filtering discovered monitor resources by labels
@@ -97,8 +100,9 @@ var DefaultArguments = Arguments{
 	Client: kubernetes.ClientArguments{
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	},
-	KubernetesRole:      string(promk8s.RoleEndpoint),
-	InformerSyncTimeout: time.Minute,
+	DisallowArbitraryFileAccess: true,
+	KubernetesRole:              string(promk8s.RoleEndpoint),
+	InformerSyncTimeout:         time.Minute,
 }
 
 // SetToDefault implements syntax.Defaulter.


### PR DESCRIPTION
### Brief description of Pull Request

Sync `prometheus.operator.servicemonitors` with Prometheus Operator's arbitrary filesystem access guard for ServiceMonitor endpoints. ServiceMonitor endpoints now reject `bearerTokenFile`, `tlsConfig.caFile`, `tlsConfig.certFile`, and `tlsConfig.keyFile` by default, while allowing trusted deployments to opt out with `allow_arbitrary_file_access = true`.

This also fixes a bug where a failing endpoint would leave earlier endpoints from the same ServiceMonitor already written into the shared scrape/discovery config

BEGIN_COMMIT_OVERRIDE
fix(prometheus.operator.servicemonitors)!: Sync ServiceMonitor permission semantics with upstream

BREAKING CHANGE: `prometheus.operator.servicemonitors` now rejects ServiceMonitor endpoints that reference local files through `bearerTokenFile`, `tlsConfig.caFile`, `tlsConfig.certFile`, or `tlsConfig.keyFile` by default. Set `allow_arbitrary_file_access = true` to preserve the previous behavior for trusted ServiceMonitor authors.
END_COMMIT_OVERRIDE

### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))