### PR TITLE
feat: Part 3 - Expose knobs for OTel v0.158.0 upgrade - add exposed_headers to otel http config

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
@@ -181,11 +181,12 @@ The `cors` block configures CORS settings for an HTTP server.
 
 The following arguments are supported:
 
-| Name              | Type           | Description                                              | Default                | Required |
-|-------------------|----------------|----------------------------------------------------------|------------------------|----------|
-| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                     | `["X-Requested-With"]` | no       |
-| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                  |                        | no       |
-| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header. |                        | no       |
+| Name              | Type           | Description                                                     | Default                | Required |
+|-------------------|----------------|-----------------------------------------------------------------|------------------------|----------|
+| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                            | `["X-Requested-With"]` | no       |
+| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                         |                        | no       |
+| `exposed_headers` | `list(string)` | Configures the `Access-Control-Expose-Headers` response header. |                        | no       |
+| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header.        |                        | no       |
 
 The `allowed_headers` specifies which headers are acceptable from a CORS request.
 The following headers are always implicitly allowed:

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
@@ -101,11 +101,12 @@ The `cors` block configures CORS settings for an HTTP server.
 
 The following arguments are supported:
 
-| Name              | Type           | Description                                              | Default                | Required |
-|-------------------|----------------|----------------------------------------------------------|------------------------|----------|
-| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                  | `[]`                   | no       |
-| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                     | `["X-Requested-With"]` | no       |
-| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header. | `0`                    | no       |
+| Name              | Type           | Description                                                     | Default                | Required |
+|-------------------|----------------|-----------------------------------------------------------------|------------------------|----------|
+| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                         | `[]`                   | no       |
+| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                            | `["X-Requested-With"]` | no       |
+| `exposed_headers` | `list(string)` | Configures the `Access-Control-Expose-Headers` response header. | `[]`                   | no       |
+| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header.        | `0`                    | no       |
 
 The `allowed_headers` argument specifies which headers are acceptable from a CORS request.
 The following headers are always implicitly allowed:

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.faro.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.faro.md
@@ -90,11 +90,12 @@ The `cors` block configures CORS settings for an HTTP server.
 
 The following arguments are supported:
 
-| Name              | Type           | Description                                              | Default                | Required |
-|-------------------|----------------|----------------------------------------------------------|------------------------|----------|
-| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                  | `[]`                   | no       |
-| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                     | `["X-Requested-With"]` | no       |
-| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header. | `0`                    | no       |
+| Name              | Type           | Description                                                     | Default                | Required |
+|-------------------|----------------|-----------------------------------------------------------------|------------------------|----------|
+| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                         | `[]`                   | no       |
+| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                            | `["X-Requested-With"]` | no       |
+| `exposed_headers` | `list(string)` | Configures the `Access-Control-Expose-Headers` response header. | `[]`                   | no       |
+| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header.        | `0`                    | no       |
 
 The `allowed_headers` argument specifies which headers are acceptable from a CORS request.
 The following headers are always implicitly allowed:

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.influxdb.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.influxdb.md
@@ -87,11 +87,12 @@ The `cors` block configures CORS settings for an HTTP server.
 
 The following arguments are supported:
 
-| Name              | Type           | Description                              | Default                | Required |
-|-------------------|----------------|------------------------------------------|------------------------|----------|
-| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.  |                        | no       |
-| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.     | `["X-Requested-With"]` | no       |
-| `max_age`         | `number`       | Configures the `Access-Control-Max-Age`. |                        | no       |
+| Name              | Type           | Description                                                     | Default                | Required |
+|-------------------|----------------|-----------------------------------------------------------------|------------------------|----------|
+| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                         |                        | no       |
+| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                            | `["X-Requested-With"]` | no       |
+| `exposed_headers` | `list(string)` | Configures the `Access-Control-Expose-Headers` response header. |                        | no       |
+| `max_age`         | `number`       | Configures the `Access-Control-Max-Age`.                        |                        | no       |
 
 The `allowed_headers` argument specifies which headers are acceptable from a
 CORS request. The following headers are always implicitly allowed:

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
@@ -191,11 +191,12 @@ The `cors` block configures CORS settings for an HTTP server.
 
 The following arguments are supported:
 
-| Name              | Type           | Description                                              | Default                | Required |
-|-------------------|----------------|----------------------------------------------------------|------------------------|----------|
-| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                     | `["X-Requested-With"]` | no       |
-| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                  |                        | no       |
-| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header. |                        | no       |
+| Name              | Type           | Description                                                     | Default                | Required |
+|-------------------|----------------|-----------------------------------------------------------------|------------------------|----------|
+| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                            | `["X-Requested-With"]` | no       |
+| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                         |                        | no       |
+| `exposed_headers` | `list(string)` | Configures the `Access-Control-Expose-Headers` response header. |                        | no       |
+| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header.        |                        | no       |
 
 The `allowed_headers` specifies which headers are acceptable from a CORS request.
 The following headers are always implicitly allowed:

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
@@ -185,11 +185,12 @@ The `cors` block configures CORS settings for an HTTP server.
 
 The following arguments are supported:
 
-| Name              | Type           | Description                                              | Default                | Required |
-|-------------------|----------------|----------------------------------------------------------|------------------------|----------|
-| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                  |                        | no       |
-| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                     | `["X-Requested-With"]` | no       |
-| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header. |                        | no       |
+| Name              | Type           | Description                                                     | Default                | Required |
+|-------------------|----------------|-----------------------------------------------------------------|------------------------|----------|
+| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                         |                        | no       |
+| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                            | `["X-Requested-With"]` | no       |
+| `exposed_headers` | `list(string)` | Configures the `Access-Control-Expose-Headers` response header. |                        | no       |
+| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header.        |                        | no       |
 
 The `allowed_headers` argument specifies which headers are acceptable from a CORS request.
 The following headers are always implicitly allowed:

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.splunkhec.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.splunkhec.md
@@ -109,11 +109,12 @@ The `cors` block configures CORS settings for an HTTP server.
 
 The following arguments are supported:
 
-| Name              | Type           | Description                                              | Default                | Required |
-|-------------------|----------------|----------------------------------------------------------|------------------------|----------|
-| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                     | `["X-Requested-With"]` | no       |
-| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                  |                        | no       |
-| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header. |                        | no       |
+| Name              | Type           | Description                                                     | Default                | Required |
+|-------------------|----------------|-----------------------------------------------------------------|------------------------|----------|
+| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                            | `["X-Requested-With"]` | no       |
+| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                         |                        | no       |
+| `exposed_headers` | `list(string)` | Configures the `Access-Control-Expose-Headers` response header. |                        | no       |
+| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header.        |                        | no       |
 
 The `allowed_headers` specifies which headers are acceptable from a CORS request.
 The following headers are always implicitly allowed:

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
@@ -93,11 +93,12 @@ The `cors` block configures CORS settings for an HTTP server.
 
 The following arguments are supported:
 
-| Name              | Type           | Description                                              | Default                | Required |
-|-------------------|----------------|----------------------------------------------------------|------------------------|----------|
-| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                     | `["X-Requested-With"]` | no       |
-| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                  |                        | no       |
-| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header. |                        | no       |
+| Name              | Type           | Description                                                     | Default                | Required |
+|-------------------|----------------|-----------------------------------------------------------------|------------------------|----------|
+| `allowed_headers` | `list(string)` | Accepted headers from CORS requests.                            | `["X-Requested-With"]` | no       |
+| `allowed_origins` | `list(string)` | Allowed values for the `Origin` header.                         |                        | no       |
+| `exposed_headers` | `list(string)` | Configures the `Access-Control-Expose-Headers` response header. |                        | no       |
+| `max_age`         | `number`       | Configures the `Access-Control-Max-Age` response header.        |                        | no       |
 
 The `allowed_headers` argument specifies which headers are acceptable from a CORS request.
 The following headers are always implicitly allowed:

--- a/internal/component/otelcol/config_http.go
+++ b/internal/component/otelcol/config_http.go
@@ -126,6 +126,7 @@ func (args *HTTPServerArguments) Extensions() map[otelcomponent.ID]otelcomponent
 type CORSArguments struct {
 	AllowedOrigins []string `alloy:"allowed_origins,attr,optional"`
 	AllowedHeaders []string `alloy:"allowed_headers,attr,optional"`
+	ExposedHeaders []string `alloy:"exposed_headers,attr,optional"`
 
 	MaxAge int `alloy:"max_age,attr,optional"`
 }
@@ -139,6 +140,7 @@ func (args *CORSArguments) Convert() configoptional.Optional[otelconfighttp.CORS
 	return configoptional.Some(otelconfighttp.CORSConfig{
 		AllowedOrigins: copyStringSlice(args.AllowedOrigins),
 		AllowedHeaders: copyStringSlice(args.AllowedHeaders),
+		ExposedHeaders: copyStringSlice(args.ExposedHeaders),
 		MaxAge:         args.MaxAge,
 	})
 }

--- a/internal/component/otelcol/config_http_test.go
+++ b/internal/component/otelcol/config_http_test.go
@@ -25,6 +25,21 @@ func TestHTTPServerArguments_ConvertTimeoutZeroValue(t *testing.T) {
 	require.Equal(t, time.Duration(0), server.ReadTimeout)
 }
 
+func TestCORSArguments_ConvertExposedHeaders(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		cors := (&otelcol.CORSArguments{}).Convert()
+		require.Nil(t, cors.Get().ExposedHeaders)
+	})
+
+	t.Run("set", func(t *testing.T) {
+		args := &otelcol.CORSArguments{
+			ExposedHeaders: []string{"X-Request-Id", "X-Trace-Id"},
+		}
+		cors := args.Convert()
+		require.Equal(t, []string{"X-Request-Id", "X-Trace-Id"}, cors.Get().ExposedHeaders)
+	})
+}
+
 func TestHTTPServerArguments_ConvertTimeoutCustom(t *testing.T) {
 	args := &otelcol.HTTPServerArguments{
 		IdleTimeout:       2 * time.Minute,

--- a/internal/converter/internal/otelcolconvert/converter_otlpreceiver.go
+++ b/internal/converter/internal/otelcolconvert/converter_otlpreceiver.go
@@ -208,6 +208,7 @@ func toCORSArguments(cfg *confighttp.CORSConfig) *otelcol.CORSArguments {
 	return &otelcol.CORSArguments{
 		AllowedOrigins: cfg.AllowedOrigins,
 		AllowedHeaders: cfg.AllowedHeaders,
+		ExposedHeaders: cfg.ExposedHeaders,
 
 		MaxAge: cfg.MaxAge,
 	}

--- a/internal/converter/internal/otelcolconvert/testdata/otlp.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/otlp.alloy
@@ -4,7 +4,14 @@ otelcol.receiver.otlp "default" {
 	}
 
 	http {
-		endpoint               = "localhost:4318"
+		endpoint = "localhost:4318"
+
+		cors {
+			allowed_origins = ["https://*.example.com"]
+			allowed_headers = ["X-Custom-Header"]
+			exposed_headers = ["X-Request-Id"]
+			max_age         = 7200
+		}
 		compression_algorithms = ["zlib"]
 		idle_timeout           = "0s"
 		write_timeout          = "0s"

--- a/internal/converter/internal/otelcolconvert/testdata/otlp.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/otlp.yaml
@@ -5,6 +5,14 @@ receivers:
       http:
         compression_algorithms:
         - "zlib"
+        cors:
+          allowed_origins:
+          - "https://*.example.com"
+          allowed_headers:
+          - "X-Custom-Header"
+          exposed_headers:
+          - "X-Request-Id"
+          max_age: 7200
 
 exporters:
   otlp:


### PR DESCRIPTION
### Brief description of Pull Request
Adds the `exposed_headers` setting to `http.cors` otel config so users can set the [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) response header, indicating which headers are safe to expose to the API of a CORS response.

### Pull Request Details
This config is present in a couple different components so is spread across

### PR Checklist
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))