### PR TITLE
chore: Update build image to use go v1.26.6

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -40,4 +40,4 @@ jobs:
           push: false
           tags: grafana/alloy-build-image:latest
           build-args: |
-            GO_RUNTIME=golang:1.26.5-alpine3.23
+            GO_RUNTIME=golang:1.26.6-alpine3.23

--- a/.github/workflows/create_build_image.yml
+++ b/.github/workflows/create_build_image.yml
@@ -51,4 +51,4 @@ jobs:
         push: true
         tags: us-docker.pkg.dev/grafanalabs-global/dockerhub-alloy-prod-mirror/alloy-build-image:${{ steps.get_image_version.outputs.image_tag }}
         build-args: |
-          GO_RUNTIME=golang:1.26.5-alpine3.23
+          GO_RUNTIME=golang:1.26.6-alpine3.23

--- a/tools/goversion/command.go
+++ b/tools/goversion/command.go
@@ -107,7 +107,6 @@ func updateBuildImage(root string, version string) error {
 	paths := []string{
 		".github/workflows/create_build_image.yml",
 		".github/workflows/check-linux-build-image.yml",
-		"build-tools/build-image/windows/Dockerfile",
 	}
 
 	for _, path := range paths {


### PR DESCRIPTION
Bump go version in our build-image so we can update version used by alloy