### PR TITLE
docs: Update outdated links in Contributing guide

### DIFF
--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -142,7 +142,7 @@ Slack channel [#alloy](https://slack.grafana.com).
 #### PR titles (and by extension CHANGELOG entries) should:
 
 1. Adhere to [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) style and use one
-   of the ["types" defined in our linting workflow](../../.github/workflows/lint-pr-title.yml#L43).
+   of the ["types" defined in our linting workflow](../../.github/workflows/release-lint-pr-title.yml).
 2. Read as a complete sentence in the imperative, present tense (e.g. "Change", not "Changes" or
    "Changed").
 3. Have a "description" which starts with an uppercase letter.
@@ -190,7 +190,7 @@ When a maintainer goes to merge your PR, the prompt they get will contain the PR
 commit's title and all of the individual commit details as the squashed commit's body.
 
 You can find the list of all Conventional Commit "types" we allow
-[here](../../.github/workflows/lint-pr-title.yml#L43).
+[here](../../.github/workflows/release-lint-pr-title.yml).
 
 ## (Maintainers) Merging a PR
 
@@ -274,7 +274,7 @@ If upstream is unresponsive, consider choosing a different dependency or making 
 creating a new Go module with the same source).
 
 [new-issue]: https://github.com/grafana/alloy/issues/new
-[code-review-comments]: https://code.google.com/p/go-wiki/wiki/CodeReviewComments
+[code-review-comments]: https://go.dev/wiki/CodeReviewComments
 [best-practices]: https://peter.bourgon.org/go-in-production/#formatting-and-style
 [uber-style-guide]: https://github.com/uber-go/guide/blob/master/style.md
 [CLA]: https://cla-assistant.io/grafana/alloy


### PR DESCRIPTION
### Brief description of Pull Request

Update outdated links inside Contributing guide

### Pull Request Details

Came across a couple of non-working links in the Contributing guide from when the Lint PR title workflow file name was adjusted in https://github.com/grafana/alloy/commit/d41dab4ce3b5b1528cfd04acff0cfc26ac2f1a80.

Also took opportunity to update stale Go Code Review Comments link to point directly to article on the Go wiki. The original link would redirect to deprecated Go wiki on GitHub citing move to go.dev. 

### Issue(s) fixed by this Pull Request

Broken links (no separate issue filed)

### Notes to the Reviewer

### PR Checklist

- [x] Documentation added
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))