### PR TITLE
perf(prometheus.fanout): Reduce blocking while removing stale refs in SeriesRefMapping

### DIFF
--- a/internal/component/prometheus/appenders/seriesrefmapping.go
+++ b/internal/component/prometheus/appenders/seriesrefmapping.go
@@ -434,41 +434,68 @@ func (s *SeriesRefMappingStore) cleanupStaleRefs() {
 	for {
 		select {
 		case <-ticker.C:
-			cutoffTime := time.Now().Add(-15 * time.Minute).Unix()
-
-			// Hold both locks to prevent race condition where a ref could be
-			// appended after we delete it from uniqueRefCell but before
-			// we delete it from uniqueRefToChildRefs
-			s.timestampTrackingMu.Lock()
-			s.refMappingMu.Lock()
-
-			staleRefCount := 0
-			for ref, ts := range s.uniqueRefTimestamps {
-				if ts < cutoffTime {
-					staleRefCount++
-
-					v, ok := s.uniqueRefToChildRefs[ref]
-					if ok {
-						delete(s.labelHashToUniqueRef, v.labelHash)
-					}
-
-					delete(s.uniqueRefTimestamps, ref)
-					delete(s.uniqueRefToChildRefs, ref)
-				}
-			}
-
-			// Update metrics
-			if staleRefCount > 0 {
-				s.refsCleaned.Add(float64(staleRefCount))
-				s.activeMappings.Sub(float64(staleRefCount))
-				s.trackedRefs.Set(float64(len(s.uniqueRefTimestamps)))
-			}
-
-			s.refMappingMu.Unlock()
-			s.timestampTrackingMu.Unlock()
-
+			s.removeStaleRefs(time.Now().Add(-15 * time.Minute).Unix())
 		case <-s.stopCleanup:
 			return
+		}
+	}
+}
+
+// staleRefDeleteChunk bounds the mappings deleted per refMappingMu acquisition.
+const staleRefDeleteChunk = 8192
+
+// removeStaleRefs evicts every ref last appended before cutoff.
+//
+// Every append takes refMappingMu as a reader via GetMapping. Deletes therefore go out
+// in bounded batches, keeping each hold of that lock short.
+func (s *SeriesRefMappingStore) removeStaleRefs(cutoff int64) {
+	// At 8192 refs this is exactly 64KiB, the largest implicit variable the compiler
+	// will stack-allocate, so the buffer costs no heap at all. Raising the chunk
+	// moves it to the heap.
+	batch := make([]storage.SeriesRef, 0, staleRefDeleteChunk)
+	stale := 0
+
+	s.timestampTrackingMu.Lock()
+	for ref, ts := range s.uniqueRefTimestamps {
+		if ts >= cutoff {
+			continue
+		}
+		batch = append(batch, ref)
+		delete(s.uniqueRefTimestamps, ref)
+		stale++
+		if len(batch) == staleRefDeleteChunk {
+			s.deleteMappings(batch)
+			batch = batch[:0]
+		}
+	}
+	s.deleteMappings(batch)
+	s.trackedRefs.Set(float64(len(s.uniqueRefTimestamps)))
+	s.timestampTrackingMu.Unlock()
+
+	s.refsCleaned.Add(float64(stale))
+
+	// Read the gauge off the map rather than tracking a running delta, so it re-syncs
+	// every cycle even when a ref was tracked without a mapping behind it.
+	s.refMappingMu.RLock()
+	s.activeMappings.Set(float64(len(s.uniqueRefToChildRefs)))
+	s.refMappingMu.RUnlock()
+}
+
+// deleteMappings drops refs' mappings under a single refMappingMu write. Callers already
+// hold timestampTrackingMu; refMappingMu is always the second of the two to avoid
+// deadlock.
+func (s *SeriesRefMappingStore) deleteMappings(refs []storage.SeriesRef) {
+	if len(refs) == 0 {
+		return
+	}
+
+	s.refMappingMu.Lock()
+	defer s.refMappingMu.Unlock()
+
+	for _, ref := range refs {
+		if v, ok := s.uniqueRefToChildRefs[ref]; ok {
+			delete(s.labelHashToUniqueRef, v.labelHash)
+			delete(s.uniqueRefToChildRefs, ref)
 		}
 	}
 }

--- a/internal/component/prometheus/appenders/seriesrefmapping_test.go
+++ b/internal/component/prometheus/appenders/seriesrefmapping_test.go
@@ -210,6 +210,209 @@ func TestSeriesRefMappingStore_TrackingRefAgainUpdatesTimestamp(t *testing.T) {
 	})
 }
 
+func TestSeriesRefMappingStore_RemoveStaleRefs_RemovesStaleKeepsFresh(t *testing.T) {
+	store := NewSeriesRefMappingStore(nil)
+	t.Cleanup(func() { store.Clear() })
+
+	staleLbls := labels.FromStrings("k", "stale")
+	freshLbls := labels.FromStrings("k", "fresh")
+	staleRef := store.CreateMapping([]storage.SeriesRef{1, 2}, staleLbls)
+	freshRef := store.CreateMapping([]storage.SeriesRef{3, 4}, freshLbls)
+
+	now := time.Now().Unix()
+	trackRef(store, staleRef, now-3600)
+	trackRef(store, freshRef, now)
+
+	store.removeStaleRefs(now - 60)
+
+	require.Nil(t, store.GetMapping(staleRef, staleLbls), "stale mapping should be removed")
+	require.NotNil(t, store.GetMapping(freshRef, freshLbls), "fresh mapping should survive")
+
+	// Both maps and the timestamp index must drop only the stale ref.
+	require.NotContains(t, store.uniqueRefToChildRefs, staleRef)
+	require.NotContains(t, store.uniqueRefTimestamps, staleRef)
+	require.Contains(t, store.uniqueRefToChildRefs, freshRef)
+	require.Contains(t, store.uniqueRefTimestamps, freshRef)
+}
+
+func TestSeriesRefMappingStore_RemoveStaleRefs_DeletesAcrossChunkBoundary(t *testing.T) {
+	store := NewSeriesRefMappingStore(nil)
+	t.Cleanup(func() { store.Clear() })
+
+	// More stale refs than a single chunk so the scan flushes at the boundary and
+	// again for the remainder.
+	total := staleRefDeleteChunk + 100
+	old := time.Now().Unix() - 3600
+	for i := range total {
+		ref := store.CreateMapping([]storage.SeriesRef{storage.SeriesRef(i)}, labels.FromStrings("k", strconv.Itoa(i)))
+		trackRef(store, ref, old)
+	}
+
+	store.removeStaleRefs(time.Now().Unix() - 60)
+
+	require.Empty(t, store.uniqueRefToChildRefs)
+	require.Empty(t, store.uniqueRefTimestamps)
+	require.Empty(t, store.labelHashToUniqueRef)
+}
+
+func TestSeriesRefMappingStore_RemoveStaleRefs_ExactChunkMultiple(t *testing.T) {
+	store := NewSeriesRefMappingStore(nil)
+	t.Cleanup(func() { store.Clear() })
+
+	// Exactly one chunk, so the flush inside the scan empties the batch and the flush
+	// after it gets nothing.
+	old := time.Now().Unix() - 3600
+	for i := range staleRefDeleteChunk {
+		ref := store.CreateMapping([]storage.SeriesRef{storage.SeriesRef(i)}, labels.FromStrings("k", strconv.Itoa(i)))
+		trackRef(store, ref, old)
+	}
+
+	store.removeStaleRefs(time.Now().Unix() - 60)
+
+	require.Empty(t, store.uniqueRefToChildRefs)
+	require.Empty(t, store.uniqueRefTimestamps)
+	require.Empty(t, store.labelHashToUniqueRef)
+	require.Equal(t, float64(staleRefDeleteChunk), testutil.ToFloat64(store.refsCleaned))
+}
+
+func TestSeriesRefMappingStore_RemoveStaleRefs_UpdatesMetrics(t *testing.T) {
+	store := NewSeriesRefMappingStore(nil)
+	t.Cleanup(func() { store.Clear() })
+
+	staleLbls := labels.FromStrings("k", "stale")
+	freshLbls := labels.FromStrings("k", "fresh")
+	staleRef := store.CreateMapping([]storage.SeriesRef{1, 2}, staleLbls)
+	freshRef := store.CreateMapping([]storage.SeriesRef{3, 4}, freshLbls)
+
+	now := time.Now().Unix()
+	trackRef(store, staleRef, now-3600)
+	trackRef(store, freshRef, now)
+	require.Equal(t, 2.0, testutil.ToFloat64(store.activeMappings))
+
+	store.removeStaleRefs(now - 60)
+
+	require.Equal(t, 1.0, testutil.ToFloat64(store.activeMappings))
+	require.Equal(t, 1.0, testutil.ToFloat64(store.refsCleaned))
+	require.Equal(t, 1.0, testutil.ToFloat64(store.trackedRefs))
+}
+
+func TestSeriesRefMappingStore_RemoveStaleRefs_OrphanTimestampsDoNotSkewActiveMappings(t *testing.T) {
+	store := NewSeriesRefMappingStore(nil)
+	t.Cleanup(func() { store.Clear() })
+
+	old := time.Now().Unix() - 3600
+	keepLbls := labels.FromStrings("k", "keep")
+	keepRef := store.CreateMapping([]storage.SeriesRef{1}, keepLbls)
+	trackRef(store, keepRef, time.Now().Unix())
+
+	staleLbls := labels.FromStrings("k", "stale")
+	staleRef := store.CreateMapping([]storage.SeriesRef{2}, staleLbls)
+	trackRef(store, staleRef, old)
+
+	// Refs tracked with no mapping behind them, as happens when a batch commits after
+	// cleanup has already evicted the ref it read. Subtracting per stale ref would
+	// charge these against a gauge that only ever counted mappings.
+	for _, orphan := range []storage.SeriesRef{9001, 9002, 9003} {
+		trackRef(store, orphan, old)
+	}
+
+	store.removeStaleRefs(time.Now().Unix() - 60)
+
+	// One real mapping survives, so the gauge must read 1 rather than 1-4.
+	require.Equal(t, 1.0, testutil.ToFloat64(store.activeMappings))
+	require.Len(t, store.uniqueRefToChildRefs, 1)
+	require.Equal(t, 4.0, testutil.ToFloat64(store.refsCleaned))
+	require.Equal(t, 1.0, testutil.ToFloat64(store.trackedRefs))
+}
+
+func TestSeriesRefMappingStore_RemoveStaleRefs_SetsGaugeFromMapEveryCycle(t *testing.T) {
+	store := NewSeriesRefMappingStore(nil)
+	t.Cleanup(func() { store.Clear() })
+
+	lbls := labels.FromStrings("k", "v")
+	ref := store.CreateMapping([]storage.SeriesRef{1}, lbls)
+	trackRef(store, ref, time.Now().Unix())
+
+	// The gauge is read off the map rather than accumulated, so every cycle re-establishes
+	// it from the map size. Forcing a wrong value stands in for divergence from any cause.
+	store.activeMappings.Set(99)
+
+	// Evict nothing, which is the case a per-delete update would miss entirely.
+	store.removeStaleRefs(time.Now().Unix() - 3600)
+
+	require.Len(t, store.uniqueRefToChildRefs, 1, "nothing should have been evicted")
+	require.Equal(t, 1.0, testutil.ToFloat64(store.activeMappings))
+}
+
+func TestSeriesRefMappingStore_RemoveStaleRefsRacesWithAppends(t *testing.T) {
+	store := NewSeriesRefMappingStore(nil)
+	t.Cleanup(func() { store.Clear() })
+
+	const series = 128
+	lbls := make([]labels.Labels, series)
+	refs := make([]storage.SeriesRef, series)
+	for i := range series {
+		lbls[i] = labels.FromStrings("k", strconv.Itoa(i))
+		refs[i] = store.CreateMapping([]storage.SeriesRef{storage.SeriesRef(i + 1)}, lbls[i])
+	}
+
+	stop := make(chan struct{})
+	var wg, ready sync.WaitGroup
+	ready.Add(8)
+	for w := range 8 {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			first := true
+			for i := w; ; i = (i + 8) % series {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				store.GetMapping(refs[i], lbls[i])
+				trackRef(store, refs[i], time.Now().Unix())
+				if first {
+					ready.Done()
+					first = false
+				}
+			}
+		}(w)
+	}
+
+	// Wait for every worker to be inside its loop, otherwise the passes below can finish
+	// before the workers are scheduled and nothing actually overlaps.
+	ready.Wait()
+
+	// A cutoff in the future makes every tracked ref stale, so each pass deletes whatever
+	// the workers just tracked.
+	for range 200 {
+		store.removeStaleRefs(time.Now().Unix() + 60)
+	}
+	close(stop)
+	wg.Wait()
+
+	// Whatever survived must be mutually consistent: each reverse entry resolves to a
+	// live mapping carrying the same hash.
+	for hash, ref := range store.labelHashToUniqueRef {
+		mapping, ok := store.uniqueRefToChildRefs[ref]
+		require.True(t, ok, "labelHashToUniqueRef points at a deleted mapping")
+		require.Equal(t, hash, mapping.labelHash)
+	}
+
+	// The store is still usable afterward.
+	newLbls := labels.FromStrings("k", "after")
+	newRef := store.CreateMapping([]storage.SeriesRef{42}, newLbls)
+	require.Equal(t, []storage.SeriesRef{42}, store.GetMapping(newRef, newLbls))
+}
+
+// trackRef records ts as ref's last-append time via the normal tracking path.
+func trackRef(store *SeriesRefMappingStore, ref storage.SeriesRef, ts int64) {
+	cell := store.GetCellForAppendedSeries()
+	cell.Refs = append(cell.Refs, ref)
+	store.TrackAppendedSeries(ts, cell)
+}
+
 func TestSeriesRefMappingStore_ClearRemovesAllMappings(t *testing.T) {
 	store := NewSeriesRefMappingStore(nil)
 	lbls := labels.EmptyLabels()


### PR DESCRIPTION
### Brief description of Pull Request

The fanout mapping store's stale ref removal now reclaims mapping in batches taking the mapping lock only when we have a full batch/the end of the cycle. Selectively taking the mapping lock allows appends to keep working while we are scanning for entries to remove by timestamp. At high active series this locking could be very detrimental to overall throughput especially with low churn in the mappings.

### Pull Request Details

The biggest tradeoff here is that a series re-appended cleanup can lose its mapping and pick up a fresh unique ref on its next append. It's a self correcting problem but but was previously impossible. Burning through some mapping is less painful than a stall for full correctness.

We do still hold the timestamp lock for the entire cleanup which will block a commit. I was planning a follow up to allow timestamp tracking to be best effort while removing stalerefs. It's a continuation of the same tradeoff made here. Accidentally removing a live wrapping is less impactful than slowing down appender throughput. 

### Issue(s) fixed by this Pull Request

Related to: https://github.com/grafana/alloy/issues/5062

### PR Checklist

- [x] Tests updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
