### PR TITLE
feat: Move otelcol.receiver.faro to public preview

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.receiver.faro.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.faro.md
@@ -2,7 +2,7 @@
 canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.faro/
 description: Learn about otelcol.receiver.faro
 labels:
-  stage: experimental
+  stage: public-preview
   products:
     - oss
 title: otelcol.receiver.faro
@@ -10,7 +10,7 @@ title: otelcol.receiver.faro
 
 # `otelcol.receiver.faro`
 
-{{< docs/shared lookup="stability/experimental.md" source="alloy" version="<ALLOY_VERSION>" >}}
+{{< docs/shared lookup="stability/public_preview.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
 `otelcol.receiver.faro` accepts telemetry data from the [Grafana Faro Web SDK][faro-sdk] and forwards it to other `otelcol.*` components.
 

--- a/internal/component/otelcol/receiver/faro/faro.go
+++ b/internal/component/otelcol/receiver/faro/faro.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	component.Register(component.Registration{
 		Name:      "otelcol.receiver.faro",
-		Stability: featuregate.StabilityExperimental,
+		Stability: featuregate.StabilityPublicPreview,
 		Args:      Arguments{},
 
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
    description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.

  **HUMANS**
  - Read and understand docs/developer/genai.md
  - Brief description / Issue(s) fixed: factual summary of the change (AI may
    help). Details, Notes, and Checklist: your motivations, trade-offs, and
    judgment — keep those human-owned.

  **AI AGENTS**
  - MANDATORY: Read, understand, and apply AGENTS.md
  - Use this template as the PR body structure. Do not invent a custom layout.
  - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
    that section's content. Leave it empty unless the human already filled it.
  - Sections without "HUMAN ONLY" may be filled by you (Brief description,
    Issue(s) fixed when known). Do not invent issue numbers or a PR title.
  - Checklist: leave unchecked unless the human explicitly confirmed; do not
    guess the AI-assistance disclosure box.
  - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
    point at docs/developer/genai.md.
-->

### Brief description of Pull Request

<!-- Factual, human-readable summary of what changed (squash commit body). -->

Change the stability of the otelcol.receiver.faro component from "experimental" to "public preview".

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->
The config of otelcol.receiver.faro is stable: it doesn't have additional arguments; it only uses the general arguments
- otelcol.HTTPServerArguments
- otelcolCfg.DebugMetrics
- *otelcol.ConsumerArguments

The risk of breaking changes is very low