### PR TITLE
docs: Fix name of config flag for disabling support-bundle endpoint

### DIFF
--- a/docs/sources/reference/cli/run.md
+++ b/docs/sources/reference/cli/run.md
@@ -43,7 +43,7 @@ The following flags are supported:
 * `--server.http.ui-path-prefix`: Base path where the UI is exposed (default `"/"`).
 * `--storage.path`: Base directory where components can store data (default `"data-alloy/"`).
 * `--disable-reporting`: Disable [data collection][] (default `false`).
-* `--disable-support-bundle`: Disable [support bundle][] endpoint (default `false`).
+* `--server.http.disable-support-bundle`: Disable [support bundle][] endpoint (default `false`).
 * `--cluster.enabled`: Start {{< param "PRODUCT_NAME" >}} in clustered mode (default `false`).
 * `--cluster.node-name`: The name to use for this node (defaults to the environment's hostname).
 * `--cluster.join-addresses`: Comma-separated list of addresses to join the cluster at (default `""`). Mutually exclusive with `--cluster.discover-peers`.

--- a/docs/sources/troubleshoot/support_bundle.md
+++ b/docs/sources/troubleshoot/support_bundle.md
@@ -19,7 +19,7 @@ to debug an [issue][alloy-repo].
 This feature isn't covered by the [backward-compatibility][backward-compatibility] guarantees.
 
 {{< admonition type="note" >}}
-This endpoint is enabled by default, but may be disabled using the `--disable-support-bundle` runtime flag.
+This endpoint is enabled by default, but may be disabled using the `--server.http.disable-support-bundle` runtime flag.
 {{< /admonition >}}
 
 The duration parameter is optional, must be less than or equal to the


### PR DESCRIPTION
### Brief description of Pull Request

<!-- Factual, human-readable summary of what changed (squash commit body). -->

Correct the documented support bundle flag from `--disable-support-bundle` to `--server.http.disable-support-bundle` in the CLI reference and troubleshooting guide.


### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))