### PR TITLE
ci: Failing linker in alloy windows CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ sync-beyla-docs-version:
 
 .PHONY: download-beyla
 download-beyla:
-	@env -u GOOS -u GOARCH -u GOARM go run ./$(BEYLA_SCHEMA_DIR)/download.go \
+	@env -u GOOS -u GOARCH -u GOARM CGO_ENABLED=0 go run ./$(BEYLA_SCHEMA_DIR)/download.go \
 	    $(BEYLA_BINARY_AMD64) \
 	    $(BEYLA_BINARY_ARM64) \
 	    $(BEYLA_BINARY_STAMP) \


### PR DESCRIPTION
### Brief description of Pull Request
Follow up to https://github.com/grafana/alloy/pull/6925

Disable `CGO_ENABLED` for the `download-beyla` target, we're setting the `CGO_LDFLAG` flag to [-lssp](https://github.com/grafana/alloy/blob/9935420f4c2ea7d621d83f784026a9be98c5ebba/build-tools/make/packaging.mk#L84) which is being propagated down to the beyla download target and causing [errors](https://github.com/grafana/alloy/actions/runs/32249214815). We don't need CGO for this step, so we can disable it entirely and prevent further issues  

### PR Checklist
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
