### PR TITLE
feat: Expose experimental OTel supervisor

### DIFF
--- a/collector/supervisor.go
+++ b/collector/supervisor.go
@@ -63,7 +63,7 @@ func newOtelSupervisorCommand() *cobra.Command {
 		Use:           "otel-supervisor",
 		Short:         "Run the embedded OpAMP supervisor for Alloy's OTel engine",
 		Long:          svCmdDoc,
-		Hidden:        true, // TODO: unhide the command after the docs are ready.
+		Hidden:        false,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/collector/supervisor_test.go
+++ b/collector/supervisor_test.go
@@ -151,3 +151,8 @@ func TestSupervisorConfigFromFileEmptyPath(t *testing.T) {
 	require.Nil(t, cfg)
 	require.EqualError(t, err, "path to supervisor configuration file cannot be empty")
 }
+
+func TestOtelSupervisorCommandIsVisible(t *testing.T) {
+	command := newOtelSupervisorCommand()
+	require.False(t, command.Hidden)
+}

--- a/collector/supervisor_test.go
+++ b/collector/supervisor_test.go
@@ -151,8 +151,3 @@ func TestSupervisorConfigFromFileEmptyPath(t *testing.T) {
 	require.Nil(t, cfg)
 	require.EqualError(t, err, "path to supervisor configuration file cannot be empty")
 }
-
-func TestOtelSupervisorCommandIsVisible(t *testing.T) {
-	command := newOtelSupervisorCommand()
-	require.False(t, command.Hidden)
-}

--- a/docs/sources/reference/cli/_index.md
+++ b/docs/sources/reference/cli/_index.md
@@ -19,6 +19,7 @@ Available commands:
 * [`gql`][gql]: Run a GraphQL query against a running {{< param "PRODUCT_NAME" >}} instance.
 * [`run`][run]: Start {{< param "PRODUCT_NAME" >}} with the Default Engine, given an Alloy syntax configuration file.
 * [`otel`][otel]: Start {{< param "PRODUCT_NAME" >}} with the experimental OTel Engine, given an OpenTelemetry Collector YAML configuration file.
+* [`otel-supervisor`][otel-supervisor]: Manage the experimental OTel Engine with Grafana Fleet Management.
 * [`tools`][tools]: Read the WAL and provide statistical information.
 * [`validate`][validate]: Validate an {{< param "PRODUCT_NAME" >}} configuration file or directory path.
 * `completion`: Generate shell completion for the `alloy` CLI.
@@ -29,5 +30,6 @@ Available commands:
 [gql]: ./gql/
 [convert]: ./convert/
 [otel]: ./otel/
+[otel-supervisor]: ./otel-supervisor/
 [tools]: ./tools/
 [validate]: ./validate/

--- a/docs/sources/reference/cli/otel-supervisor.md
+++ b/docs/sources/reference/cli/otel-supervisor.md
@@ -65,3 +65,34 @@ alloy otel-supervisor --config=<SUPERVISOR_CONFIG_FILE>
 ```
 
 Replace _`<SUPERVISOR_CONFIG_FILE>`_ with the path to an [OpenTelemetry Collector OpAMP supervisor configuration file](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/cmd/opampsupervisor/specification/README.md).
+
+Alloy always sets `agent.executable` to the running Alloy binary.
+It ignores any `agent.executable` value in the supervisor configuration file.
+You can set `agent.args` to change the arguments passed to the Alloy binary.
+
+### Configure an OpAMP connection
+
+The following configuration connects the supervisor to Grafana Fleet Management:
+
+```yaml
+server:
+  endpoint: "${env:GCLOUD_FM_URL}/v1/opamp"
+  headers:
+    Authorization: "Basic ${env:GCLOUD_BASIC_AUTH_BASE64}"
+capabilities:
+  accepts_remote_config: true
+  reports_remote_config: true
+storage:
+  directory: ${env:STORAGE_DIR}
+```
+
+Set `GCLOUD_BASIC_AUTH_BASE64` to the base64-encoded Grafana Cloud instance ID and API token, separated by a colon.
+
+### Override Alloy arguments
+
+To pass different arguments to the Alloy binary, add an `agent` block to the supervisor configuration file:
+
+```yaml
+agent:
+  args: [otel, --feature-gates, +service.profilesSupport]
+```

--- a/docs/sources/reference/cli/otel-supervisor.md
+++ b/docs/sources/reference/cli/otel-supervisor.md
@@ -64,4 +64,4 @@ To run it, use the following command:
 alloy otel-supervisor --config=<SUPERVISOR_CONFIG_FILE>
 ```
 
-Replace _`<SUPERVISOR_CONFIG_FILE>`_ with the path to an OpenTelemetry Collector OpAMP supervisor configuration file.
+Replace _`<SUPERVISOR_CONFIG_FILE>`_ with the path to an [OpenTelemetry Collector OpAMP supervisor configuration file](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/{{< param "OTEL_VERSION" >}}/cmd/opampsupervisor/specification/README.md).

--- a/docs/sources/reference/cli/otel-supervisor.md
+++ b/docs/sources/reference/cli/otel-supervisor.md
@@ -19,29 +19,23 @@ weight: 360
 The `otel-supervisor` command runs {{< param "PRODUCT_NAME" >}} with the {{< param "OTEL_ENGINE" >}} under an embedded OpAMP supervisor.
 The supervisor connects to Grafana Fleet Management and receives the {{< param "OTEL_ENGINE" >}} configuration through OpAMP.
 
-{{< admonition type="note" >}}
-Grafana Fleet Management doesn't officially support {{< param "PRODUCT_NAME" >}}. Grafana Labs doesn't provide support for this configuration.
-{{< /admonition >}}
-
 ## Usage
 
-To use environment-based configuration, run the following command:
+The `otel-supervisor` command supports simple and manual modes.
+
+Simple mode helps you get started quickly with Grafana Fleet Management.
+Use manual mode to connect to an OpAMP server other than Grafana Fleet Management.
+
+## Run in simple mode
+
+Simple mode uses environment variables to configure the supervisor.
+To run it, use the following command:
 
 ```shell
 alloy otel-supervisor
 ```
 
-To use a supervisor configuration file, run the following command:
-
-```shell
-alloy otel-supervisor --config=<SUPERVISOR_CONFIG_FILE>
-```
-
-Replace _`<SUPERVISOR_CONFIG_FILE>`_ with the path to an OpAMP supervisor configuration file.
-
-## Configure with environment variables
-
-When you omit `--config`, the command reads the following environment variables:
+To configure simple mode, set the following environment variables:
 
 * `GCLOUD_FM_URL`: The Grafana Fleet Management base URL. The command adds `/v1/opamp` when the URL doesn't include it.
 * `GCLOUD_INSTANCE_ID`: Your Grafana Cloud instance ID.
@@ -60,3 +54,14 @@ alloy otel-supervisor
 ```
 
 For information about setting up Fleet Management, refer to the [Grafana Fleet Management documentation](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/).
+
+## Run in manual mode
+
+Manual mode uses a supervisor configuration file.
+To run it, use the following command:
+
+```shell
+alloy otel-supervisor --config=<SUPERVISOR_CONFIG_FILE>
+```
+
+Replace _`<SUPERVISOR_CONFIG_FILE>`_ with the path to an OpenTelemetry Collector OpAMP supervisor configuration file.

--- a/docs/sources/reference/cli/otel-supervisor.md
+++ b/docs/sources/reference/cli/otel-supervisor.md
@@ -11,10 +11,7 @@ weight: 360
 
 # `otel-supervisor`
 
-> **EXPERIMENTAL**: This is an [experimental][] feature.
-> Experimental features are subject to frequent breaking changes, and may be removed with no equivalent replacement.
-
-[experimental]: https://grafana.com/docs/release-life-cycle/
+{{< docs/shared lookup="stability/experimental_feature.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 The `otel-supervisor` command runs {{< param "PRODUCT_NAME" >}} with the {{< param "OTEL_ENGINE" >}} under an embedded OpAMP supervisor.
 The supervisor connects to Grafana Fleet Management and receives the {{< param "OTEL_ENGINE" >}} configuration through OpAMP.

--- a/docs/sources/reference/cli/otel-supervisor.md
+++ b/docs/sources/reference/cli/otel-supervisor.md
@@ -1,0 +1,62 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/cli/otel-supervisor/
+description: Learn about the otel-supervisor command
+labels:
+  stage: experimental
+  products:
+    - oss
+title: otel-supervisor
+weight: 360
+---
+
+# `otel-supervisor`
+
+> **EXPERIMENTAL**: This is an [experimental][] feature.
+> Experimental features are subject to frequent breaking changes, and may be removed with no equivalent replacement.
+
+[experimental]: https://grafana.com/docs/release-life-cycle/
+
+The `otel-supervisor` command runs {{< param "PRODUCT_NAME" >}} with the {{< param "OTEL_ENGINE" >}} under an embedded OpAMP supervisor.
+The supervisor connects to Grafana Fleet Management and receives the {{< param "OTEL_ENGINE" >}} configuration through OpAMP.
+
+{{< admonition type="note" >}}
+Grafana Fleet Management doesn't officially support {{< param "PRODUCT_NAME" >}}. Grafana Labs doesn't provide support for this configuration.
+{{< /admonition >}}
+
+## Usage
+
+To use environment-based configuration, run the following command:
+
+```shell
+alloy otel-supervisor
+```
+
+To use a supervisor configuration file, run the following command:
+
+```shell
+alloy otel-supervisor --config=<SUPERVISOR_CONFIG_FILE>
+```
+
+Replace _`<SUPERVISOR_CONFIG_FILE>`_ with the path to an OpAMP supervisor configuration file.
+
+## Configure with environment variables
+
+When you omit `--config`, the command reads the following environment variables:
+
+* `GCLOUD_FM_URL`: The Grafana Fleet Management base URL. The command adds `/v1/opamp` when the URL doesn't include it.
+* `GCLOUD_INSTANCE_ID`: Your Grafana Cloud instance ID.
+* `GCLOUD_RW_API_KEY`: Your Grafana Cloud API token.
+* `STORAGE_DIR`: A directory where the supervisor stores its data.
+
+Set the variables before you start the supervisor. The following shell example uses placeholder values:
+
+```shell
+export GCLOUD_FM_URL="<FLEET_MANAGEMENT_URL>"
+export GCLOUD_INSTANCE_ID="<GRAFANA_CLOUD_INSTANCE_ID>"
+export GCLOUD_RW_API_KEY="<GRAFANA_CLOUD_API_TOKEN>"
+export STORAGE_DIR="<SUPERVISOR_STORAGE_DIRECTORY>"
+
+alloy otel-supervisor
+```
+
+For information about setting up Fleet Management, refer to the [Grafana Fleet Management documentation](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/).

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -85,6 +85,13 @@ alloy otel --config=<CONFIG_FILE> [<FLAGS> ...]
 Metrics are also available on the default collector port and endpoint at `0.0.0.0:8888/metrics`.
 Since the {{< param "DEFAULT_ENGINE" >}} isn't running, the UI and metrics aren't available at `0.0.0.0:12345/metrics`.
 
+### Manage with Grafana Fleet Management
+
+Use the embedded `otel-supervisor` command to manage the {{< param "OTEL_ENGINE" >}} through Grafana Fleet Management.
+The supervisor starts {{< param "PRODUCT_NAME" >}} and receives OpenTelemetry Collector configuration from Grafana Fleet Management through OpAMP.
+
+Refer to [`otel-supervisor`](../../reference/cli/otel-supervisor/) for setup instructions and required environment variables.
+
 ### Run the {{% param "PRODUCT_NAME" %}} Engine extension
 
 You can also run the {{< param "OTEL_ENGINE" >}} with the {{< param "DEFAULT_ENGINE" >}}.
@@ -273,8 +280,6 @@ In the meantime, use the CLI or Helm options for testing.
    The {{< param "OTEL_ENGINE" >}} exposes its HTTP server on port `8888`.
    The {{< param "OTEL_ENGINE" >}} HTTP server doesn't expose a UI, support bundles, or reload endpoint functionality like the {{< param "DEFAULT_ENGINE" >}} does.
 1. **Inline configuration module path**: If `config.inline.module_path` isn't defined, the `module_path` {{< param "PRODUCT_NAME" >}} configuration keyword resolves to the process current working directory.
-1. **Fleet management**: [Grafana Fleet Management](https://grafana.com/blog/opentelemetry-and-grafana-labs-whats-new-and-whats-next-in-2026/#fleet-management) doesn't support the {{< param "OTEL_ENGINE" >}} yet.
-   You must define and manage the input configuration manually.
 
 ## Next steps
 


### PR DESCRIPTION
### Brief description of Pull Request

This exposes the experimental OTel supervisor command and adds relevant docs/instructions to set it up with Grafana fleet Management

### Pull Request Details

This experimental feature seems to be already working, and now it's ready to be used (see epic: #6415 )

Command is now shown, with relevant docs on how to use it.

I myself tested it with Grafana fleet management and it's working.
<img width="934" height="99" alt="image" src="https://github.com/user-attachments/assets/e298aab9-f2fa-4874-a50d-e087b65b1d5c" />
<img width="1573" height="455" alt="image" src="https://github.com/user-attachments/assets/593239d5-744c-4642-92f3-4ab7e0ae50a4" />

One thing about wording is I added the "Grafana Fleet Management doesn't officially support Alloy", I'm not a 100% if that's the right way to word it, but I got that from the original issue #6687 

While the initial bulk of modifications was made by AI, I made modifications to ensure it follows proper wording standards, and I did a sanity check on everything and manually test it.

### Issue(s) fixed by this Pull Request

Fixes #6687 

### Notes to the Reviewer

Direct follow up to #6415 , now that the experimental command for Otel supervisor works, this exposes it and adds documentation, would a double check on the wording there, especially around official support from FM

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))