### PR TITLE
feat(prometheus.exporter.cloudwatch): Export historical data points

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
@@ -334,8 +334,11 @@ Refer to the [View available metrics](https://docs.aws.amazon.com/AmazonCloudWat
 | `period`                   | `duration`     | Refer to the [period][] section below.                                     | The value of `period` in the parent job.                                                                           | no       |
 | `statistics`               | `list(string)` | List of statistics to scrape. For example, `"Minimum"`, `"Maximum"`, etc.  |                                                                                                                    | yes      |
 | `add_cloudwatch_timestamp` | `bool`         | When `true`, use the timestamp from CloudWatch instead of the scrape time. | The value of `add_cloudwatch_timestamp` in the parent job.                                                         | no       |
+| `export_all_data_points`   | `bool`         | When `true`, export every CloudWatch data point in the configured time range. This setting requires `add_cloudwatch_timestamp` to be `true`. | `false` | no |
 | `length`                   | `duration`     | Refer to the [period][] section below.                                     | The value of `length` in the parent job.                                                                           | no       |
 | `nil_to_zero`              | `bool`         | When `true`, `NaN` metric values are converted to 0.                       | The value of `nil_to_zero` in the parent [`static`][static] or [`discovery`][discovery] block. `true` if not set in the parent block. | no       |
+
+To export historical data points, set both `add_cloudwatch_timestamp` and `export_all_data_points` to `true`. To export multiple historical data points, configure `length` to be longer than `period`.
 
 [period]: #period-and-length
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
@@ -341,7 +341,23 @@ Refer to the [View available metrics](https://docs.aws.amazon.com/AmazonCloudWat
 To export historical data points, set `export_all_data_points` to `true` and enable `add_cloudwatch_timestamp`.
 For `discovery` and `custom_namespace` jobs, you can set `add_cloudwatch_timestamp` on the job or metric.
 For `static` jobs, set `add_cloudwatch_timestamp` on each metric.
-To export multiple historical data points, configure `length` to be longer than `period`.
+| Name                       | Type           | Description                                                    | Default                                                                                  | Required |
+| -------------------------- | -------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------- |
+| `name`                     | `string`       | Metric name.                                                   |                                                                                          | yes      |
+| `statistics`               | `list(string)` | Statistics to scrape, for example `"Minimum"` and `"Maximum"`. |                                                                                          | yes      |
+| `add_cloudwatch_timestamp` | `bool`         | Use CloudWatch timestamp instead of scrape time.               | Inherited from parent `discovery` or `custom_namespace`. `false` if not set.             | no       |
+| `export_all_data_points`   | `bool`         | Export all CloudWatch data points in the selected time range.  | `false`                                                                                  | no       |
+| `length`                   | `duration`     | Query range length. Refer to [period][].                       | Inherited from parent job `length`.                                                      | no       |
+| `nil_to_zero`              | `bool`         | Convert `NaN` metric values to 0.                              | Inherited from parent [`static`][static] or [`discovery`][discovery]. `true` if not set. | no       |
+| `period`                   | `duration`     | CloudWatch period. Refer to [period][].                        | Inherited from parent job `period`.                                                      | no       |
+
+For `discovery` and `custom_namespace` jobs, you can set `add_cloudwatch_timestamp` on the job or metric.
+
+For `static` jobs, set `add_cloudwatch_timestamp` on each metric.
+
+To export all historical data points, set `export_all_data_points` and `add_cloudwatch_timestamp` to `true`.
+
+To export multiple historical data points, configure `length` greater than `period`.
 
 [period]: #period-and-length
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
@@ -328,19 +328,6 @@ Represents an AWS Metric to scrape.
 The `metric` block may be specified multiple times to define multiple target metrics.
 Refer to the [View available metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/viewing_metrics_with_cloudwatch.html) topic in the Amazon CloudWatch documentation for detailed metrics information.
 
-| Name                       | Type           | Description                                                                | Default                                                                                                            | Required |
-| -------------------------- | -------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- |
-| `name`                     | `string`       | Metric name.                                                               |                                                                                                                    | yes      |
-| `period`                   | `duration`     | Refer to the [period][] section below.                                     | The value of `period` in the parent job.                                                                           | no       |
-| `statistics`               | `list(string)` | List of statistics to scrape. For example, `"Minimum"`, `"Maximum"`, etc.  |                                                                                                                    | yes      |
-| `add_cloudwatch_timestamp` | `bool`         | When `true`, use the timestamp from CloudWatch instead of the scrape time. | The value of `add_cloudwatch_timestamp` in the parent `discovery` or `custom_namespace` job. `false` if not set. | no       |
-| `export_all_data_points`   | `bool`         | When `true`, export every CloudWatch data point in the configured time range. You must enable `add_cloudwatch_timestamp`. | `false` | no |
-| `length`                   | `duration`     | Refer to the [period][] section below.                                     | The value of `length` in the parent job.                                                                           | no       |
-| `nil_to_zero`              | `bool`         | When `true`, `NaN` metric values are converted to 0.                       | The value of `nil_to_zero` in the parent [`static`][static] or [`discovery`][discovery] block. `true` if not set in the parent block. | no       |
-
-To export historical data points, set `export_all_data_points` to `true` and enable `add_cloudwatch_timestamp`.
-For `discovery` and `custom_namespace` jobs, you can set `add_cloudwatch_timestamp` on the job or metric.
-For `static` jobs, set `add_cloudwatch_timestamp` on each metric.
 | Name                       | Type           | Description                                                    | Default                                                                                  | Required |
 | -------------------------- | -------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------- |
 | `name`                     | `string`       | Metric name.                                                   |                                                                                          | yes      |

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.cloudwatch.md
@@ -333,12 +333,15 @@ Refer to the [View available metrics](https://docs.aws.amazon.com/AmazonCloudWat
 | `name`                     | `string`       | Metric name.                                                               |                                                                                                                    | yes      |
 | `period`                   | `duration`     | Refer to the [period][] section below.                                     | The value of `period` in the parent job.                                                                           | no       |
 | `statistics`               | `list(string)` | List of statistics to scrape. For example, `"Minimum"`, `"Maximum"`, etc.  |                                                                                                                    | yes      |
-| `add_cloudwatch_timestamp` | `bool`         | When `true`, use the timestamp from CloudWatch instead of the scrape time. | The value of `add_cloudwatch_timestamp` in the parent job.                                                         | no       |
-| `export_all_data_points`   | `bool`         | When `true`, export every CloudWatch data point in the configured time range. This setting requires `add_cloudwatch_timestamp` to be `true`. | `false` | no |
+| `add_cloudwatch_timestamp` | `bool`         | When `true`, use the timestamp from CloudWatch instead of the scrape time. | The value of `add_cloudwatch_timestamp` in the parent `discovery` or `custom_namespace` job. `false` if not set. | no       |
+| `export_all_data_points`   | `bool`         | When `true`, export every CloudWatch data point in the configured time range. You must enable `add_cloudwatch_timestamp`. | `false` | no |
 | `length`                   | `duration`     | Refer to the [period][] section below.                                     | The value of `length` in the parent job.                                                                           | no       |
 | `nil_to_zero`              | `bool`         | When `true`, `NaN` metric values are converted to 0.                       | The value of `nil_to_zero` in the parent [`static`][static] or [`discovery`][discovery] block. `true` if not set in the parent block. | no       |
 
-To export historical data points, set both `add_cloudwatch_timestamp` and `export_all_data_points` to `true`. To export multiple historical data points, configure `length` to be longer than `period`.
+To export historical data points, set `export_all_data_points` to `true` and enable `add_cloudwatch_timestamp`.
+For `discovery` and `custom_namespace` jobs, you can set `add_cloudwatch_timestamp` on the job or metric.
+For `static` jobs, set `add_cloudwatch_timestamp` on each metric.
+To export multiple historical data points, configure `length` to be longer than `period`.
 
 [period]: #period-and-length
 

--- a/internal/component/prometheus/exporter/cloudwatch/config.go
+++ b/internal/component/prometheus/exporter/cloudwatch/config.go
@@ -132,6 +132,7 @@ type Metric struct {
 	Length                 time.Duration `alloy:"length,attr,optional"`
 	NilToZero              *bool         `alloy:"nil_to_zero,attr,optional"`
 	AddCloudwatchTimestamp *bool         `alloy:"add_cloudwatch_timestamp,attr,optional"`
+	ExportAllDataPoints    *bool         `alloy:"export_all_data_points,attr,optional"`
 }
 
 // SetToDefault implements syntax.Defaulter.
@@ -294,6 +295,7 @@ func toYACEMetrics(ms []Metric, jobPeriod time.Duration, jobLength time.Duration
 
 			NilToZero:              m.NilToZero,
 			AddCloudwatchTimestamp: m.AddCloudwatchTimestamp,
+			ExportAllDataPoints:    m.ExportAllDataPoints,
 		})
 	}
 	return yaceMetrics

--- a/internal/component/prometheus/exporter/cloudwatch/config.go
+++ b/internal/component/prometheus/exporter/cloudwatch/config.go
@@ -285,11 +285,10 @@ func toYACEMetrics(ms []Metric, jobPeriod time.Duration, jobLength time.Duration
 			Name:       m.Name,
 			Statistics: m.Statistics,
 
-			// Length dictates the size of the window for whom we request metrics, that is, endTime - startTime. Period
-			// dictates the size of the buckets in which we aggregate data, inside that window. Since data will be scraped
-			// by Alloy every so often, dictated by the scrapedInterval, CloudWatch should return a single datapoint
-			// for each requested metric. That is if Period >= Length, but is Period > Length, we will be getting not enough
-			// data to fill the whole aggregation bucket. Therefore, Period == Length.
+			// Length defines the metric query window, endTime - startTime. Period defines the aggregation bucket size within
+			// that window. When length isn't configured, this function sets it equal to period. A configured length greater
+			// than period lets YACE return multiple data points when ExportAllDataPoints is enabled. YACE rejects a length
+			// shorter than period.
 			Period: periodSeconds,
 			Length: lengthSeconds,
 

--- a/internal/component/prometheus/exporter/cloudwatch/config_test.go
+++ b/internal/component/prometheus/exporter/cloudwatch/config_test.go
@@ -851,7 +851,7 @@ var expectedCustomNamespaceJobPeriodConfig = yaceModel.JobsConfig{
 //==============================
 
 // Shows that historical data-point export can be enabled on a static-job metric.
-const staticJobAddCloudwatchTimestampConfig = `
+const staticJobHistoricalDataPointsConfig = `
 sts_region = "us-east-2"
 debug = true
 static "test_instance" {
@@ -889,7 +889,7 @@ static "test_instance" {
 }
 `
 
-var expectedStaticJobAddCloudwatchTimestampConfig = yaceModel.JobsConfig{
+var expectedStaticJobHistoricalDataPointsConfig = yaceModel.JobsConfig{
 	StsRegion: "us-east-2",
 	StaticJobs: []yaceModel.StaticJob{
 		{
@@ -1312,9 +1312,9 @@ func TestCloudwatchComponentConfig(t *testing.T) {
 			raw:              staticJobExportAllDataPointsWithoutTimestampConfig,
 			expectConvertErr: true,
 		},
-		"static job add cloudwatch timestamp config": {
-			raw:      staticJobAddCloudwatchTimestampConfig,
-			expected: expectedStaticJobAddCloudwatchTimestampConfig,
+		"static job historical data points config": {
+			raw:      staticJobHistoricalDataPointsConfig,
+			expected: expectedStaticJobHistoricalDataPointsConfig,
 		},
 		"custom namespace job add cloudwatch timestamp config": {
 			raw:      customNamespaceAddCloudwatchTimestampConfig,

--- a/internal/component/prometheus/exporter/cloudwatch/config_test.go
+++ b/internal/component/prometheus/exporter/cloudwatch/config_test.go
@@ -1050,6 +1050,21 @@ var expectedDiscoveryJobAddCloudwatchTimestampConfig = yaceModel.JobsConfig{
 	},
 }
 
+const discoveryJobHistoricalDataPointsWithInheritedTimestampConfig = `
+sts_region = "us-east-2"
+discovery {
+	type = "AWS/SQS"
+	regions = ["us-east-2"]
+	add_cloudwatch_timestamp = true
+	metric {
+		name = "NumberOfMessagesSent"
+		statistics = ["Sum"]
+		period = "1m"
+		export_all_data_points = true
+	}
+}
+`
+
 // ==========
 // delay jobs
 //===========
@@ -1358,4 +1373,22 @@ func TestCloudwatchComponentConfig(t *testing.T) {
 			require.EqualValues(t, tc.expected, converted)
 		})
 	}
+}
+
+func TestDiscoveryJobHistoricalDataPointsWithInheritedTimestamp(t *testing.T) {
+	args := Arguments{}
+	err := syntax.Unmarshal([]byte(discoveryJobHistoricalDataPointsWithInheritedTimestampConfig), &args)
+	require.NoError(t, err)
+
+	logger, err := logging.New(io.Discard, logging.DefaultOptions)
+	require.NoError(t, err)
+
+	converted, err := ConvertToYACE(args, logger.Slog())
+	require.NoError(t, err)
+	require.Len(t, converted.DiscoveryJobs, 1)
+	require.Len(t, converted.DiscoveryJobs[0].Metrics, 1)
+
+	metric := converted.DiscoveryJobs[0].Metrics[0]
+	require.True(t, metric.AddCloudwatchTimestamp)
+	require.True(t, metric.ExportAllDataPoints)
 }

--- a/internal/component/prometheus/exporter/cloudwatch/config_test.go
+++ b/internal/component/prometheus/exporter/cloudwatch/config_test.go
@@ -850,7 +850,7 @@ var expectedCustomNamespaceJobPeriodConfig = yaceModel.JobsConfig{
 // add_cloudwatch_timestamp jobs
 //==============================
 
-// Shows that add_cloudwatch_timestamp is not supported on static jobs will be set to false on metrics.
+// Shows that historical data-point export can be enabled on a static-job metric.
 const staticJobAddCloudwatchTimestampConfig = `
 sts_region = "us-east-2"
 debug = true
@@ -864,6 +864,27 @@ static "test_instance" {
 		name = "CPUUtilization"
 		statistics = ["Average"]
 		period = "5m"
+		add_cloudwatch_timestamp = true
+		export_all_data_points = true
+	}
+}
+`
+
+// Shows that historical data-point export requires CloudWatch timestamps.
+const staticJobExportAllDataPointsWithoutTimestampConfig = `
+sts_region = "us-east-2"
+debug = true
+static "test_instance" {
+	regions = ["us-east-2"]
+	namespace = "AWS/EC2"
+	dimensions = {
+		"InstanceId" = "i-test",
+	}
+	metric {
+		name = "CPUUtilization"
+		statistics = ["Average"]
+		period = "5m"
+		export_all_data_points = true
 	}
 }
 `
@@ -890,7 +911,8 @@ var expectedStaticJobAddCloudwatchTimestampConfig = yaceModel.JobsConfig{
 				Length:                 300,
 				Delay:                  0,
 				NilToZero:              defaultNilToZero,
-				AddCloudwatchTimestamp: falsePtr,
+				AddCloudwatchTimestamp: truePtr,
+				ExportAllDataPoints:    truePtr,
 			}},
 		},
 	},
@@ -1285,6 +1307,10 @@ func TestCloudwatchComponentConfig(t *testing.T) {
 		"custom namespace job period config": {
 			raw:      customNameSpaceJobPeriodConfig,
 			expected: expectedCustomNamespaceJobPeriodConfig,
+		},
+		"export all data points requires CloudWatch timestamps": {
+			raw:              staticJobExportAllDataPointsWithoutTimestampConfig,
+			expectConvertErr: true,
 		},
 		"static job add cloudwatch timestamp config": {
 			raw:      staticJobAddCloudwatchTimestampConfig,


### PR DESCRIPTION
### Brief description of Pull Request

This PR adds support for exporting all CloudWatch data points in prometheus.exporter.cloudwatch

### Pull Request Details

This PR simply adds the export_all_data_points optional config, now that YACE supports it. 

I also added an extra test just to be on the safe side, see notes below.

### Issue(s) fixed by this Pull Request

Fixes #6101

### Notes to the Reviewer

I added a negative test in case of future regression or change on YACE implementation, they don't seem to have a test for it but, they definitely check for it: https://github.com/kgeckhart/yet-another-cloudwatch-exporter/blob/440211eac126/pkg/config/config.go#L420 . Please let me know if it makes sense to keep

### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
