### PR TITLE
fix: Reject empty snmp module and auth definitions instead of panicking

### DIFF
--- a/internal/static/integrations/snmp_exporter/snmp.go
+++ b/internal/static/integrations/snmp_exporter/snmp.go
@@ -84,6 +84,10 @@ func Handler(w http.ResponseWriter, r *http.Request, logger *slog.Logger, snmpCf
 			http.Error(w, fmt.Sprintf("Unknown module '%s'", moduleName), http.StatusBadRequest)
 			return
 		}
+		if module == nil {
+			http.Error(w, fmt.Sprintf("Module '%s' has an empty definition", moduleName), http.StatusBadRequest)
+			return
+		}
 
 		// override module connection details with custom walk params if provided
 		if walkParams != "" {
@@ -114,6 +118,10 @@ func Handler(w http.ResponseWriter, r *http.Request, logger *slog.Logger, snmpCf
 	auth, ok := (*snmpCfg).Auths[authName]
 	if !ok {
 		http.Error(w, fmt.Sprintf("Unknown auth '%s'", authName), http.StatusBadRequest)
+		return
+	}
+	if auth == nil {
+		http.Error(w, fmt.Sprintf("Auth '%s' has an empty definition", authName), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter.go
@@ -121,6 +121,9 @@ func LoadSNMPConfig(snmpConfigFile string, customSnmpCfg *snmp_config.Config, st
 				return nil, fmt.Errorf("failed to load embedded snmp config: %w", err)
 			}
 		}
+		if err := validateSNMPConfig(customSnmpCfg); err != nil {
+			return nil, err
+		}
 		return customSnmpCfg, nil
 	case "merge":
 		var finalCfg *snmp_config.Config
@@ -135,10 +138,28 @@ func LoadSNMPConfig(snmpConfigFile string, customSnmpCfg *snmp_config.Config, st
 		if len(customSnmpCfg.Modules) > 0 {
 			maps.Copy(finalCfg.Modules, customSnmpCfg.Modules)
 		}
+		if err := validateSNMPConfig(finalCfg); err != nil {
+			return nil, err
+		}
 		return finalCfg, nil
 	default:
 		return nil, fmt.Errorf("unsupported snmp config merge strategy is used: '%s'", strategy)
 	}
+}
+
+// validateSNMPConfig rejects module and auth entries with empty definitions.
+func validateSNMPConfig(cfg *snmp_config.Config) error {
+	for name, module := range cfg.Modules {
+		if module == nil {
+			return fmt.Errorf("snmp module %q has an empty definition", name)
+		}
+	}
+	for name, auth := range cfg.Auths {
+		if auth == nil {
+			return fmt.Errorf("snmp auth %q has an empty definition", name)
+		}
+	}
+	return nil
 }
 
 func NewSNMPMetrics(reg prometheus.Registerer) collector.Metrics {

--- a/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
+++ b/internal/static/integrations/snmp_exporter/snmp_exporter_test.go
@@ -119,3 +119,45 @@ func TestLoadSNMPConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadSNMPConfigRejectsEmptyDefinitions(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         Config
+		expectedErr string
+	}{
+		{
+			name: "nil module in replace strategy",
+			cfg: Config{
+				SnmpConfig:              snmp_config.Config{Modules: map[string]*snmp_config.Module{"if_mib": nil}},
+				SnmpConfigMergeStrategy: "replace",
+			},
+			expectedErr: `snmp module "if_mib" has an empty definition`,
+		},
+		{
+			name: "nil module in merge strategy",
+			cfg: Config{
+				SnmpConfig:              snmp_config.Config{Modules: map[string]*snmp_config.Module{"cisco_device": nil}},
+				SnmpConfigMergeStrategy: "merge",
+			},
+			expectedErr: `snmp module "cisco_device" has an empty definition`,
+		},
+		{
+			name: "nil auth in replace strategy",
+			cfg: Config{
+				SnmpConfig: snmp_config.Config{
+					Modules: map[string]*snmp_config.Module{"if_mib": {Walk: []string{"1.3.6.1.2.1.2"}}},
+					Auths:   map[string]*snmp_config.Auth{"inno": nil},
+				},
+				SnmpConfigMergeStrategy: "replace",
+			},
+			expectedErr: `snmp auth "inno" has an empty definition`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadSNMPConfig(tt.cfg.SnmpConfigFile, &tt.cfg.SnmpConfig, tt.cfg.SnmpConfigMergeStrategy)
+			require.ErrorContains(t, err, tt.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #6760.

A config like `modules: {if_mib:}` parses the module as nil. The map key exists, so the handler's Unknown module check passes, and the nil module reaches the snmp_exporter collector, which crashes the whole process at scrape time (collector.go:445 in the report). LoadSNMPConfig now rejects nil module and auth entries with an error naming the key, in both merge strategies, and the scrape handler has matching nil backstops. The new tests fail on main and pass with the fix.

The deeper guard arguably belongs in prometheus/snmp_exporter's collector too, so a nil module can never panic regardless of the caller, but I kept this PR to the alloy side.