### PR TITLE
ci: Add CGO_LDFLAGS options and set to -lssp for windows release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@
 ##   GOARCH               Override target architecture to build binaries for
 ##   GOARM                Override ARM version (6 or 7) when GOARCH=arm
 ##   CGO_ENABLED          Set to 0 to disable Cgo for binaries.
+##   CGO_LDFLAGS          Extra flags passed to the external C linker for Cgo binaries.
 ##   RELEASE_BUILD        Set to 1 to build release binaries.
 ##   VERSION              Version to inject into built binaries.
 ##   GO_TAGS              Extra tags to use when building.
@@ -107,6 +108,7 @@ GOOS                 		?= $(shell go env GOOS)
 GOARCH               		?= $(shell go env GOARCH)
 GOARM                		?= $(shell go env GOARM)
 CGO_ENABLED          		?= 1
+CGO_LDFLAGS          		?=
 RELEASE_BUILD        		?= 0
 GOEXPERIMENT         		?= $(shell go env GOEXPERIMENT)
 
@@ -138,7 +140,7 @@ GOLANGCI_LINT_BINARY ?= $(or \
 # container. USE_CONTAINER must _not_ be included to avoid infinite recursion.
 PROPAGATE_VARS := \
     ALLOY_IMAGE ALLOY_IMAGE_WINDOWS \
-    BUILD_IMAGE GOOS GOARCH GOARM CGO_ENABLED RELEASE_BUILD \
+    BUILD_IMAGE GOOS GOARCH GOARM CGO_ENABLED CGO_LDFLAGS RELEASE_BUILD \
     ALLOY_BINARY \
     VERSION GO_TAGS GOEXPERIMENT GOLANGCI_LINT_BINARY \
     SKIP_CODE_GENERATION \
@@ -154,7 +156,7 @@ ifeq ($(filter gore2regex,$(GO_TAGS)),)
 override GO_TAGS := $(strip gore2regex $(GO_TAGS))
 endif
 
-GO_ENV := GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED)
+GO_ENV := GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED) CGO_LDFLAGS="$(CGO_LDFLAGS)"
 
 # Clears cross-compile settings, to be set in any build-time generation steps that run "go run" under the hood
 GO_HOST_ENV := env -u GOOS -u GOARCH CGO_ENABLED=0

--- a/build-tools/make/packaging.mk
+++ b/build-tools/make/packaging.mk
@@ -17,7 +17,7 @@ clean-dist:
 # reference time. Earlier iterations of this file had each target explicitly
 # list these, but it's too easy to forget to set on so this is used to ensure
 # everything needed is always passed through.
-PACKAGING_VARS = RELEASE_BUILD=1 GO_TAGS="$(GO_TAGS)" GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) GOEXPERIMENT=$(GOEXPERIMENT)
+PACKAGING_VARS = RELEASE_BUILD=1 GO_TAGS="$(GO_TAGS)" GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) GOEXPERIMENT=$(GOEXPERIMENT) CGO_LDFLAGS="$(CGO_LDFLAGS)"
 
 .PHONY: dist-alloy-mixin-zip
 dist-alloy-mixin-zip:
@@ -78,9 +78,10 @@ dist/alloy-darwin-arm64: generate-ui
 #
 # TODO(rfratto): add netgo back to Windows builds if a version of Go is
 # released which natively supports resolving DNS short names on Windows.
-dist/alloy-windows-amd64.exe: GO_TAGS += embedalloyui
-dist/alloy-windows-amd64.exe: GOOS    := windows
-dist/alloy-windows-amd64.exe: GOARCH  := amd64
+dist/alloy-windows-amd64.exe: GO_TAGS    += embedalloyui
+dist/alloy-windows-amd64.exe: GOOS       := windows
+dist/alloy-windows-amd64.exe: GOARCH     := amd64
+dist/alloy-windows-amd64.exe: CGO_LDFLAGS := -lssp
 dist/alloy-windows-amd64.exe: generate-ui generate-winmanifest
 	$(PACKAGING_VARS) ALLOY_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy
 
@@ -128,9 +129,10 @@ dist/alloy-boringcrypto-linux-arm64: generate-ui
 
 dist-alloy-service-binaries: dist.temp/alloy-service-windows-amd64.exe
 
-dist.temp/alloy-service-windows-amd64.exe: GO_TAGS += embedalloyui
-dist.temp/alloy-service-windows-amd64.exe: GOOS    := windows
-dist.temp/alloy-service-windows-amd64.exe: GOARCH  := amd64
+dist.temp/alloy-service-windows-amd64.exe: GO_TAGS    += embedalloyui
+dist.temp/alloy-service-windows-amd64.exe: GOOS       := windows
+dist.temp/alloy-service-windows-amd64.exe: GOARCH     := amd64
+dist.temp/alloy-service-windows-amd64.exe: CGO_LDFLAGS := -lssp
 dist.temp/alloy-service-windows-amd64.exe: generate-ui generate-winmanifest
 	$(PACKAGING_VARS) SERVICE_BINARY=$@ "$(MAKE)" -f $(PARENT_MAKEFILE) alloy-service
 


### PR DESCRIPTION
### Brief description of Pull Request
This PR sets `CGO_LDFLAGS` in the windows packaging workflows, which would hopefully fix the [linking errors we're seeing](https://github.com/grafana/alloy/actions/runs/32185298563/job/95960314337) in the RC build

### Pull Request Details
[This PR](https://github.com/grafana/alloy/pull/6692) was merged that migrated the windows toolchain from `TDM-GCC` to `mingw-w64` in our windows docker image that is used to build Alloy in PR CI workflows. This was because a new db o11y [feature](https://github.com/grafana/alloy/pull/6746) was merged that required CGO dependencies compiled with `-fstack-protector` - which `TDM-GCC` does not support

Our build image, used for building/publishing for alloy windows images, uses the [viceroy library](https://github.com/grafana/alloy/blob/4cd37219590b1623c6843402cfddde5ad4d6ce12/build-tools/build-image/Dockerfile#L54-L56) for cross compilation, which under the hood actually does use [mingw-w64](https://github.com/rfratto/viceroy/blob/main/rootfs/viceroycc-windows#L5-L6), but it's an older version that explicitly requires the `-lssp` `CGO_LDFLAGS` variable to be set to properly link with stack protector settings

### PR Checklist
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md)) -> my findings here are based on a claude investigation, but looking at upstream commits like [this](https://github.com/mingw-w64/mingw-w64/commit/10394c9a966f8e93e9e2f09677dab273a0f6c00c), it seems to check out
