### PR TITLE
feat: Part 4 - Expose knobs for Prometheus 3.13.2 & OTel v0.158.0 upgrade

### DIFF
--- a/docs/sources/reference/components/discovery/discovery.aws.md
+++ b/docs/sources/reference/components/discovery/discovery.aws.md
@@ -61,7 +61,7 @@ You can use the following arguments with `discovery.aws`:
 
 The `clusters` and `request_concurrency` arguments only apply to the `ecs`, `elasticache`, `msk`, and `rds` roles.
 When `request_concurrency` isn't set, it defaults to `20` for the `ecs` role and `10` for the `elasticache`, `msk`, and `rds` roles.
-The [`filter`][filter] block only applies to the `ec2` role.
+The [`filter`][filter] block only applies to the `ec2` and `rds` roles.
 
 At most, one of the following can be provided:
 
@@ -83,7 +83,7 @@ You can use the following blocks with `discovery.aws`:
 | ------------------------------------- | ---------------------------------------------------------- | -------- |
 | [`authorization`][authorization]      | Configure generic authorization to the endpoint.           | no       |
 | [`basic_auth`][basic_auth]            | Configure `basic_auth` for authenticating to the endpoint. | no       |
-| [`filter`][filter]                    | Filters discoverable resources. Only used with the `ec2` role. | no   |
+| [`filter`][filter]                    | Filters discoverable resources. Only used with the `ec2` and `rds` roles. | no   |
 | [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
 | `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |
 | [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |
@@ -110,17 +110,19 @@ The `basic_auth` block configures basic authentication to the endpoint.
 
 ### `filter`
 
-The `filter` block filters the EC2 instance list by other criteria. It only applies to the `ec2` role.
-Refer to the [Amazon EC2 documentation][amazon] for more information about filters.
+The `filter` block filters the discovered instance list by other criteria. It only applies to the `ec2` and `rds` roles.
+Refer to the [Amazon EC2 documentation][amazon] for more information about EC2 filters, or the
+[Amazon RDS documentation][amazon rds] for RDS filters.
 
 | Name     | Type           | Description                   | Default | Required |
 | -------- | -------------- | ----------------------------- | ------- | -------- |
 | `name`   | `string`       | Filter name to use.           |         | yes      |
 | `values` | `list(string)` | Values to pass to the filter. |         | yes      |
 
-Refer to the [Filter API AWS EC2 documentation][filter api] for the list of supported filters and their descriptions.
+Refer to the [Filter API AWS EC2 documentation][filter api] for the list of supported `ec2` filters and their descriptions.
 
 [amazon]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
+[amazon rds]: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html
 [filter api]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html
 
 ### `oauth2`

--- a/docs/sources/reference/components/otelcol/otelcol.processor.resourcedetection.md
+++ b/docs/sources/reference/components/otelcol/otelcol.processor.resourcedetection.md
@@ -41,11 +41,12 @@ otelcol.processor.resourcedetection "<LABEL>" {
 
 You can use the following arguments with `otelcol.processor.resourcedetection`:
 
-| Name        | Type           | Description                                                                        | Default   | Required |
-| ----------- | -------------- | ---------------------------------------------------------------------------------- | --------- | -------- |
-| `detectors` | `list(string)` | An ordered list of named detectors used to detect resource information.            | `["env"]` | no       |
-| `override`  | `bool`         | Configures whether existing resource attributes should be overridden or preserved. | `true`    | no       |
-| `timeout`   | `duration`     | Timeout by which all specified detectors must complete.                            | `"5s"`    | no       |
+| Name                       | Type           | Description                                                                                     | Default   | Required |
+| -------------------------- | -------------- | ----------------------------------------------------------------------------------------------- | --------- | -------- |
+| `detectors`                | `list(string)` | An ordered list of named detectors used to detect resource information.                         | `["env"]` | no       |
+| `override`                 | `bool`         | Configures whether existing resource attributes should be overridden or preserved.              | `true`    | no       |
+| `timeout`                  | `duration`     | Timeout by which all specified detectors must complete.                                         | `"5s"`    | no       |
+| `fail_on_missing_metadata` | `bool`         | Treat an unreachable metadata service as a hard failure instead of returning an empty resource. | `false`   | no       |
 
 `detectors` could contain the following values:
 

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
@@ -40,21 +40,22 @@ otelcol.receiver.datadog "<LABEL>" {
 
 You can use the following arguments with `otelcol.receiver.datadog`:
 
-| Name                     | Type                       | Description                                                                  | Default                                                    | Required |
-|--------------------------|----------------------------|------------------------------------------------------------------------------|------------------------------------------------------------|----------|
-| `auth`                   | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests. |                                                            | no       |
-| `compression_algorithms` | `list(string)`             | A list of compression algorithms the server can accept.                      | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no       |
-| `endpoint`               | `string`                   | `host:port` to listen for traffic on.                                        | `"localhost:8126"`                                         | no       |
-| `idle_series_cleanup_interval` | `duration`            | How frequently to check for stale series.                                    | `"5m"`                                                     | no       |
-| `idle_series_timeout`    | `duration`                 | Duration after which a series is considered stale and evicted. `0` disables eviction. | `"0s"`                                             | no       |
-| `idle_timeout`           | `duration`                 | Maximum idle time before closing a keep-alive connection.                    | `"1m"`                                                     | no       |
-| `include_metadata`       | `bool`                     | Propagate incoming connection metadata to downstream consumers.              | `false`                                                    | no       |
-| `keep_alives_enabled`    | `boolean`                  | Whether or not HTTP keep-alives are enabled                                  | `true`                                                     | no       |
-| `max_request_body_size`  | `string`                   | Maximum request body size the server will allow.                             | `"20MiB"`                                                  | no       |
-| `read_header_timeout`    | `duration`                 | Maximum time allowed to read request headers.                                | `"1m"`                                                     | no       |
-| `read_timeout`           | `duration`                 | Maximum time allowed to read an HTTP request, including the body.            | `"1m"`                                                     | no       |
-| `trace_id_cache_size`    | `int`                      | Cache size for mapping 64-bit to 128-bit trace IDs.                          | `0`                                                        | no       |
-| `write_timeout`          | `duration`                 | Maximum time allowed to write an HTTP response.                              | `"30s"`                                                    | no       |
+| Name                           | Type                       | Description                                                                                       | Default                                                    | Required |
+| ------------------------------ | -------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | -------- |
+| `auth`                         | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.                      |                                                            | no       |
+| `compression_algorithms`       | `list(string)`             | A list of compression algorithms the server can accept.                                           | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no       |
+| `decode_json_message`          | `bool`                     | Parse a log record whose message is itself a JSON object and lift its fields into the log record. | `true`                                                     | no       |
+| `endpoint`                     | `string`                   | `host:port` to listen for traffic on.                                                             | `"localhost:8126"`                                         | no       |
+| `idle_series_cleanup_interval` | `duration`                 | How frequently to check for stale series.                                                         | `"5m"`                                                     | no       |
+| `idle_series_timeout`          | `duration`                 | Duration after which a series is considered stale and evicted. `0` disables eviction.             | `"0s"`                                                     | no       |
+| `idle_timeout`                 | `duration`                 | Maximum idle time before closing a keep-alive connection.                                         | `"1m"`                                                     | no       |
+| `include_metadata`             | `bool`                     | Propagate incoming connection metadata to downstream consumers.                                   | `false`                                                    | no       |
+| `keep_alives_enabled`          | `boolean`                  | Whether or not HTTP keep-alives are enabled                                                       | `true`                                                     | no       |
+| `max_request_body_size`        | `string`                   | Maximum request body size the server will allow.                                                  | `"20MiB"`                                                  | no       |
+| `read_header_timeout`          | `duration`                 | Maximum time allowed to read request headers.                                                     | `"1m"`                                                     | no       |
+| `read_timeout`                 | `duration`                 | Maximum time allowed to read an HTTP request, including the body.                                 | `"1m"`                                                     | no       |
+| `trace_id_cache_size`          | `int`                      | Cache size for mapping 64-bit to 128-bit trace IDs.                                               | `0`                                                        | no       |
+| `write_timeout`                | `duration`                 | Maximum time allowed to write an HTTP response.                                                   | `"30s"`                                                    | no       |
 
 
 

--- a/internal/component/discovery/aws/aws.go
+++ b/internal/component/discovery/aws/aws.go
@@ -46,7 +46,7 @@ type AWSArguments struct {
 	RefreshInterval time.Duration     `alloy:"refresh_interval,attr,optional"`
 	Port            int               `alloy:"port,attr,optional"`
 
-	// Filters applies only to the ec2 role.
+	// Filters applies only to the ec2 and rds roles.
 	Filters []*EC2Filter `alloy:"filter,block,optional"`
 	// Clusters and RequestConcurrency apply only to the ecs, elasticache, msk, and rds roles.
 	Clusters           []string `alloy:"clusters,attr,optional"`
@@ -82,9 +82,7 @@ func (args AWSArguments) Convert() discovery.DiscovererConfig {
 			Port:             nonZero(args.Port, def.Port),
 			HTTPClientConfig: httpClient,
 		}
-		for _, f := range args.Filters {
-			sub.Filters = append(sub.Filters, &promaws.Filter{Name: f.Name, Values: f.Values})
-		}
+		sub.Filters = toFilters(args.Filters)
 		cfg.EC2SDConfig = sub
 	case promaws.RoleECS:
 		def := promaws.DefaultECSSDConfig
@@ -150,7 +148,7 @@ func (args AWSArguments) Convert() discovery.DiscovererConfig {
 		}
 	case promaws.RoleRDS:
 		def := promaws.DefaultRDSSDConfig
-		cfg.RDSSDConfig = &promaws.RDSSDConfig{
+		sub := &promaws.RDSSDConfig{
 			Endpoint:           args.Endpoint,
 			Region:             args.Region,
 			AccessKey:          args.AccessKey,
@@ -164,6 +162,8 @@ func (args AWSArguments) Convert() discovery.DiscovererConfig {
 			RequestConcurrency: nonZero(args.RequestConcurrency, def.RequestConcurrency),
 			HTTPClientConfig:   httpClient,
 		}
+		sub.Filters = toFilters(args.Filters)
+		cfg.RDSSDConfig = sub
 	}
 	return cfg
 }
@@ -181,6 +181,14 @@ func nonZero[T int | model.Duration](v, roleDefault T) T {
 		return v
 	}
 	return roleDefault
+}
+
+func toFilters(filters []*EC2Filter) []*promaws.Filter {
+	var out []*promaws.Filter
+	for _, f := range filters {
+		out = append(out, &promaws.Filter{Name: f.Name, Values: f.Values})
+	}
+	return out
 }
 
 // resolveRegion mirrors upstream loadRegion: prefer the region from AWS
@@ -227,8 +235,8 @@ func (args *AWSArguments) Validate() error {
 		args.Region = region
 	}
 
-	if len(args.Filters) > 0 && role != promaws.RoleEC2 {
-		return fmt.Errorf("filter blocks are only supported with the ec2 role, not %q", args.Role)
+	if len(args.Filters) > 0 && role != promaws.RoleEC2 && role != promaws.RoleRDS {
+		return fmt.Errorf("filter blocks are only supported with the ec2 and rds roles, not %q", args.Role)
 	}
 	for _, f := range args.Filters {
 		if len(f.Values) == 0 {

--- a/internal/component/discovery/aws/aws.go
+++ b/internal/component/discovery/aws/aws.go
@@ -70,7 +70,7 @@ func (args AWSArguments) Convert() discovery.DiscovererConfig {
 	switch role {
 	case promaws.RoleEC2:
 		def := promaws.DefaultEC2SDConfig
-		sub := &promaws.EC2SDConfig{
+		cfg.EC2SDConfig = &promaws.EC2SDConfig{
 			Endpoint:         args.Endpoint,
 			Region:           args.Region,
 			AccessKey:        args.AccessKey,
@@ -81,9 +81,8 @@ func (args AWSArguments) Convert() discovery.DiscovererConfig {
 			RefreshInterval:  nonZero(model.Duration(args.RefreshInterval), def.RefreshInterval),
 			Port:             nonZero(args.Port, def.Port),
 			HTTPClientConfig: httpClient,
+			Filters:          toFilters(args.Filters),
 		}
-		sub.Filters = toFilters(args.Filters)
-		cfg.EC2SDConfig = sub
 	case promaws.RoleECS:
 		def := promaws.DefaultECSSDConfig
 		cfg.ECSSDConfig = &promaws.ECSSDConfig{
@@ -148,7 +147,7 @@ func (args AWSArguments) Convert() discovery.DiscovererConfig {
 		}
 	case promaws.RoleRDS:
 		def := promaws.DefaultRDSSDConfig
-		sub := &promaws.RDSSDConfig{
+		cfg.RDSSDConfig = &promaws.RDSSDConfig{
 			Endpoint:           args.Endpoint,
 			Region:             args.Region,
 			AccessKey:          args.AccessKey,
@@ -161,9 +160,8 @@ func (args AWSArguments) Convert() discovery.DiscovererConfig {
 			Port:               nonZero(args.Port, def.Port),
 			RequestConcurrency: nonZero(args.RequestConcurrency, def.RequestConcurrency),
 			HTTPClientConfig:   httpClient,
+			Filters:            toFilters(args.Filters),
 		}
-		sub.Filters = toFilters(args.Filters)
-		cfg.RDSSDConfig = sub
 	}
 	return cfg
 }

--- a/internal/component/discovery/aws/aws_test.go
+++ b/internal/component/discovery/aws/aws_test.go
@@ -40,6 +40,21 @@ func TestAWSConvertEC2(t *testing.T) {
 	require.Equal(t, []string{"prod"}, cfg.EC2SDConfig.Filters[0].Values)
 }
 
+func TestAWSConvertRDSFilters(t *testing.T) {
+	args := AWSArguments{
+		Role:             "rds",
+		Region:           "us-east-1",
+		Filters:          []*EC2Filter{{Name: "tag:env", Values: []string{"prod"}}},
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
+	}
+
+	cfg := args.Convert().(*promaws.SDConfig)
+	require.NotNil(t, cfg.RDSSDConfig)
+	require.Len(t, cfg.RDSSDConfig.Filters, 1)
+	require.Equal(t, "tag:env", cfg.RDSSDConfig.Filters[0].Name)
+	require.Equal(t, []string{"prod"}, cfg.RDSSDConfig.Filters[0].Values)
+}
+
 // TestAWSRequestConcurrencyDefault guards the per-role default: upstream uses 20
 // for ecs and 10 for elasticache/msk/rds. An explicit value overrides both.
 func TestAWSRequestConcurrencyDefault(t *testing.T) {
@@ -182,11 +197,18 @@ func TestAWSValidate(t *testing.T) {
 		require.ErrorContains(t, args.Validate(), "filter values cannot be empty")
 	})
 
-	t.Run("filter with non-ec2 role", func(t *testing.T) {
+	t.Run("valid rds filter", func(t *testing.T) {
+		args := base()
+		args.Role = "rds"
+		args.Filters = []*EC2Filter{{Name: "tag:env", Values: []string{"prod"}}}
+		require.NoError(t, args.Validate())
+	})
+
+	t.Run("filter with unsupported role", func(t *testing.T) {
 		args := base()
 		args.Role = "ecs"
 		args.Filters = []*EC2Filter{{Name: "tag:env", Values: []string{"prod"}}}
-		require.ErrorContains(t, args.Validate(), "only supported with the ec2 role")
+		require.ErrorContains(t, args.Validate(), "only supported with the ec2 and rds roles")
 	})
 
 	t.Run("clusters with ec2 role", func(t *testing.T) {

--- a/internal/component/otelcol/processor/resourcedetection/resourcedetection.go
+++ b/internal/component/otelcol/processor/resourcedetection/resourcedetection.go
@@ -66,6 +66,11 @@ type Arguments struct {
 	// should be overridden or preserved. Defaults to true.
 	Override bool `alloy:"override,attr,optional"`
 
+	// FailOnMissingMetadata controls whether network-based detectors treat an
+	// unreachable metadata service as a hard failure instead of silently
+	// returning an empty resource. Defaults to false.
+	FailOnMissingMetadata bool `alloy:"fail_on_missing_metadata,attr,optional"`
+
 	// DetectorConfig is a list of settings specific to all detectors
 	DetectorConfig DetectorConfig `alloy:",squash"`
 
@@ -284,6 +289,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 	input["detectors"] = args.ConvertDetectors()
 	input["override"] = args.Override
 	input["timeout"] = args.Timeout
+	input["fail_on_missing_metadata"] = args.FailOnMissingMetadata
 
 	input["ec2"] = args.DetectorConfig.EC2Config.Convert()
 	input["ecs"] = args.DetectorConfig.ECSConfig.Convert()

--- a/internal/component/otelcol/processor/resourcedetection/resourcedetection_test.go
+++ b/internal/component/otelcol/processor/resourcedetection/resourcedetection_test.go
@@ -148,6 +148,45 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 			},
 		},
 		{
+			testName: "fail_on_missing_metadata_explicit",
+			cfg: `
+			fail_on_missing_metadata = true
+			output {}
+			`,
+			expected: map[string]any{
+				"detectors":                []string{"env"},
+				"timeout":                  5 * time.Second,
+				"override":                 true,
+				"fail_on_missing_metadata": true,
+				"ec2":                      ec2.DefaultArguments.Convert(),
+				"ecs":                      ecs.DefaultArguments.Convert(),
+				"eks":                      eks.DefaultArguments.Convert(),
+				"elasticbeanstalk":         elasticbeanstalk.DefaultArguments.Convert(),
+				"lambda":                   lambda.DefaultArguments.Convert(),
+				"azure":                    azure.DefaultArguments.Convert(),
+				"aks":                      aks.DefaultArguments.Convert(),
+				"akamai":                   akamai.DefaultArguments.Convert(),
+				"consul":                   consul.DefaultArguments.Convert(),
+				"digitalocean":             digitalocean.DefaultArguments.Convert(),
+				"docker":                   docker.DefaultArguments.Convert(),
+				"gcp":                      gcp.DefaultArguments.Convert(),
+				"heroku":                   heroku.DefaultArguments.Convert(),
+				"hetzner":                  hetzner.DefaultArguments.Convert(),
+				"system":                   defaultArgs.Convert(),
+				"openshift":                openshift.DefaultArguments.Convert(),
+				"nova":                     openstacknova.DefaultArguments.Convert(),
+				"oraclecloud":              oraclecloud.DefaultArguments.Convert(),
+				"k8snode":                  kubernetes_node.DefaultArguments.Convert(),
+				"kubeadm":                  kubeadm.DefaultArguments.Convert(),
+				"dynatrace":                dynatrace.DefaultArguments.Convert(),
+				"scaleway":                 scaleway.DefaultArguments.Convert(),
+				"upcloud":                  upcloud.DefaultArguments.Convert(),
+				"vultr":                    vultr.DefaultArguments.Convert(),
+				"tencent_cvm":              tencentcvm.DefaultArguments.Convert(),
+				"alibaba_ecs":              alibabaecs.DefaultArguments.Convert(),
+			},
+		},
+		{
 			testName: "ec2_defaults",
 			cfg: `
 			detectors = ["ec2"]

--- a/internal/component/otelcol/receiver/datadog/datadog.go
+++ b/internal/component/otelcol/receiver/datadog/datadog.go
@@ -42,6 +42,10 @@ type Arguments struct {
 	// IdleSeriesCleanupInterval defines how frequently the receiver checks for stale series.
 	IdleSeriesCleanupInterval time.Duration `alloy:"idle_series_cleanup_interval,attr,optional"`
 
+	// DecodeJSONMessage parses a log record whose message is itself a JSON
+	// object and lifts its fields into the log record. Defaults to true
+	DecodeJSONMessage bool `alloy:"decode_json_message,attr,optional"`
+
 	Intake *IntakeArguments `alloy:"intake,block,optional"`
 
 	// DebugMetrics configures component internal metrics. Optional.
@@ -111,6 +115,7 @@ func (args *Arguments) SetToDefault() {
 			WriteTimeout:          otelcol.DefaultHTTPServerWriteTimeout,
 		},
 		IdleSeriesCleanupInterval: 5 * time.Minute,
+		DecodeJSONMessage:         true,
 	}
 	args.DebugMetrics.SetToDefault()
 }
@@ -127,6 +132,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 		TraceIDCacheSize:          args.TraceIDCacheSize,
 		IdleSeriesTimeout:         args.IdleSeriesTimeout,
 		IdleSeriesCleanupInterval: args.IdleSeriesCleanupInterval,
+		Logs:                      datadogreceiver.LogsConfig{DecodeJSONMessage: args.DecodeJSONMessage},
 	}
 
 	if args.Intake != nil {

--- a/internal/component/otelcol/receiver/datadog/datadog_test.go
+++ b/internal/component/otelcol/receiver/datadog/datadog_test.go
@@ -105,6 +105,32 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 		require.Equal(t, time.Minute, otelArgs.IdleSeriesCleanupInterval)
 	})
 
+	t.Run("decode_json_message_default", func(t *testing.T) {
+		in := `
+		output { /* no-op */ }
+		`
+		var args datadog.Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(in), &args))
+		ext, err := args.Convert()
+		require.NoError(t, err)
+		otelArgs := ext.(*datadogreceiver.Config)
+		require.True(t, otelArgs.Logs.DecodeJSONMessage)
+	})
+
+	t.Run("decode_json_message_explicit", func(t *testing.T) {
+		in := `
+		decode_json_message = false
+
+		output { /* no-op */ }
+		`
+		var args datadog.Arguments
+		require.NoError(t, syntax.Unmarshal([]byte(in), &args))
+		ext, err := args.Convert()
+		require.NoError(t, err)
+		otelArgs := ext.(*datadogreceiver.Config)
+		require.False(t, otelArgs.Logs.DecodeJSONMessage)
+	})
+
 	t.Run("intake_proxy", func(t *testing.T) {
 		in := `
 		intake {

--- a/internal/converter/internal/otelcolconvert/converter_datadogreceiver.go
+++ b/internal/converter/internal/otelcolconvert/converter_datadogreceiver.go
@@ -47,8 +47,9 @@ func toDatadogReceiver(state *State, id componentstatus.InstanceID, cfg *datadog
 	)
 
 	return &datadog.Arguments{
-		HTTPServer:   *toHTTPServerArguments(&cfg.ServerConfig),
-		DebugMetrics: common.DefaultValue[datadog.Arguments]().DebugMetrics,
+		HTTPServer:        *toHTTPServerArguments(&cfg.ServerConfig),
+		DecodeJSONMessage: cfg.Logs.DecodeJSONMessage,
+		DebugMetrics:      common.DefaultValue[datadog.Arguments]().DebugMetrics,
 
 		Output: &otelcol.ConsumerArguments{
 			Metrics: ToTokenizedConsumers(nextMetrics),


### PR DESCRIPTION
### Brief description of Pull Request
The PR for exposing upstream config in alloy after the upgrade from v0.153.0 to v0.158.0

### Pull Request Details
**discovery.aws** => exposes the ability to also apply the `filter` functionality to the `rds` role ([docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#aws_sd_config)) - this was already available before 3.12.* but adding it now

**processor.resourcedetection** => exposes the `fail_on_missing_metadata` config

**receiver.datadog** => exposes the `decode_json_message` config and ensures it matches upstream defaults

### Notes to Reviewer
There aren't any existing converters for `processor.resourcedetection`, so this was left out. Similarly there are also no converters for the unified `aws_sd_configs` so I didn't implement this for the `discovery.aws` change either. I think those can both be addressed in a future PR to keep this scoped to the upgrade.

### PR Checklist
- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
