### PR TITLE
chore: Enable Appender v2 for prometheus.scrape, prometheus.operator.*, and otelcol.receiver.prometheus pipelines

### DIFF
--- a/internal/component/prometheus/debugv2.go
+++ b/internal/component/prometheus/debugv2.go
@@ -1,0 +1,58 @@
+package prometheus
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/grafana/alloy/internal/service/livedebugging"
+)
+
+// PublishV2DebugData publishes live debugging data for a v2 Append call.
+func PublishV2DebugData(
+	publisher livedebugging.DebugDataPublisher,
+	componentID livedebugging.ComponentID,
+	l labels.Labels,
+	t int64, v float64,
+	h *histogram.Histogram, fh *histogram.FloatHistogram,
+	opts storage.AppendV2Options,
+) {
+	if !publisher.IsActive(componentID) {
+		return
+	}
+
+	var data string
+	switch {
+	case fh != nil:
+		data = fmt.Sprintf("float_histogram: ts=%d, labels=%s, value=%s", t, l, fh.String())
+	case h != nil:
+		data = fmt.Sprintf("histogram: ts=%d, labels=%s, value=%s", t, l, h.String())
+	default:
+		data = fmt.Sprintf("sample: ts=%d, labels=%s, value=%f", t, l, v)
+	}
+	publisher.PublishIfActive(livedebugging.NewData(
+		componentID, livedebugging.PrometheusMetric, 1,
+		func() string { return data },
+	))
+
+	if opts.Metadata != (metadata.Metadata{}) {
+		publisher.PublishIfActive(livedebugging.NewData(
+			componentID, livedebugging.PrometheusMetric, 1,
+			func() string {
+				return fmt.Sprintf("metadata: labels=%s, type=%q, unit=%q, help=%q", l, opts.Metadata.Type, opts.Metadata.Unit, opts.Metadata.Help)
+			},
+		))
+	}
+
+	for _, e := range opts.Exemplars {
+		publisher.PublishIfActive(livedebugging.NewData(
+			componentID, livedebugging.PrometheusMetric, 1,
+			func() string {
+				return fmt.Sprintf("exemplar: ts=%d, labels=%s, exemplar_labels=%s, value=%f", e.Ts, l, e.Labels, e.Value)
+			},
+		))
+	}
+}

--- a/internal/component/prometheus/enrich/enrich.go
+++ b/internal/component/prometheus/enrich/enrich.go
@@ -206,6 +206,16 @@ func New(opts component.Options, args Arguments) (*Component, error) {
 
 			return next.AppendHistogram(0, newLabels, t, h, fh)
 		}),
+		prometheus.WithAppendV2Hook(func(_ storage.SeriesRef, ls labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, aopts storage.AppendV2Options, next storage.AppenderV2) (storage.SeriesRef, error) {
+			if c.exited.Load() {
+				return 0, fmt.Errorf("%s has exited", opts.ID)
+			}
+
+			newLabels := c.enrich(ls)
+
+			// Since SeriesRefs are tied to the labels, we send zero to indicate the seriesRef should be recalculated downstream.
+			return next.Append(0, newLabels, st, t, v, h, fh, aopts)
+		}),
 	)
 
 	if err = c.Update(args); err != nil {

--- a/internal/component/prometheus/operator/common/crdmanager.go
+++ b/internal/component/prometheus/operator/common/crdmanager.go
@@ -190,7 +190,7 @@ func (c *crdManager) Run(ctx context.Context) error {
 		ParseST:                           c.args.Scrape.StartTimestampZeroIngestion,
 		EnableStartTimestampZeroIngestion: c.args.Scrape.StartTimestampZeroIngestion,
 	}
-	c.scrapeManager, err = scrape.NewManager(scrapeOpts, c.logger, nil, alloyAppendable, nil, unregisterer)
+	c.scrapeManager, err = scrape.NewManager(scrapeOpts, c.logger, nil, nil, alloyAppendable, unregisterer)
 	if err != nil {
 		return fmt.Errorf("creating scrape manager: %w", err)
 	}

--- a/internal/component/prometheus/relabel/relabel.go
+++ b/internal/component/prometheus/relabel/relabel.go
@@ -243,6 +243,20 @@ func New(o component.Options, args Arguments) (*Component, error) {
 			// Since SeriesRefs are tied to the labels, we send zero to indicate the seriesRef should be recalculated downstream.
 			return next.AppendHistogram(0, newLbl, t, h, fh)
 		}),
+		prometheus.WithAppendV2Hook(func(ref storage.SeriesRef, ls labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts storage.AppendV2Options, next storage.AppenderV2) (storage.SeriesRef, error) {
+			if c.exited.Load() {
+				return 0, fmt.Errorf("%s has exited", o.ID)
+			}
+
+			newLbl := c.relabel(v, ls)
+			if newLbl.IsEmpty() {
+				return 0, nil
+			}
+			c.metricsOutgoing.Inc()
+
+			// Since SeriesRefs are tied to the labels, we send zero to indicate the seriesRef should be recalculated downstream.
+			return next.Append(0, newLbl, st, t, v, h, fh, opts)
+		}),
 	)
 
 	// Immediately export the receiver which remains the same for the component

--- a/internal/component/prometheus/remotewrite/interceptor.go
+++ b/internal/component/prometheus/remotewrite/interceptor.go
@@ -183,5 +183,27 @@ func NewInterceptor(componentID string, exited *atomic.Bool, debugDataPublisher 
 			}
 			return finalRef, err
 		}),
+		prometheus.WithAppendV2Hook(func(ref storage.SeriesRef, l labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts storage.AppendV2Options, next storage.AppenderV2) (storage.SeriesRef, error) {
+			if exited.Load() {
+				return 0, fmt.Errorf("%s has exited", componentID)
+			}
+
+			var finalRef storage.SeriesRef
+			var err error
+			if ls.Enabled() {
+				localRef := ls.GetLocalRefID(componentID, uint64(ref))
+				newLocalRef, nextErr := next.Append(storage.SeriesRef(localRef), l, st, t, v, h, fh, opts)
+				if nextErr == nil {
+					handleLocalLink(uint64(ref), l, localRef, uint64(newLocalRef))
+				}
+				finalRef = ref
+				err = nextErr
+			} else {
+				finalRef, err = next.Append(ref, l, st, t, v, h, fh, opts)
+			}
+
+			prometheus.PublishV2DebugData(debugDataPublisher, liveDebuggingComponentID, l, t, v, h, fh, opts)
+			return finalRef, err
+		}),
 	)
 }

--- a/internal/component/prometheus/scrape/interceptor.go
+++ b/internal/component/prometheus/scrape/interceptor.go
@@ -81,5 +81,10 @@ func NewInterceptor(componentID livedebugging.ComponentID, debugDataPublisher li
 			}
 			return newRef, nextErr
 		}),
+		prometheus.WithAppendV2Hook(func(ref storage.SeriesRef, l labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts storage.AppendV2Options, next storage.AppenderV2) (storage.SeriesRef, error) {
+			newRef, nextErr := next.Append(ref, l, st, t, v, h, fh, opts)
+			prometheus.PublishV2DebugData(debugDataPublisher, componentID, l, t, v, h, fh, opts)
+			return newRef, nextErr
+		}),
 	)
 }

--- a/internal/component/prometheus/scrape/scrape.go
+++ b/internal/component/prometheus/scrape/scrape.go
@@ -371,8 +371,8 @@ func New(o component.Options, args Arguments) (*Component, error) {
 		scrapeOptions,
 		c.opts.Logger,
 		func(s string) (*promlogging.JSONFileLogger, error) { return promlogging.NewJSONFileLogger(s) },
-		interceptor,
 		nil,
+		interceptor,
 		unregisterer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create scrape manager: %w", err)

--- a/internal/util/testappender/collectingappender.go
+++ b/internal/util/testappender/collectingappender.go
@@ -183,10 +183,50 @@ func (c ConstantAppendable) Appender(_ context.Context) storage.Appender {
 }
 
 func (c ConstantAppendable) AppenderV2(_ context.Context) storage.AppenderV2 {
-	panic("ConstantAppendable: AppenderV2 not implemented")
+	return &collectingAppenderV2{inner: c.Inner.(CollectingAppender)}
 }
 
 var (
 	_ storage.Appendable   = &ConstantAppendable{}
 	_ storage.AppendableV2 = &ConstantAppendable{}
 )
+
+// collectingAppenderV2 implements storage.AppenderV2 natively, recording
+// samples directly into the underlying CollectingAppender's maps.
+type collectingAppenderV2 struct {
+	inner CollectingAppender
+}
+
+var _ storage.AppenderV2 = (*collectingAppenderV2)(nil)
+
+func (a *collectingAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts storage.AppendV2Options) (storage.SeriesRef, error) {
+
+	switch {
+	case fh != nil:
+		ref, _ = a.inner.AppendHistogram(ref, ls, t, nil, fh)
+	case h != nil:
+		ref, _ = a.inner.AppendHistogram(ref, ls, t, h, nil)
+	default:
+		ref, _ = a.inner.Append(ref, ls, t, v)
+	}
+
+	if (opts.Metadata != metadata.Metadata{}) {
+		_, _ = a.inner.UpdateMetadata(ref, ls, opts.Metadata)
+	}
+	for _, e := range opts.Exemplars {
+		_, _ = a.inner.AppendExemplar(ref, ls, e)
+	}
+	if st != 0 {
+		switch {
+		case fh != nil || h != nil:
+			_, _ = a.inner.AppendHistogramSTZeroSample(ref, ls, t, st, h, fh)
+		default:
+			_, _ = a.inner.AppendSTZeroSample(ref, ls, t, st)
+		}
+	}
+
+	return ref, nil
+}
+
+func (a *collectingAppenderV2) Commit() error   { return a.inner.Commit() }
+func (a *collectingAppenderV2) Rollback() error { return a.inner.Rollback() }


### PR DESCRIPTION
### Pull Request Details

If a pipeline starts with prometheus.scrape, prometheus.operator.*, or otelcol.receiver.prometheus, then it will use Appender v2.

### Issue(s) fixed by this Pull Request

Part of #6896

### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
