### PR TITLE
feat(database_observability.sql_server): Add explain_plans collector

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.sql_server.md
+++ b/docs/sources/reference/components/database_observability/database_observability.sql_server.md
@@ -45,6 +45,7 @@ The following collectors are configurable:
 | `schema_details`  | Collect schemas and tables from `information_schema`.                         | yes                |
 | `query_metrics`   | Collect per-query executions, errors, and duration counters from Query Store. | yes                |
 | `query_details`   | Collect query text and parsed table names from Query Store.                   | yes                |
+| `explain_plans`   | Collect and parse query execution plans already captured by Query Store.      | yes                |
 
 ## Blocks
 
@@ -61,6 +62,7 @@ You can use the following blocks with `database_observability.sql_server`:
 | [`schema_details`][schema_details]   | Configure the schema and table details collector. | no       |
 | [`query_metrics`][query_metrics]     | Configure the Query Store metrics collector.      | no       |
 | [`query_details`][query_details]     | Configure the Query Store query text collector.   | no       |
+| [`explain_plans`][explain_plans]     | Configure the query execution plan collector.     | no       |
 
 [cloud_provider]: #cloud_provider
 [aws]: #aws
@@ -69,6 +71,7 @@ You can use the following blocks with `database_observability.sql_server`:
 [schema_details]: #schema_details
 [query_metrics]: #query_metrics
 [query_details]: #query_details
+[explain_plans]: #explain_plans
 
 {{< /docs/alloy-config >}}
 
@@ -143,6 +146,16 @@ The login requires `VIEW DATABASE STATE` on the connected database. On SQL Serve
 | `collect_interval` | `duration` | How frequently to collect query text from Query Store. | `"1m"`  | no       |
 
 The `query_details` collector reads [Query Store][query_store] query text for the database selected in the `data_source_name`, not every database on the instance.
+
+### `explain_plans`
+
+| Name               | Type       | Description                                    | Default | Required |
+|--------------------|------------|-------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to check for a changed execution plan. | `"1m"`  | no       |
+
+The `explain_plans` collector reads the execution plan [Query Store][query_store] already captured for each query tracked by the `query_metrics` collector; it doesn't compile or run a fresh plan. Only queries `query_metrics` is currently tracking are eligible, so `explain_plans` produces no output when `query_metrics` is disabled.
+
+The collector checks for a changed plan every `collect_interval`, but only forwards a log entry when the plan's shape has changed since the last entry, or when 30 minutes have passed since the last entry, whichever comes first. This keeps log volume low without ever going more than 30 minutes without a fresh entry.
 
 ## Example
 

--- a/docs/sources/reference/components/database_observability/database_observability.sql_server.md
+++ b/docs/sources/reference/components/database_observability/database_observability.sql_server.md
@@ -153,9 +153,15 @@ The `query_details` collector reads [Query Store][query_store] query text for th
 |--------------------|------------|-------------------------------------------------|---------|----------|
 | `collect_interval` | `duration` | How frequently to check for a changed execution plan. | `"1m"`  | no       |
 
-The `explain_plans` collector reads the execution plan [Query Store][query_store] already captured for each query tracked by the `query_metrics` collector; it doesn't compile or run a fresh plan. Only queries `query_metrics` is currently tracking are eligible, so `explain_plans` produces no output when `query_metrics` is disabled.
+The `explain_plans` collector reads the execution plan [Query Store][query_store] already captured for each query tracked by the `query_metrics` collector.
+It doesn't compile or run a fresh plan.
+Only queries that `query_metrics` is currently tracking are eligible.
+When `query_metrics` is disabled, `explain_plans` produces no output.
 
-The collector checks for a changed plan every `collect_interval`, but only forwards a log entry when the plan's shape has changed since the last entry, or when 30 minutes have passed since the last entry, whichever comes first. This keeps log volume low without ever going more than 30 minutes without a fresh entry.
+The collector checks for a changed plan every `collect_interval`.
+It forwards a log entry only when the plan's shape has changed since the last entry.
+It also forwards a log entry when 30 minutes have passed since the last entry.
+This keeps log volume low and ensures a fresh entry at least every 30 minutes.
 
 ## Example
 

--- a/docs/sources/reference/components/database_observability/database_observability.sql_server.md
+++ b/docs/sources/reference/components/database_observability/database_observability.sql_server.md
@@ -42,10 +42,10 @@ The following collectors are configurable:
 
 | Name              | Description                                                                   | Enabled by default |
 |-------------------|-------------------------------------------------------------------------------|--------------------|
-| `schema_details`  | Collect schemas and tables from `information_schema`.                         | yes                |
-| `query_metrics`   | Collect per-query executions, errors, and duration counters from Query Store. | yes                |
-| `query_details`   | Collect query text and parsed table names from Query Store.                   | yes                |
 | `explain_plans`   | Collect and parse query execution plans already captured by Query Store.      | yes                |
+| `query_details`   | Collect query text and parsed table names from Query Store.                   | yes                |
+| `query_metrics`   | Collect per-query executions, errors, and duration counters from Query Store. | yes                |
+| `schema_details`  | Collect schemas and tables from `information_schema`.                         | yes                |
 
 ## Blocks
 
@@ -59,19 +59,19 @@ You can use the following blocks with `database_observability.sql_server`:
 | `cloud_provider` > [`aws`][aws]      | Provide AWS database host information.            | no       |
 | `cloud_provider` > [`azure`][azure]  | Provide Azure database host information.          | no       |
 | `cloud_provider` > [`gcp`][gcp]      | Provide GCP database host information.            | no       |
-| [`schema_details`][schema_details]   | Configure the schema and table details collector. | no       |
-| [`query_metrics`][query_metrics]     | Configure the Query Store metrics collector.      | no       |
-| [`query_details`][query_details]     | Configure the Query Store query text collector.   | no       |
 | [`explain_plans`][explain_plans]     | Configure the query execution plan collector.     | no       |
+| [`query_details`][query_details]     | Configure the Query Store query text collector.   | no       |
+| [`query_metrics`][query_metrics]     | Configure the Query Store metrics collector.      | no       |
+| [`schema_details`][schema_details]   | Configure the schema and table details collector. | no       |
 
 [cloud_provider]: #cloud_provider
 [aws]: #aws
 [azure]: #azure
 [gcp]: #gcp
-[schema_details]: #schema_details
-[query_metrics]: #query_metrics
-[query_details]: #query_details
 [explain_plans]: #explain_plans
+[query_details]: #query_details
+[query_metrics]: #query_metrics
+[schema_details]: #schema_details
 
 {{< /docs/alloy-config >}}
 
@@ -115,13 +115,29 @@ The `gcp` block supplies the identifying information for the GCP Cloud SQL datab
 |-------------------|----------|-----------------------------------------------------------------------------------------------------------------------------|---------|----------|
 | `connection_name` | `string` | The Cloud SQL instance connection name in the format `project:region:instance`, for example `my-project:us-central1:my-db`. |         | yes      |
 
-### `schema_details`
+### `explain_plans`
 
-| Name               | Type       | Description                                          | Default | Required |
-|--------------------|------------|------------------------------------------------------|---------|----------|
-| `collect_interval` | `duration` | How frequently to collect information from database. | `"1m"`  | no       |
+| Name               | Type       | Description                                    | Default | Required |
+|--------------------|------------|-------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to check for a changed execution plan. | `"1m"`  | no       |
 
-The collector scans every database that the login can access on the instance and collects schema details from each. Only databases where the login has `CONNECT` access to catalog views are collected.
+The `explain_plans` collector reads the execution plan [Query Store][query_store] already captured for each query tracked by the `query_metrics` collector.
+It doesn't compile or run a fresh plan.
+Only queries that `query_metrics` is currently tracking are eligible.
+When `query_metrics` is disabled, `explain_plans` produces no output.
+
+The collector checks for a changed plan every `collect_interval`.
+It forwards a log entry only when the plan's shape has changed since the last entry.
+It also forwards a log entry when 30 minutes have passed since the last entry.
+This keeps log volume low and ensures a fresh entry at least every 30 minutes.
+
+### `query_details`
+
+| Name               | Type       | Description                                            | Default | Required |
+|--------------------|------------|--------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect query text from Query Store. | `"1m"`  | no       |
+
+The `query_details` collector reads [Query Store][query_store] query text for the database selected in the `data_source_name`, not every database on the instance.
 
 ### `query_metrics`
 
@@ -139,29 +155,13 @@ The login requires `VIEW DATABASE STATE` on the connected database. On SQL Serve
 
 [query_store]: https://learn.microsoft.com/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store
 
-### `query_details`
+### `schema_details`
 
-| Name               | Type       | Description                                            | Default | Required |
-|--------------------|------------|--------------------------------------------------------|---------|----------|
-| `collect_interval` | `duration` | How frequently to collect query text from Query Store. | `"1m"`  | no       |
+| Name               | Type       | Description                                          | Default | Required |
+|--------------------|------------|------------------------------------------------------|---------|----------|
+| `collect_interval` | `duration` | How frequently to collect information from database. | `"1m"`  | no       |
 
-The `query_details` collector reads [Query Store][query_store] query text for the database selected in the `data_source_name`, not every database on the instance.
-
-### `explain_plans`
-
-| Name               | Type       | Description                                    | Default | Required |
-|--------------------|------------|-------------------------------------------------|---------|----------|
-| `collect_interval` | `duration` | How frequently to check for a changed execution plan. | `"1m"`  | no       |
-
-The `explain_plans` collector reads the execution plan [Query Store][query_store] already captured for each query tracked by the `query_metrics` collector.
-It doesn't compile or run a fresh plan.
-Only queries that `query_metrics` is currently tracking are eligible.
-When `query_metrics` is disabled, `explain_plans` produces no output.
-
-The collector checks for a changed plan every `collect_interval`.
-It forwards a log entry only when the plan's shape has changed since the last entry.
-It also forwards a log entry when 30 minutes have passed since the last entry.
-This keeps log volume low and ensures a fresh entry at least every 30 minutes.
+The collector scans every database that the login can access on the instance and collects schema details from each. Only databases where the login has `CONNECT` access to catalog views are collected.
 
 ## Example
 

--- a/internal/component/database_observability/explain_plan_output.go
+++ b/internal/component/database_observability/explain_plan_output.go
@@ -15,6 +15,13 @@ const (
 	ExplainPlanOutputOperationAttachedSubquery     ExplainPlanOutputOperation = "Attached Subquery"
 	ExplainPlanOutputOperationUnion                ExplainPlanOutputOperation = "Union"
 	ExplainPlanOutputOperationUnknown              ExplainPlanOutputOperation = "Unknown"
+
+	// SQL Server showplan-specific operations with no equivalent among the operations above.
+	ExplainPlanOutputOperationComputeScalar ExplainPlanOutputOperation = "Compute Scalar"
+	ExplainPlanOutputOperationFilter        ExplainPlanOutputOperation = "Filter"
+	ExplainPlanOutputOperationTop           ExplainPlanOutputOperation = "Top"
+	ExplainPlanOutputOperationSpool         ExplainPlanOutputOperation = "Spool"
+	ExplainPlanOutputOperationParallelism   ExplainPlanOutputOperation = "Parallelism"
 )
 
 type ExplainPlanAccessType string
@@ -127,8 +134,13 @@ type ExplainPlanOutput struct {
 }
 
 type ExplainPlanMetadataInfo struct {
-	DatabaseEngine  string `json:"databaseEngine"`
-	DatabaseVersion string `json:"databaseVersion"`
+	// DatabaseEngine/DatabaseVersion are omitempty because sql_server no
+	// longer populates them (grafana-dbo11y-app#3471 found no consumer ever
+	// read them, and the engine is now carried as a Loki label instead,
+	// which is queryable, unlike this field). mysql/postgres still set both
+	// unconditionally, so omitempty has no effect on their existing output.
+	DatabaseEngine  string `json:"databaseEngine,omitempty"`
+	DatabaseVersion string `json:"databaseVersion,omitempty"`
 	QueryIdentifier string `json:"queryIdentifier"`
 	GeneratedAt     string `json:"generatedAt"`
 
@@ -154,5 +166,9 @@ type ExplainPlanNodeDetails struct {
 	Condition     *string                   `json:"condition,omitempty"`
 	GroupByKeys   []string                  `json:"groupByKeys,omitempty"`
 	SortKeys      []string                  `json:"sortKeys,omitempty"`
-	Warning       *string                   `json:"warning,omitempty"`
+	// Warnings holds engine-reported plan warnings for this node (for example
+	// SQL Server's missing-statistics or no-join-predicate warnings). Unused by
+	// mysql/postgres today; a node can carry more than one simultaneously, hence
+	// a slice rather than a single string.
+	Warnings []string `json:"warnings,omitempty"`
 }

--- a/internal/component/database_observability/sql_server/collector/connection_info.go
+++ b/internal/component/database_observability/sql_server/collector/connection_info.go
@@ -14,6 +14,11 @@ import (
 
 const ConnectionInfoName = "connection_info"
 
+// EngineName is the value the sql_server component uses to identify itself
+// wherever an engine identifier is needed, e.g. the connection_info metric's
+// "engine" label and the "engine" Loki label added to every log line.
+const EngineName = "sql_server"
+
 type ConnectionInfoArguments struct {
 	DSN           string
 	Registry      *prometheus.Registry
@@ -64,7 +69,7 @@ func (c *ConnectionInfo) Start(ctx context.Context) error {
 		providerRegion       = "unknown"
 		providerAccount      = "unknown"
 		dbInstanceIdentifier = "unknown"
-		engine               = "sql_server"
+		engine               = EngineName
 	)
 
 	if c.CloudProvider != nil {

--- a/internal/component/database_observability/sql_server/collector/explain_plans.go
+++ b/internal/component/database_observability/sql_server/collector/explain_plans.go
@@ -1,0 +1,398 @@
+package collector
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/runtime/logging"
+)
+
+const (
+	ExplainPlansCollector  = "explain_plans"
+	OP_EXPLAIN_PLAN_OUTPUT = "explain_plan_output"
+)
+
+// selectExplainPlansTemplate resolves each tracked query_hash to the most
+// recently active plan Query Store has already captured for it (no live
+// SET SHOWPLAN_XML ON compilation - the plan is read from the same Query
+// Store data query_metrics already joins). A query_hash can map to more than
+// one query_id/plan_id (recompiles, parameter sniffing), so ROW_NUMBER picks
+// exactly one plan per hash rather than enumerating every match.
+const selectExplainPlansTemplate = `
+	WITH ranked_plans AS (
+		SELECT
+			q.query_hash,
+			p.query_plan,
+			ROW_NUMBER() OVER (
+				PARTITION BY q.query_hash
+				ORDER BY MAX(i.end_time) DESC
+			) AS rn
+		FROM sys.query_store_query q
+		JOIN sys.query_store_plan p ON p.query_id = q.query_id
+		JOIN sys.query_store_runtime_stats rs ON rs.plan_id = p.plan_id
+		JOIN sys.query_store_runtime_stats_interval i
+			ON i.runtime_stats_interval_id = rs.runtime_stats_interval_id
+		WHERE q.is_internal_query = 0
+			AND q.query_hash IN (%s)
+		GROUP BY q.query_hash, p.plan_id, p.query_plan
+	)
+	SELECT query_hash, query_plan
+	FROM ranked_plans
+	WHERE rn = 1`
+
+type ExplainPlansArguments struct {
+	DB              *sql.DB
+	CollectInterval time.Duration
+	// Tracker is query_metrics's tracked query_hash set. This is nil when
+	// query_metrics is disabled, in which case explain_plans has no bounded
+	// candidate set to work from and no-ops every cycle, mirroring
+	// query_details's existing dependency on the same tracker.
+	Tracker      QueryTracker
+	EntryHandler loki.EntryHandler
+
+	Logger *slog.Logger
+}
+
+type ExplainPlans struct {
+	dbConnection    *sql.DB
+	collectInterval time.Duration
+	tracker         QueryTracker
+	entryHandler    loki.EntryHandler
+
+	// lastEmittedAt/lastEmittedHash gate emission: a plan is only logged again
+	// once its structural hash changes, or once EmitInterval has elapsed since
+	// the last emission - whichever comes first. This bounds volume without
+	// ever going longer than EmitInterval without a fresh line for the UI to
+	// pick up.
+	lastEmittedAt   map[queryMetricsKey]time.Time
+	lastEmittedHash map[queryMetricsKey]string
+
+	// now allows overriding time.Now() in tests.
+	now func() time.Time
+
+	logger  *slog.Logger
+	running *atomic.Bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+func NewExplainPlans(args ExplainPlansArguments) (*ExplainPlans, error) {
+	return &ExplainPlans{
+		dbConnection:    args.DB,
+		collectInterval: args.CollectInterval,
+		tracker:         args.Tracker,
+		entryHandler:    args.EntryHandler,
+		lastEmittedAt:   map[queryMetricsKey]time.Time{},
+		lastEmittedHash: map[queryMetricsKey]string{},
+		now:             time.Now,
+		logger:          args.Logger.With("collector", ExplainPlansCollector),
+		running:         atomic.NewBool(false),
+	}, nil
+}
+
+func (c *ExplainPlans) Name() string {
+	return ExplainPlansCollector
+}
+
+func (c *ExplainPlans) Start(ctx context.Context) error {
+	c.logger.Debug("collector started")
+
+	c.running.Store(true)
+	ctx, cancel := context.WithCancel(ctx)
+	c.ctx = ctx
+	c.cancel = cancel
+
+	c.wg.Go(func() {
+		defer c.running.Store(false)
+
+		ticker := time.NewTicker(c.collectInterval)
+		defer ticker.Stop()
+
+		for {
+			if err := c.collectWithTimeout(c.ctx); err != nil {
+				c.logger.Error("collector error", "err", err)
+			}
+
+			select {
+			case <-c.ctx.Done():
+				return
+			case <-ticker.C:
+				// continue loop
+			}
+		}
+	})
+
+	return nil
+}
+
+func (c *ExplainPlans) Stopped() bool {
+	return !c.running.Load()
+}
+
+func (c *ExplainPlans) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.wg.Wait()
+}
+
+func (c *ExplainPlans) collectWithTimeout(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return c.collect(ctx)
+}
+
+func (c *ExplainPlans) collect(ctx context.Context) error {
+	if c.tracker == nil {
+		c.logger.Error("no query tracker available, skipping collection")
+		return nil
+	}
+
+	database, ok := checkQueryStoreState(ctx, c.dbConnection, c.logger)
+	if !ok {
+		return nil
+	}
+
+	hashes := c.tracker.GetQueryHashes(database)
+	if len(hashes) == 0 {
+		// query_metrics is enabled but nothing is tracked yet: emit nothing.
+		c.pruneStale(nil)
+		return nil
+	}
+
+	query, args, err := buildExplainPlansStatement(hashes)
+	if err != nil {
+		return err
+	}
+
+	rs, err := c.dbConnection.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to fetch explain plans: %w", err)
+	}
+	defer rs.Close()
+
+	now := c.now()
+	seen := map[queryMetricsKey]struct{}{}
+	found := map[string]struct{}{}
+
+	for rs.Next() {
+		var hashBytes []byte
+		var planXML []byte
+		if err := rs.Scan(&hashBytes, &planXML); err != nil {
+			c.logger.Error("failed to scan explain plan row", "err", err)
+			continue
+		}
+
+		queryHash, err := formatQueryHash(hashBytes)
+		if err != nil {
+			c.logger.Error("failed to format query hash", "err", err)
+			continue
+		}
+
+		found[queryHash] = struct{}{}
+		key := queryMetricsKey{database: database, queryHash: queryHash}
+		seen[key] = struct{}{}
+
+		c.processPlan(now, key, queryHash, database, planXML)
+	}
+	if err := rs.Err(); err != nil {
+		return fmt.Errorf("failed to iterate over explain plan rows: %w", err)
+	}
+
+	// Tracked hashes with no captured plan yet still get a gated skip
+	// emission, so the UI's "no explain plan available" reflects Query Store
+	// not having a plan yet rather than looking like a silent gap.
+	for _, hash := range hashes {
+		if _, ok := found[hash]; ok {
+			continue
+		}
+		key := queryMetricsKey{database: database, queryHash: hash}
+		seen[key] = struct{}{}
+		c.maybeEmitSkip(now, key, hash, database, "no captured plan for this query in Query Store")
+	}
+
+	c.pruneStale(seen)
+	return nil
+}
+
+func (c *ExplainPlans) processPlan(now time.Time, key queryMetricsKey, queryHash, database string, planXML []byte) {
+	planNode, err := newExplainPlanOutputFromShowPlanXML(planXML)
+	if err != nil {
+		c.logger.Error("failed to parse showplan xml", "query_hash", queryHash, "err", err)
+		c.maybeEmitSkip(now, key, queryHash, database, fmt.Sprintf("failed to parse showplan xml: %s", err.Error()))
+		return
+	}
+
+	hash, err := structuralHash(*planNode)
+	if err != nil {
+		// Skip this cycle entirely rather than recording a sentinel hash: a
+		// bogus value here would either wrongly look "unchanged" against the
+		// last real hash (suppressing a genuine change) or, if this recurs
+		// intermittently, keep looking "changed" against it (defeating the
+		// gate the same way grafana-dbo11y-app#3409 did). Leaving state
+		// untouched means the next successful cycle still compares against
+		// the last known-good hash.
+		c.logger.Error("failed to compute structural hash for explain plan, skipping this cycle", "query_hash", queryHash, "err", err)
+		return
+	}
+	if !c.shouldEmit(key, hash, now) {
+		return
+	}
+
+	c.emit(database, queryHash, now, database_observability.ExplainProcessingResultSuccess, "", planNode)
+	c.recordEmission(key, hash, now)
+}
+
+func (c *ExplainPlans) maybeEmitSkip(now time.Time, key queryMetricsKey, queryHash, database, reason string) {
+	skipHash := "skip:" + reason
+	if !c.shouldEmit(key, skipHash, now) {
+		return
+	}
+	c.emit(database, queryHash, now, database_observability.ExplainProcessingResultSkipped, reason, nil)
+	c.recordEmission(key, skipHash, now)
+}
+
+// shouldEmit gates emission on either the plan having changed since the last
+// emission, or EmitInterval having elapsed - whichever comes first. This
+// intentionally checks for a changed plan every collect_interval (poll cost
+// is a cheap system-view read, not a live compile) while never emitting more
+// often than that unless the plan actually changed, avoiding the unbounded
+// per-poll re-emission that caused grafana-dbo11y-app#3409 for mysql/postgres.
+func (c *ExplainPlans) shouldEmit(key queryMetricsKey, hash string, now time.Time) bool {
+	prevHash, hasPrevHash := c.lastEmittedHash[key]
+	prevTime, hasPrevTime := c.lastEmittedAt[key]
+	if !hasPrevHash || !hasPrevTime {
+		return true
+	}
+	if hash != prevHash {
+		return true
+	}
+	return now.Sub(prevTime) >= database_observability.EmitInterval
+}
+
+func (c *ExplainPlans) recordEmission(key queryMetricsKey, hash string, now time.Time) {
+	if c.lastEmittedAt == nil {
+		c.lastEmittedAt = map[queryMetricsKey]time.Time{}
+	}
+	if c.lastEmittedHash == nil {
+		c.lastEmittedHash = map[queryMetricsKey]string{}
+	}
+	c.lastEmittedAt[key] = now
+	c.lastEmittedHash[key] = hash
+}
+
+// pruneStale drops gate state for keys that were not observed this cycle,
+// i.e. hashes query_metrics is no longer tracking.
+func (c *ExplainPlans) pruneStale(seen map[queryMetricsKey]struct{}) {
+	for key := range c.lastEmittedAt {
+		if _, ok := seen[key]; !ok {
+			delete(c.lastEmittedAt, key)
+			delete(c.lastEmittedHash, key)
+		}
+	}
+}
+
+func (c *ExplainPlans) emit(
+	database, queryHash string,
+	now time.Time,
+	result database_observability.ExplainProcessingResult,
+	reason string,
+	plan *database_observability.ExplainPlanNode,
+) {
+
+	output := &database_observability.ExplainPlanOutput{
+		Metadata: database_observability.ExplainPlanMetadataInfo{
+			// DatabaseEngine/DatabaseVersion are intentionally left unset: the
+			// engine is now carried as a Loki label (see addLokiLabels) instead,
+			// which is queryable and consistent with connection_info's "engine"
+			// metric label, unlike these fields which no UI consumer ever read
+			// (grafana-dbo11y-app#3471). mysql/postgres still populate them
+			// pending a follow-up change there.
+			QueryIdentifier:        queryHash,
+			GeneratedAt:            now.Format(time.RFC3339),
+			ProcessingResult:       result,
+			ProcessingResultReason: reason,
+		},
+	}
+	if plan != nil {
+		output.Plan = *plan
+	}
+
+	explainPlanOutputJSON, err := json.Marshal(output)
+	if err != nil {
+		c.logger.Error("failed to marshal explain plan output", "err", err)
+		return
+	}
+
+	logMessage := fmt.Sprintf(
+		`database="%s" query_hash="%s" explain_plan_output="%s"`,
+		database,
+		queryHash,
+		base64.StdEncoding.EncodeToString(explainPlanOutputJSON),
+	)
+
+	c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
+		logging.LevelInfo,
+		OP_EXPLAIN_PLAN_OUTPUT,
+		logMessage,
+	)
+}
+
+// structuralHash hashes the plan tree with EstimatedRows/EstimatedCost
+// excluded, since those optimizer estimates jitter between polls even when
+// the plan shape is unchanged (see grafana-dbo11y-app#3409). The error is the
+// caller's signal to skip this cycle for this query rather than record a
+// hash that isn't a genuine reflection of the plan's content.
+func structuralHash(node database_observability.ExplainPlanNode) (string, error) {
+	b, err := json.Marshal(stripVolatileFields(node))
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal plan for hashing: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func stripVolatileFields(node database_observability.ExplainPlanNode) database_observability.ExplainPlanNode {
+	node.Details.EstimatedRows = 0
+	node.Details.EstimatedCost = nil
+	if len(node.Children) > 0 {
+		children := make([]database_observability.ExplainPlanNode, len(node.Children))
+		for i, child := range node.Children {
+			children[i] = stripVolatileFields(child)
+		}
+		node.Children = children
+	}
+	return node
+}
+
+// buildExplainPlansStatement returns the hash-resolution statement plus its
+// named parameters, binding each 16-char hex hash back to its binary(8) form.
+func buildExplainPlansStatement(hashes []string) (string, []any, error) {
+	placeholders := make([]string, 0, len(hashes))
+	args := make([]any, 0, len(hashes))
+	for i, h := range hashes {
+		raw, err := hex.DecodeString(h)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to decode tracked query hash %q: %w", h, err)
+		}
+		name := fmt.Sprintf("h%d", i)
+		placeholders = append(placeholders, "@"+name)
+		args = append(args, sql.Named(name, raw))
+	}
+
+	return fmt.Sprintf(selectExplainPlansTemplate, strings.Join(placeholders, ", ")), args, nil
+}

--- a/internal/component/database_observability/sql_server/collector/explain_plans_test.go
+++ b/internal/component/database_observability/sql_server/collector/explain_plans_test.go
@@ -1,0 +1,292 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
+	"github.com/grafana/alloy/internal/util"
+)
+
+// decodedExplainPlanPayload extracts and base64-decodes the explain_plan_output
+// field's raw JSON from a log line, so tests can assert on absent keys
+// (json.Marshal's omitempty) rather than just zero-valued struct fields.
+func decodedExplainPlanPayload(t *testing.T, line string) string {
+	t.Helper()
+	_, rest, ok := strings.Cut(line, `explain_plan_output="`)
+	require.True(t, ok, "line missing explain_plan_output field: %s", line)
+	encoded := strings.TrimSuffix(rest, `"`)
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	return string(decoded)
+}
+
+func mockExplainPlanRows(rows ...[]driver.Value) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"query_hash", "query_plan"})
+	for _, row := range rows {
+		r.AddRow(row...)
+	}
+	return r
+}
+
+// expectExplainPlans sets up the two queries one collect cycle runs: the
+// Query Store state preflight and the hash-to-plan resolution query.
+func expectExplainPlans(t *testing.T, mock sqlmock.Sqlmock, hashes []string, rows ...[]driver.Value) {
+	t.Helper()
+
+	query, args, err := buildExplainPlansStatement(hashes)
+	require.NoError(t, err)
+
+	mockSelectQueryStoreState(mock, "READ_WRITE")
+	mock.ExpectQuery(query).
+		WithArgs(namedArgs(args)...).
+		RowsWillBeClosed().
+		WillReturnRows(mockExplainPlanRows(rows...))
+}
+
+const simplePlanXML = `<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence><Batch><Statements><StmtSimple><QueryPlan>
+    <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="10" EstimatedTotalSubtreeCost="0.1">
+      <TableScan><Object Database="[MyDb]" Schema="[dbo]" Table="[Orders]" /></TableScan>
+    </RelOp>
+  </QueryPlan></StmtSimple></Statements></Batch></BatchSequence>
+</ShowPlanXML>`
+
+// planXMLWithCost returns simplePlanXML with a different EstimateRows/cost so
+// tests can assert the emission gate ignores exactly those two fields.
+func planXMLWithEstimate(rows string, cost string) string {
+	return fmt.Sprintf(`<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence><Batch><Statements><StmtSimple><QueryPlan>
+    <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="%s" EstimatedTotalSubtreeCost="%s">
+      <TableScan><Object Database="[MyDb]" Schema="[dbo]" Table="[Orders]" /></TableScan>
+    </RelOp>
+  </QueryPlan></StmtSimple></Statements></Batch></BatchSequence>
+</ShowPlanXML>`, rows, cost)
+}
+
+func newExplainPlansForTest(t *testing.T, db *sql.DB, entryHandler loki.EntryHandler, tracker QueryTracker) *ExplainPlans {
+	t.Helper()
+
+	c, err := NewExplainPlans(ExplainPlansArguments{
+		DB:              db,
+		CollectInterval: time.Minute,
+		Tracker:         tracker,
+		EntryHandler:    entryHandler,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+	return c
+}
+
+func TestExplainPlans_NoTrackerIsNoOp(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c := newExplainPlansForTest(t, db, lokiClient, nil)
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.Empty(t, lokiClient.Received())
+}
+
+func TestExplainPlans_EmptyTrackerEmitsNothing(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c := newExplainPlansForTest(t, db, lokiClient, fakeTracker{hashes: map[string][]string{}})
+
+	mockSelectQueryStoreState(mock, "READ_WRITE")
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.Empty(t, lokiClient.Received())
+}
+
+func TestExplainPlans_SkipsWhenQueryStoreUnavailable(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c := newExplainPlansForTest(t, db, lokiClient, trackerFor(testHash))
+
+	mockSelectQueryStoreState(mock, "OFF")
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.Empty(t, lokiClient.Received())
+}
+
+func TestExplainPlans_EmitsOnFirstSighting(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c := newExplainPlansForTest(t, db, lokiClient, trackerFor(testHash))
+
+	expectExplainPlans(t, mock, []string{testHash}, []driver.Value{queryHashBytes, simplePlanXML})
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.Eventually(t, func() bool { return len(lokiClient.Received()) == 1 }, 5*time.Second, 20*time.Millisecond)
+	entries := lokiClient.Received()
+	require.Equal(t, model.LabelSet{"op": OP_EXPLAIN_PLAN_OUTPUT}, entries[0].Labels)
+	require.Contains(t, entries[0].Line, `database="books_store"`)
+	require.Contains(t, entries[0].Line, `query_hash="0011223344556677"`)
+
+	// Engine identity is carried as a Loki label (added by addLokiLabels at
+	// the component level, not exercised by this collector-level test) - the
+	// metadata payload itself must not carry databaseEngine/databaseVersion
+	// at all now that they're omitempty and sql_server no longer sets them.
+	payload := decodedExplainPlanPayload(t, entries[0].Line)
+	require.NotContains(t, payload, "databaseEngine")
+	require.NotContains(t, payload, "databaseVersion")
+}
+
+func TestExplainPlans_SkipsTrackedHashWithNoPlanYet(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c := newExplainPlansForTest(t, db, lokiClient, trackerFor(testHash))
+
+	// No rows returned: Query Store has no captured plan yet for this hash.
+	expectExplainPlans(t, mock, []string{testHash})
+
+	require.NoError(t, c.collect(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.Eventually(t, func() bool { return len(lokiClient.Received()) == 1 }, 5*time.Second, 20*time.Millisecond)
+	require.Contains(t, lokiClient.Received()[0].Line, `explain_plan_output=`)
+}
+
+func TestExplainPlans_EmissionGate(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c := newExplainPlansForTest(t, db, lokiClient, trackerFor(testHash))
+
+	base := time.Now()
+	c.now = func() time.Time { return base }
+	key := queryMetricsKey{database: testDatabase, queryHash: testHash}
+
+	poll := func(planXML string) {
+		t.Helper()
+		expectExplainPlans(t, mock, []string{testHash}, []driver.Value{queryHashBytes, planXML})
+		require.NoError(t, c.collect(context.Background()))
+	}
+
+	// First cycle: always emits.
+	poll(simplePlanXML)
+	require.Equal(t, base, c.lastEmittedAt[key])
+	firstHash := c.lastEmittedHash[key]
+
+	// Second cycle, moments later, same structural shape but different
+	// EstimateRows/cost (optimizer jitter): must NOT emit, and the recorded
+	// hash must be unchanged since the structural hash excludes those fields.
+	c.now = func() time.Time { return base.Add(time.Minute) }
+	poll(planXMLWithEstimate("999", "9.9"))
+	require.Equal(t, base, c.lastEmittedAt[key], "jittered estimate must not trigger emission")
+	require.Equal(t, firstHash, c.lastEmittedHash[key])
+
+	// Third cycle, still within EmitInterval, but the plan is now genuinely
+	// different (a different physical operator): must emit immediately,
+	// regardless of EmitInterval not having elapsed.
+	changedAt := base.Add(2 * time.Minute)
+	c.now = func() time.Time { return changedAt }
+	differentPlanXML := `<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+	  <BatchSequence><Batch><Statements><StmtSimple><QueryPlan>
+	    <RelOp PhysicalOp="Clustered Index Scan" LogicalOp="Clustered Index Scan" EstimateRows="10" EstimatedTotalSubtreeCost="0.1">
+	      <IndexScan><Object Database="[MyDb]" Schema="[dbo]" Table="[Orders]" Index="[PK_Orders]" /></IndexScan>
+	    </RelOp>
+	  </QueryPlan></StmtSimple></Statements></Batch></BatchSequence>
+	</ShowPlanXML>`
+	poll(differentPlanXML)
+	require.Equal(t, changedAt, c.lastEmittedAt[key], "a structurally different plan must emit immediately")
+	require.NotEqual(t, firstHash, c.lastEmittedHash[key])
+
+	// Fourth cycle: unchanged plan again, but EmitInterval has now elapsed
+	// since the last emission - must emit a fresh copy for the UI.
+	afterInterval := changedAt.Add(database_observability.EmitInterval + time.Minute)
+	c.now = func() time.Time { return afterInterval }
+	poll(differentPlanXML)
+	require.Equal(t, afterInterval, c.lastEmittedAt[key], "unchanged plan past EmitInterval must still refresh")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+	lokiClient.Stop()
+	require.Len(t, lokiClient.Received(), 3)
+}
+
+func TestExplainPlans_PrunesStaleKeys(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	tracker := fakeTracker{hashes: map[string][]string{testDatabase: {testHash}}}
+	c := newExplainPlansForTest(t, db, lokiClient, tracker)
+
+	expectExplainPlans(t, mock, []string{testHash}, []driver.Value{queryHashBytes, simplePlanXML})
+	require.NoError(t, c.collect(context.Background()))
+
+	key := queryMetricsKey{database: testDatabase, queryHash: testHash}
+	require.Contains(t, c.lastEmittedAt, key)
+
+	// The hash falls out of query_metrics's tracked set.
+	tracker.hashes[testDatabase] = nil
+	mockSelectQueryStoreState(mock, "READ_WRITE")
+	require.NoError(t, c.collect(context.Background()))
+
+	require.NotContains(t, c.lastEmittedAt, key)
+	require.NotContains(t, c.lastEmittedHash, key)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/component/database_observability/sql_server/collector/explain_plans_xml.go
+++ b/internal/component/database_observability/sql_server/collector/explain_plans_xml.go
@@ -1,0 +1,381 @@
+package collector
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/alloy/internal/component/database_observability"
+)
+
+// This file parses SQL Server's "showplan" XML (the format captured by Query
+// Store in sys.query_store_plan.query_plan) into the shared
+// database_observability.ExplainPlanNode model. Unlike mysql/postgres's JSON
+// plan formats, showplan nests each operator's children inside a wrapper
+// element named after its physical operator category (e.g. <NestedLoops>,
+// <Hash>, <IndexScan>) rather than under a uniform key, so the RelOp struct
+// below declares one optional field per wrapper category we understand.
+// Anything not modeled here falls back to ExplainPlanOutputOperationUnknown
+// rather than being silently misclassified.
+
+type xmlShowPlan struct {
+	XMLName       xml.Name    `xml:"ShowPlanXML"`
+	BatchSequence xmlBatchSeq `xml:"BatchSequence"`
+}
+
+type xmlBatchSeq struct {
+	Batch []xmlBatch `xml:"Batch"`
+}
+
+type xmlBatch struct {
+	Statements xmlStatements `xml:"Statements"`
+}
+
+type xmlStatements struct {
+	StmtSimple []xmlStmtSimple `xml:"StmtSimple"`
+}
+
+type xmlStmtSimple struct {
+	QueryPlan xmlQueryPlan `xml:"QueryPlan"`
+}
+
+type xmlQueryPlan struct {
+	RelOp *xmlRelOp `xml:"RelOp"`
+}
+
+type xmlRelOp struct {
+	PhysicalOp                string `xml:"PhysicalOp,attr"`
+	LogicalOp                 string `xml:"LogicalOp,attr"`
+	EstimateRows              string `xml:"EstimateRows,attr"`
+	EstimatedTotalSubtreeCost string `xml:"EstimatedTotalSubtreeCost,attr"`
+
+	Warnings *xmlWarnings `xml:"Warnings"`
+
+	// One of the following is populated, depending on PhysicalOp. Each wrapper
+	// element is named for its operator category, not for the specific
+	// PhysicalOp string, so IndexScan covers Table Scan/Index Scan/Clustered
+	// Index Scan/Index Seek/Clustered Index Seek/RID Lookup/Key Lookup alike.
+	IndexScan       *xmlIndexScan  `xml:"IndexScan"`
+	TableScan       *xmlIndexScan  `xml:"TableScan"`
+	NestedLoops     *xmlOpChildren `xml:"NestedLoops"`
+	Hash            *xmlHash       `xml:"Hash"`
+	Merge           *xmlOpChildren `xml:"Merge"`
+	StreamAggregate *xmlOpChildren `xml:"StreamAggregate"`
+	Sort            *xmlSort       `xml:"Sort"`
+	ComputeScalar   *xmlOpChildren `xml:"ComputeScalar"`
+	Filter          *xmlFilter     `xml:"Filter"`
+	Top             *xmlOpChildren `xml:"Top"`
+	Concat          *xmlOpChildren `xml:"Concat"`
+	Parallelism     *xmlOpChildren `xml:"Parallelism"`
+	TableSpool      *xmlOpChildren `xml:"TableSpool"`
+	IndexSpool      *xmlOpChildren `xml:"IndexSpool"`
+}
+
+// xmlOpChildren is reused by wrapper elements whose only content we care
+// about is their nested RelOp children (join build/probe sides, the single
+// child of a unary operator like Sort/Filter/Top, etc.).
+type xmlOpChildren struct {
+	RelOp []xmlRelOp `xml:"RelOp"`
+}
+
+type xmlIndexScan struct {
+	Lookup    string        `xml:"Lookup,attr"`
+	Object    xmlObject     `xml:"Object"`
+	Predicate *xmlPredicate `xml:"Predicate"`
+}
+
+type xmlObject struct {
+	Table string `xml:"Table,attr"`
+	Index string `xml:"Index,attr"`
+}
+
+type xmlHash struct {
+	xmlOpChildren
+	GroupBy *xmlGroupBy `xml:"GroupBy"`
+}
+
+type xmlSort struct {
+	xmlOpChildren
+	OrderBy *xmlOrderBy `xml:"OrderBy"`
+}
+
+type xmlFilter struct {
+	xmlOpChildren
+	Predicate *xmlPredicate `xml:"Predicate"`
+}
+
+type xmlPredicate struct {
+	ScalarOperator xmlScalarOperator `xml:"ScalarOperator"`
+}
+
+type xmlScalarOperator struct {
+	ScalarString string `xml:"ScalarString,attr"`
+}
+
+type xmlGroupBy struct {
+	ColumnReference []xmlColumnReference `xml:"ColumnReference"`
+}
+
+type xmlOrderBy struct {
+	OrderByColumn []xmlOrderByColumn `xml:"OrderByColumn"`
+}
+
+type xmlOrderByColumn struct {
+	ColumnReference xmlColumnReference `xml:"ColumnReference"`
+}
+
+type xmlColumnReference struct {
+	Column string `xml:"Column,attr"`
+}
+
+type xmlWarnings struct {
+	NoJoinPredicate         *struct{} `xml:"NoJoinPredicate"`
+	ColumnsWithNoStatistics *struct{} `xml:"ColumnsWithNoStatistics"`
+	SpillToTempDb           *struct{} `xml:"SpillToTempDb"`
+}
+
+// newExplainPlanOutputFromShowPlanXML parses a single StmtSimple's showplan
+// XML (as captured by sys.query_store_plan.query_plan) into the shared
+// ExplainPlanNode model. It does not execute or re-plan anything - this is
+// the plan SQL Server already compiled and cached in Query Store.
+func newExplainPlanOutputFromShowPlanXML(showPlanXML []byte) (*database_observability.ExplainPlanNode, error) {
+	var plan xmlShowPlan
+	if err := xml.Unmarshal(showPlanXML, &plan); err != nil {
+		return nil, fmt.Errorf("failed to parse showplan xml: %w", err)
+	}
+
+	if len(plan.BatchSequence.Batch) == 0 || len(plan.BatchSequence.Batch[0].Statements.StmtSimple) == 0 {
+		return nil, fmt.Errorf("showplan xml has no statements")
+	}
+
+	rootRelOp := plan.BatchSequence.Batch[0].Statements.StmtSimple[0].QueryPlan.RelOp
+	if rootRelOp == nil {
+		return nil, fmt.Errorf("showplan xml has no root RelOp")
+	}
+
+	node := relOpToExplainPlanNode(*rootRelOp)
+	return &node, nil
+}
+
+func relOpToExplainPlanNode(op xmlRelOp) database_observability.ExplainPlanNode {
+	node := database_observability.ExplainPlanNode{
+		Details: database_observability.ExplainPlanNodeDetails{
+			EstimatedRows: parseInt64OrZero(op.EstimateRows),
+			EstimatedCost: parseFloatPtrOrNil(op.EstimatedTotalSubtreeCost),
+		},
+	}
+
+	if op.Warnings != nil {
+		node.Details.Warnings = op.Warnings.strings()
+	}
+
+	switch {
+	case op.IndexScan != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationIndexScan
+		populateScanDetails(&node, *op.IndexScan)
+	case op.TableScan != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationTableScan
+		populateScanDetails(&node, *op.TableScan)
+	case op.NestedLoops != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationNestedLoopJoin
+		algo := database_observability.ExplainPlanJoinAlgorithmNestedLoop
+		node.Details.JoinAlgorithm = &algo
+		if op.LogicalOp != "" {
+			node.Details.JoinType = &op.LogicalOp
+		}
+		node.Children = childrenOf(op.NestedLoops.RelOp)
+	case op.Hash != nil:
+		populateHashDetails(&node, op)
+		node.Children = childrenOf(op.Hash.RelOp)
+	case op.Merge != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationMergeJoin
+		algo := database_observability.ExplainPlanJoinAlgorithmMerge
+		node.Details.JoinAlgorithm = &algo
+		if op.LogicalOp != "" {
+			node.Details.JoinType = &op.LogicalOp
+		}
+		node.Children = childrenOf(op.Merge.RelOp)
+	case op.StreamAggregate != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationGroupingOperation
+		node.Children = childrenOf(op.StreamAggregate.RelOp)
+	case op.Sort != nil:
+		if strings.EqualFold(op.LogicalOp, "Distinct Sort") {
+			node.Operation = database_observability.ExplainPlanOutputOperationDuplicatesRemoval
+		} else {
+			node.Operation = database_observability.ExplainPlanOutputOperationOrderingOperation
+		}
+		if op.Sort.OrderBy != nil {
+			node.Details.SortKeys = orderByColumns(op.Sort.OrderBy)
+		}
+		node.Children = childrenOf(op.Sort.RelOp)
+	case op.ComputeScalar != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationComputeScalar
+		node.Children = childrenOf(op.ComputeScalar.RelOp)
+	case op.Filter != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationFilter
+		if op.Filter.Predicate != nil {
+			node.Details.Condition = redactedCondition(op.Filter.Predicate)
+		}
+		node.Children = childrenOf(op.Filter.RelOp)
+	case op.Top != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationTop
+		node.Children = childrenOf(op.Top.RelOp)
+	case op.Concat != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationUnion
+		node.Children = childrenOf(op.Concat.RelOp)
+	case op.Parallelism != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationParallelism
+		node.Children = childrenOf(op.Parallelism.RelOp)
+	case op.TableSpool != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationSpool
+		node.Children = childrenOf(op.TableSpool.RelOp)
+	case op.IndexSpool != nil:
+		node.Operation = database_observability.ExplainPlanOutputOperationSpool
+		node.Children = childrenOf(op.IndexSpool.RelOp)
+	default:
+		node.Operation = database_observability.ExplainPlanOutputOperationUnknown
+	}
+
+	return node
+}
+
+// populateHashDetails disambiguates SQL Server's "Hash Match" operator, which
+// serves as a join, an aggregate, or a set operation depending on LogicalOp -
+// PhysicalOp alone is not enough to classify it.
+func populateHashDetails(node *database_observability.ExplainPlanNode, op xmlRelOp) {
+	switch {
+	case strings.Contains(op.LogicalOp, "Join") || strings.Contains(op.LogicalOp, "Semi"):
+		node.Operation = database_observability.ExplainPlanOutputOperationHashJoin
+		algo := database_observability.ExplainPlanJoinAlgorithmHash
+		node.Details.JoinAlgorithm = &algo
+		joinType := op.LogicalOp
+		node.Details.JoinType = &joinType
+	case strings.EqualFold(op.LogicalOp, "Aggregate"):
+		node.Operation = database_observability.ExplainPlanOutputOperationGroupingOperation
+		if op.Hash.GroupBy != nil {
+			node.Details.GroupByKeys = columnReferences(op.Hash.GroupBy.ColumnReference)
+		}
+	case strings.EqualFold(op.LogicalOp, "Union"):
+		node.Operation = database_observability.ExplainPlanOutputOperationUnion
+	case strings.EqualFold(op.LogicalOp, "Distinct"):
+		node.Operation = database_observability.ExplainPlanOutputOperationDuplicatesRemoval
+	default:
+		node.Operation = database_observability.ExplainPlanOutputOperationUnknown
+	}
+}
+
+func populateScanDetails(node *database_observability.ExplainPlanNode, scan xmlIndexScan) {
+	if table := stripBrackets(scan.Object.Table); table != "" {
+		node.Details.TableName = &table
+	}
+	if index := stripBrackets(scan.Object.Index); index != "" {
+		node.Details.KeyUsed = &index
+	}
+
+	accessType := scanAccessType(node.Operation, scan)
+	node.Details.AccessType = &accessType
+
+	if scan.Predicate != nil {
+		node.Details.Condition = redactedCondition(scan.Predicate)
+	}
+}
+
+func scanAccessType(operation database_observability.ExplainPlanOutputOperation, scan xmlIndexScan) database_observability.ExplainPlanAccessType {
+	switch {
+	case scan.Lookup == "true" || scan.Lookup == "1":
+		return database_observability.ExplainPlanAccessTypeEqRef
+	case operation == database_observability.ExplainPlanOutputOperationTableScan:
+		return database_observability.ExplainPlanAccessTypeAll
+	case scan.Object.Index != "":
+		return database_observability.ExplainPlanAccessTypeIndex
+	default:
+		return database_observability.ExplainPlanAccessTypeAll
+	}
+}
+
+func redactedCondition(predicate *xmlPredicate) *string {
+	if predicate.ScalarOperator.ScalarString == "" {
+		return nil
+	}
+	redacted := database_observability.RedactSql(predicate.ScalarOperator.ScalarString)
+	return &redacted
+}
+
+func childrenOf(relOps []xmlRelOp) []database_observability.ExplainPlanNode {
+	if len(relOps) == 0 {
+		return nil
+	}
+	children := make([]database_observability.ExplainPlanNode, 0, len(relOps))
+	for _, child := range relOps {
+		children = append(children, relOpToExplainPlanNode(child))
+	}
+	return children
+}
+
+func columnReferences(refs []xmlColumnReference) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+	cols := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if col := stripBrackets(ref.Column); col != "" {
+			cols = append(cols, col)
+		}
+	}
+	return cols
+}
+
+func orderByColumns(orderBy *xmlOrderBy) []string {
+	if orderBy == nil || len(orderBy.OrderByColumn) == 0 {
+		return nil
+	}
+	cols := make([]string, 0, len(orderBy.OrderByColumn))
+	for _, col := range orderBy.OrderByColumn {
+		if name := stripBrackets(col.ColumnReference.Column); name != "" {
+			cols = append(cols, name)
+		}
+	}
+	return cols
+}
+
+func (w *xmlWarnings) strings() []string {
+	var warnings []string
+	if w.NoJoinPredicate != nil {
+		warnings = append(warnings, "no join predicate (cartesian product)")
+	}
+	if w.ColumnsWithNoStatistics != nil {
+		warnings = append(warnings, "columns with no statistics")
+	}
+	if w.SpillToTempDb != nil {
+		warnings = append(warnings, "spilled to tempdb")
+	}
+	return warnings
+}
+
+// stripBrackets removes the [schema]/[object] bracket-quoting SQL Server uses
+// for identifiers in showplan XML attributes (e.g. "[dbo].[Orders]").
+func stripBrackets(identifier string) string {
+	return strings.NewReplacer("[", "", "]", "").Replace(identifier)
+}
+
+func parseInt64OrZero(s string) int64 {
+	var v int64
+	if s == "" {
+		return 0
+	}
+	if _, err := fmt.Sscanf(s, "%d", &v); err != nil {
+		return 0
+	}
+	return v
+}
+
+func parseFloatPtrOrNil(s string) *float64 {
+	if s == "" {
+		return nil
+	}
+	var v float64
+	if _, err := fmt.Sscanf(s, "%g", &v); err != nil {
+		return nil
+	}
+	return &v
+}

--- a/internal/component/database_observability/sql_server/collector/explain_plans_xml_test.go
+++ b/internal/component/database_observability/sql_server/collector/explain_plans_xml_test.go
@@ -1,0 +1,281 @@
+package collector
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/txtar"
+
+	"github.com/grafana/alloy/internal/component/database_observability"
+)
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}
+
+func accessTypePtr(a database_observability.ExplainPlanAccessType) *database_observability.ExplainPlanAccessType {
+	return &a
+}
+
+func joinAlgorithmPtr(a database_observability.ExplainPlanJoinAlgorithm) *database_observability.ExplainPlanJoinAlgorithm {
+	return &a
+}
+
+func loadShowPlanFixture(t *testing.T, name string) []byte {
+	t.Helper()
+
+	archive, err := txtar.ParseFile(fmt.Sprintf("./testdata/explain_plan/%s.txtar", name))
+	require.NoError(t, err)
+	require.Len(t, archive.Files, 1)
+	require.Equal(t, fmt.Sprintf("%s.xml", name), archive.Files[0].Name)
+	return archive.Files[0].Data
+}
+
+func TestNewExplainPlanOutputFromShowPlanXML(t *testing.T) {
+	tests := []struct {
+		fixture string
+		want    database_observability.ExplainPlanNode
+	}{
+		{
+			fixture: "nested_loop_seek_and_scan",
+			want: database_observability.ExplainPlanNode{
+				Operation: database_observability.ExplainPlanOutputOperationNestedLoopJoin,
+				Details: database_observability.ExplainPlanNodeDetails{
+					EstimatedRows: 12,
+					EstimatedCost: floatPtr(0.045),
+					JoinAlgorithm: joinAlgorithmPtr(database_observability.ExplainPlanJoinAlgorithmNestedLoop),
+					JoinType:      stringPtr("Inner Join"),
+				},
+				Children: []database_observability.ExplainPlanNode{
+					{
+						Operation: database_observability.ExplainPlanOutputOperationIndexScan,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 8,
+							EstimatedCost: floatPtr(0.012),
+							TableName:     stringPtr("Orders"),
+							KeyUsed:       stringPtr("PK_Orders"),
+							AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeIndex),
+							Condition:     stringPtr("[dbo].[Orders].[Total]>(?)"),
+						},
+					},
+					{
+						Operation: database_observability.ExplainPlanOutputOperationIndexScan,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 1,
+							EstimatedCost: floatPtr(0.003),
+							TableName:     stringPtr("Customers"),
+							KeyUsed:       stringPtr("PK_Customers"),
+							AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeEqRef),
+						},
+					},
+				},
+			},
+		},
+		{
+			fixture: "hash_match_join",
+			want: database_observability.ExplainPlanNode{
+				Operation: database_observability.ExplainPlanOutputOperationHashJoin,
+				Details: database_observability.ExplainPlanNodeDetails{
+					EstimatedRows: 500,
+					EstimatedCost: floatPtr(1.2),
+					JoinAlgorithm: joinAlgorithmPtr(database_observability.ExplainPlanJoinAlgorithmHash),
+					JoinType:      stringPtr("Inner Join"),
+				},
+				Children: []database_observability.ExplainPlanNode{
+					{
+						Operation: database_observability.ExplainPlanOutputOperationTableScan,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 1000,
+							EstimatedCost: floatPtr(0.5),
+							TableName:     stringPtr("Customers"),
+							AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeAll),
+						},
+					},
+					{
+						Operation: database_observability.ExplainPlanOutputOperationTableScan,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 2000,
+							EstimatedCost: floatPtr(0.6),
+							TableName:     stringPtr("Orders"),
+							AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeAll),
+						},
+					},
+				},
+			},
+		},
+		{
+			fixture: "hash_match_aggregate",
+			want: database_observability.ExplainPlanNode{
+				Operation: database_observability.ExplainPlanOutputOperationGroupingOperation,
+				Details: database_observability.ExplainPlanNodeDetails{
+					EstimatedRows: 300,
+					EstimatedCost: floatPtr(0.9),
+					GroupByKeys:   []string{"CustomerId"},
+				},
+				Children: []database_observability.ExplainPlanNode{
+					{
+						Operation: database_observability.ExplainPlanOutputOperationTableScan,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 2000,
+							EstimatedCost: floatPtr(0.6),
+							TableName:     stringPtr("Orders"),
+							AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeAll),
+						},
+					},
+				},
+			},
+		},
+		{
+			fixture: "sort_and_top",
+			want: database_observability.ExplainPlanNode{
+				Operation: database_observability.ExplainPlanOutputOperationTop,
+				Details: database_observability.ExplainPlanNodeDetails{
+					EstimatedRows: 10,
+					EstimatedCost: floatPtr(0.7),
+				},
+				Children: []database_observability.ExplainPlanNode{
+					{
+						Operation: database_observability.ExplainPlanOutputOperationOrderingOperation,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 2000,
+							EstimatedCost: floatPtr(0.65),
+							SortKeys:      []string{"OrderDate"},
+						},
+						Children: []database_observability.ExplainPlanNode{
+							{
+								Operation: database_observability.ExplainPlanOutputOperationTableScan,
+								Details: database_observability.ExplainPlanNodeDetails{
+									EstimatedRows: 2000,
+									EstimatedCost: floatPtr(0.6),
+									TableName:     stringPtr("Orders"),
+									AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeAll),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			fixture: "compute_scalar_with_filter",
+			want: database_observability.ExplainPlanNode{
+				Operation: database_observability.ExplainPlanOutputOperationComputeScalar,
+				Details: database_observability.ExplainPlanNodeDetails{
+					EstimatedRows: 80,
+					EstimatedCost: floatPtr(0.55),
+				},
+				Children: []database_observability.ExplainPlanNode{
+					{
+						Operation: database_observability.ExplainPlanOutputOperationFilter,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 80,
+							EstimatedCost: floatPtr(0.54),
+							Condition:     stringPtr("[dbo].[Orders].[Total]>(?)"),
+						},
+						Children: []database_observability.ExplainPlanNode{
+							{
+								Operation: database_observability.ExplainPlanOutputOperationTableScan,
+								Details: database_observability.ExplainPlanNodeDetails{
+									EstimatedRows: 2000,
+									EstimatedCost: floatPtr(0.5),
+									TableName:     stringPtr("Orders"),
+									AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeAll),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			fixture: "concatenation",
+			want: database_observability.ExplainPlanNode{
+				Operation: database_observability.ExplainPlanOutputOperationUnion,
+				Details: database_observability.ExplainPlanNodeDetails{
+					EstimatedRows: 1500,
+					EstimatedCost: floatPtr(1.1),
+				},
+				Children: []database_observability.ExplainPlanNode{
+					{
+						Operation: database_observability.ExplainPlanOutputOperationTableScan,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 1000,
+							EstimatedCost: floatPtr(0.5),
+							TableName:     stringPtr("ActiveCustomers"),
+							AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeAll),
+						},
+					},
+					{
+						Operation: database_observability.ExplainPlanOutputOperationTableScan,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 500,
+							EstimatedCost: floatPtr(0.4),
+							TableName:     stringPtr("ArchivedCustomers"),
+							AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeAll),
+						},
+					},
+				},
+			},
+		},
+		{
+			fixture: "warnings",
+			want: database_observability.ExplainPlanNode{
+				Operation: database_observability.ExplainPlanOutputOperationHashJoin,
+				Details: database_observability.ExplainPlanNodeDetails{
+					EstimatedRows: 2000000,
+					EstimatedCost: floatPtr(45.2),
+					JoinAlgorithm: joinAlgorithmPtr(database_observability.ExplainPlanJoinAlgorithmHash),
+					JoinType:      stringPtr("Inner Join"),
+					Warnings:      []string{"no join predicate (cartesian product)", "spilled to tempdb"},
+				},
+				Children: []database_observability.ExplainPlanNode{
+					{
+						Operation: database_observability.ExplainPlanOutputOperationTableScan,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 1000,
+							EstimatedCost: floatPtr(0.5),
+							TableName:     stringPtr("Customers"),
+							AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeAll),
+						},
+					},
+					{
+						Operation: database_observability.ExplainPlanOutputOperationTableScan,
+						Details: database_observability.ExplainPlanNodeDetails{
+							EstimatedRows: 2000,
+							EstimatedCost: floatPtr(0.6),
+							TableName:     stringPtr("Orders"),
+							AccessType:    accessTypePtr(database_observability.ExplainPlanAccessTypeAll),
+							Warnings:      []string{"columns with no statistics"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.fixture, func(t *testing.T) {
+			xmlData := loadShowPlanFixture(t, test.fixture)
+			got, err := newExplainPlanOutputFromShowPlanXML(xmlData)
+			require.NoError(t, err)
+			require.Equal(t, test.want, *got)
+		})
+	}
+}
+
+func TestNewExplainPlanOutputFromShowPlanXML_Errors(t *testing.T) {
+	t.Run("invalid xml", func(t *testing.T) {
+		_, err := newExplainPlanOutputFromShowPlanXML([]byte("not xml"))
+		require.Error(t, err)
+	})
+
+	t.Run("no statements", func(t *testing.T) {
+		_, err := newExplainPlanOutputFromShowPlanXML([]byte(`<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan"><BatchSequence><Batch><Statements></Statements></Batch></BatchSequence></ShowPlanXML>`))
+		require.Error(t, err)
+	})
+}

--- a/internal/component/database_observability/sql_server/collector/testdata/explain_plan/compute_scalar_with_filter.txtar
+++ b/internal/component/database_observability/sql_server/collector/testdata/explain_plan/compute_scalar_with_filter.txtar
@@ -1,0 +1,37 @@
+SQL Server showplan XML generated from a query shaped like:
+
+```
+SELECT OrderId, Total * 1.1 AS TotalWithTax
+FROM Orders
+WHERE Total > 100
+```
+
+-- compute_scalar_with_filter.xml --
+<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence>
+    <Batch>
+      <Statements>
+        <StmtSimple>
+          <QueryPlan>
+            <RelOp PhysicalOp="Compute Scalar" LogicalOp="Compute Scalar" EstimateRows="80" EstimatedTotalSubtreeCost="0.55">
+              <ComputeScalar>
+                <RelOp PhysicalOp="Filter" LogicalOp="Filter" EstimateRows="80" EstimatedTotalSubtreeCost="0.54">
+                  <Filter>
+                    <Predicate>
+                      <ScalarOperator ScalarString="[dbo].[Orders].[Total]&gt;(100)" />
+                    </Predicate>
+                    <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="2000" EstimatedTotalSubtreeCost="0.5">
+                      <TableScan>
+                        <Object Database="[MyDb]" Schema="[dbo]" Table="[Orders]" />
+                      </TableScan>
+                    </RelOp>
+                  </Filter>
+                </RelOp>
+              </ComputeScalar>
+            </RelOp>
+          </QueryPlan>
+        </StmtSimple>
+      </Statements>
+    </Batch>
+  </BatchSequence>
+</ShowPlanXML>

--- a/internal/component/database_observability/sql_server/collector/testdata/explain_plan/concatenation.txtar
+++ b/internal/component/database_observability/sql_server/collector/testdata/explain_plan/concatenation.txtar
@@ -1,0 +1,35 @@
+SQL Server showplan XML generated from a query shaped like:
+
+```
+SELECT Name FROM ActiveCustomers
+UNION ALL
+SELECT Name FROM ArchivedCustomers
+```
+
+-- concatenation.xml --
+<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence>
+    <Batch>
+      <Statements>
+        <StmtSimple>
+          <QueryPlan>
+            <RelOp PhysicalOp="Concatenation" LogicalOp="Concatenation" EstimateRows="1500" EstimatedTotalSubtreeCost="1.1">
+              <Concat>
+                <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="1000" EstimatedTotalSubtreeCost="0.5">
+                  <TableScan>
+                    <Object Database="[MyDb]" Schema="[dbo]" Table="[ActiveCustomers]" />
+                  </TableScan>
+                </RelOp>
+                <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="500" EstimatedTotalSubtreeCost="0.4">
+                  <TableScan>
+                    <Object Database="[MyDb]" Schema="[dbo]" Table="[ArchivedCustomers]" />
+                  </TableScan>
+                </RelOp>
+              </Concat>
+            </RelOp>
+          </QueryPlan>
+        </StmtSimple>
+      </Statements>
+    </Batch>
+  </BatchSequence>
+</ShowPlanXML>

--- a/internal/component/database_observability/sql_server/collector/testdata/explain_plan/hash_match_aggregate.txtar
+++ b/internal/component/database_observability/sql_server/collector/testdata/explain_plan/hash_match_aggregate.txtar
@@ -1,0 +1,33 @@
+SQL Server showplan XML generated from a query shaped like:
+
+```
+SELECT CustomerId, COUNT(*)
+FROM Orders
+GROUP BY CustomerId
+```
+
+-- hash_match_aggregate.xml --
+<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence>
+    <Batch>
+      <Statements>
+        <StmtSimple>
+          <QueryPlan>
+            <RelOp PhysicalOp="Hash Match" LogicalOp="Aggregate" EstimateRows="300" EstimatedTotalSubtreeCost="0.9">
+              <Hash>
+                <GroupBy>
+                  <ColumnReference Database="[MyDb]" Schema="[dbo]" Table="[Orders]" Column="[CustomerId]" />
+                </GroupBy>
+                <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="2000" EstimatedTotalSubtreeCost="0.6">
+                  <TableScan>
+                    <Object Database="[MyDb]" Schema="[dbo]" Table="[Orders]" />
+                  </TableScan>
+                </RelOp>
+              </Hash>
+            </RelOp>
+          </QueryPlan>
+        </StmtSimple>
+      </Statements>
+    </Batch>
+  </BatchSequence>
+</ShowPlanXML>

--- a/internal/component/database_observability/sql_server/collector/testdata/explain_plan/hash_match_join.txtar
+++ b/internal/component/database_observability/sql_server/collector/testdata/explain_plan/hash_match_join.txtar
@@ -1,0 +1,35 @@
+SQL Server showplan XML generated from a query shaped like:
+
+```
+SELECT o.OrderId, c.Name
+FROM Orders o
+JOIN Customers c ON c.CustomerId = o.CustomerId
+```
+
+-- hash_match_join.xml --
+<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence>
+    <Batch>
+      <Statements>
+        <StmtSimple>
+          <QueryPlan>
+            <RelOp PhysicalOp="Hash Match" LogicalOp="Inner Join" EstimateRows="500" EstimatedTotalSubtreeCost="1.2">
+              <Hash>
+                <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="1000" EstimatedTotalSubtreeCost="0.5">
+                  <TableScan>
+                    <Object Database="[MyDb]" Schema="[dbo]" Table="[Customers]" />
+                  </TableScan>
+                </RelOp>
+                <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="2000" EstimatedTotalSubtreeCost="0.6">
+                  <TableScan>
+                    <Object Database="[MyDb]" Schema="[dbo]" Table="[Orders]" />
+                  </TableScan>
+                </RelOp>
+              </Hash>
+            </RelOp>
+          </QueryPlan>
+        </StmtSimple>
+      </Statements>
+    </Batch>
+  </BatchSequence>
+</ShowPlanXML>

--- a/internal/component/database_observability/sql_server/collector/testdata/explain_plan/nested_loop_seek_and_scan.txtar
+++ b/internal/component/database_observability/sql_server/collector/testdata/explain_plan/nested_loop_seek_and_scan.txtar
@@ -1,0 +1,39 @@
+SQL Server showplan XML generated from a query shaped like:
+
+```
+SELECT o.OrderId, c.Name
+FROM Orders o
+JOIN Customers c ON c.CustomerId = o.CustomerId
+WHERE o.Total > 100
+```
+
+-- nested_loop_seek_and_scan.xml --
+<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence>
+    <Batch>
+      <Statements>
+        <StmtSimple>
+          <QueryPlan>
+            <RelOp PhysicalOp="Nested Loops" LogicalOp="Inner Join" EstimateRows="12" EstimatedTotalSubtreeCost="0.045">
+              <NestedLoops>
+                <RelOp PhysicalOp="Clustered Index Seek" LogicalOp="Clustered Index Seek" EstimateRows="8" EstimatedTotalSubtreeCost="0.012">
+                  <IndexScan>
+                    <Object Database="[MyDb]" Schema="[dbo]" Table="[Orders]" Index="[PK_Orders]" />
+                    <Predicate>
+                      <ScalarOperator ScalarString="[dbo].[Orders].[Total]&gt;(100)" />
+                    </Predicate>
+                  </IndexScan>
+                </RelOp>
+                <RelOp PhysicalOp="Clustered Index Seek" LogicalOp="Clustered Index Seek" EstimateRows="1" EstimatedTotalSubtreeCost="0.003">
+                  <IndexScan Lookup="1">
+                    <Object Database="[MyDb]" Schema="[dbo]" Table="[Customers]" Index="[PK_Customers]" />
+                  </IndexScan>
+                </RelOp>
+              </NestedLoops>
+            </RelOp>
+          </QueryPlan>
+        </StmtSimple>
+      </Statements>
+    </Batch>
+  </BatchSequence>
+</ShowPlanXML>

--- a/internal/component/database_observability/sql_server/collector/testdata/explain_plan/sort_and_top.txtar
+++ b/internal/component/database_observability/sql_server/collector/testdata/explain_plan/sort_and_top.txtar
@@ -1,0 +1,39 @@
+SQL Server showplan XML generated from a query shaped like:
+
+```
+SELECT TOP 10 OrderId, OrderDate
+FROM Orders
+ORDER BY OrderDate DESC
+```
+
+-- sort_and_top.xml --
+<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence>
+    <Batch>
+      <Statements>
+        <StmtSimple>
+          <QueryPlan>
+            <RelOp PhysicalOp="Top" LogicalOp="Top" EstimateRows="10" EstimatedTotalSubtreeCost="0.7">
+              <Top>
+                <RelOp PhysicalOp="Sort" LogicalOp="Sort" EstimateRows="2000" EstimatedTotalSubtreeCost="0.65">
+                  <Sort>
+                    <OrderBy>
+                      <OrderByColumn Ascending="0">
+                        <ColumnReference Database="[MyDb]" Schema="[dbo]" Table="[Orders]" Column="[OrderDate]" />
+                      </OrderByColumn>
+                    </OrderBy>
+                    <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="2000" EstimatedTotalSubtreeCost="0.6">
+                      <TableScan>
+                        <Object Database="[MyDb]" Schema="[dbo]" Table="[Orders]" />
+                      </TableScan>
+                    </RelOp>
+                  </Sort>
+                </RelOp>
+              </Top>
+            </RelOp>
+          </QueryPlan>
+        </StmtSimple>
+      </Statements>
+    </Batch>
+  </BatchSequence>
+</ShowPlanXML>

--- a/internal/component/database_observability/sql_server/collector/testdata/explain_plan/warnings.txtar
+++ b/internal/component/database_observability/sql_server/collector/testdata/explain_plan/warnings.txtar
@@ -1,0 +1,43 @@
+SQL Server showplan XML generated from a query with a missing join predicate and a
+hash join that spills to tempdb (a synthetic worst-case shape, hand-authored for
+warning coverage rather than a real query):
+
+```
+SELECT o.OrderId, c.Name
+FROM Orders o, Customers c
+```
+
+-- warnings.xml --
+<ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence>
+    <Batch>
+      <Statements>
+        <StmtSimple>
+          <QueryPlan>
+            <RelOp PhysicalOp="Hash Match" LogicalOp="Inner Join" EstimateRows="2000000" EstimatedTotalSubtreeCost="45.2">
+              <Warnings>
+                <NoJoinPredicate />
+                <SpillToTempDb />
+              </Warnings>
+              <Hash>
+                <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="1000" EstimatedTotalSubtreeCost="0.5">
+                  <TableScan>
+                    <Object Database="[MyDb]" Schema="[dbo]" Table="[Customers]" />
+                  </TableScan>
+                </RelOp>
+                <RelOp PhysicalOp="Table Scan" LogicalOp="Table Scan" EstimateRows="2000" EstimatedTotalSubtreeCost="0.6">
+                  <Warnings>
+                    <ColumnsWithNoStatistics />
+                  </Warnings>
+                  <TableScan>
+                    <Object Database="[MyDb]" Schema="[dbo]" Table="[Orders]" />
+                  </TableScan>
+                </RelOp>
+              </Hash>
+            </RelOp>
+          </QueryPlan>
+        </StmtSimple>
+      </Statements>
+    </Batch>
+  </BatchSequence>
+</ShowPlanXML>

--- a/internal/component/database_observability/sql_server/component.go
+++ b/internal/component/database_observability/sql_server/component.go
@@ -73,6 +73,7 @@ type Arguments struct {
 	SchemaDetailsArguments SchemaDetailsArguments `alloy:"schema_details,block,optional"`
 	QueryMetricsArguments  QueryMetricsArguments  `alloy:"query_metrics,block,optional"`
 	QueryDetailsArguments  QueryDetailsArguments  `alloy:"query_details,block,optional"`
+	ExplainPlansArguments  ExplainPlansArguments  `alloy:"explain_plans,block,optional"`
 }
 
 type CloudProvider struct {
@@ -109,6 +110,10 @@ type QueryDetailsArguments struct {
 	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
 }
 
+type ExplainPlansArguments struct {
+	CollectInterval time.Duration `alloy:"collect_interval,attr,optional"`
+}
+
 func defaultArguments() Arguments {
 	return Arguments{
 		ExcludeSchemas:   database_observability.DefaultExcludedSchemas(),
@@ -125,6 +130,10 @@ func defaultArguments() Arguments {
 		},
 
 		QueryDetailsArguments: QueryDetailsArguments{
+			CollectInterval: 1 * time.Minute,
+		},
+
+		ExplainPlansArguments: ExplainPlansArguments{
 			CollectInterval: 1 * time.Minute,
 		},
 	}
@@ -156,6 +165,12 @@ func (a *Arguments) Validate() error {
 	if enableOrDisableCollectors(*a)[collector.QueryDetailsCollector] {
 		if a.QueryDetailsArguments.CollectInterval <= 0 {
 			return fmt.Errorf("query_details.collect_interval must be greater than zero")
+		}
+	}
+
+	if enableOrDisableCollectors(*a)[collector.ExplainPlansCollector] {
+		if a.ExplainPlansArguments.CollectInterval <= 0 {
+			return fmt.Errorf("explain_plans.collect_interval must be greater than zero")
 		}
 	}
 
@@ -426,6 +441,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 		collector.SchemaDetailsCollector: true,
 		collector.QueryMetricsCollector:  true,
 		collector.QueryDetailsCollector:  true,
+		collector.ExplainPlansCollector:  true,
 	}
 
 	for _, disabled := range a.DisableCollectors {
@@ -520,6 +536,33 @@ func (c *Component) startCollectors(serverID string, engineVersion string, cloud
 		}
 	}
 
+	if collectors[collector.ExplainPlansCollector] {
+		epArgs := collector.ExplainPlansArguments{
+			DB:              c.dbConnection,
+			CollectInterval: c.args.ExplainPlansArguments.CollectInterval,
+			EntryHandler:    entryHandler,
+			Logger:          c.opts.Logger,
+		}
+
+		// explain_plans has the same hard dependency on query_metrics's tracked
+		// query_hash set as query_details does, so its candidate set stays
+		// bounded by query_metrics.statements_limit rather than being an
+		// independent, unbounded discovery query.
+		if queryMetricsCollector != nil {
+			epArgs.Tracker = queryMetricsCollector.Tracker()
+		}
+
+		epCollector, err := collector.NewExplainPlans(epArgs)
+		if err != nil {
+			logStartError(collector.ExplainPlansCollector, "create", err)
+		} else {
+			if err := epCollector.Start(context.Background()); err != nil {
+				logStartError(collector.ExplainPlansCollector, "start", err)
+			}
+			c.collectors = append(c.collectors, epCollector)
+		}
+	}
+
 	// Connection Info collector is always enabled
 	ciCollector, err := collector.NewConnectionInfo(collector.ConnectionInfoArguments{
 		DSN:           string(c.args.DataSourceName),
@@ -609,6 +652,7 @@ func addLokiLabels(entryHandler loki.EntryHandler, instanceKey string, serverID 
 		"job":       database_observability.JobName,
 		"instance":  model.LabelValue(instanceKey),
 		"server_id": model.LabelValue(serverID),
+		"engine":    model.LabelValue(collector.EngineName),
 	}).Wrap(entryHandler)
 
 	return entryHandler

--- a/internal/component/database_observability/sql_server/component_test.go
+++ b/internal/component/database_observability/sql_server/component_test.go
@@ -4,12 +4,47 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/component/database_observability"
 	"github.com/grafana/alloy/internal/component/database_observability/sql_server/collector"
 	"github.com/grafana/alloy/syntax"
 )
+
+func Test_addLokiLabels(t *testing.T) {
+	t.Run("add required labels to loki entries", func(t *testing.T) {
+		handler := loki.NewCollectingHandler()
+		defer handler.Stop()
+		entryHandler := addLokiLabels(handler, "some-instance-key", "some-server-id-hash")
+
+		go func() {
+			ts := time.Now().UnixNano()
+			entryHandler.Chan() <- loki.Entry{
+				Entry: push.Entry{
+					Timestamp: time.Unix(0, ts),
+					Line:      "some-message",
+				},
+			}
+		}()
+
+		require.Eventually(t, func() bool {
+			return len(handler.Received()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+
+		require.Len(t, handler.Received(), 1)
+		assert.Equal(t, model.LabelSet{
+			"job":       database_observability.JobName,
+			"instance":  model.LabelValue("some-instance-key"),
+			"server_id": model.LabelValue("some-server-id-hash"),
+			"engine":    model.LabelValue(collector.EngineName),
+		}, handler.Received()[0].Labels)
+		assert.Equal(t, "some-message", handler.Received()[0].Line)
+	})
+}
 
 func Test_parseCloudProvider(t *testing.T) {
 	t.Run("parse aws cloud provider block", func(t *testing.T) {
@@ -198,4 +233,66 @@ func TestValidateQueryMetrics(t *testing.T) {
 		args.QueryMetricsArguments.StatementsLookback = 0
 		require.NoError(t, args.Validate())
 	})
+}
+
+func TestExplainPlansDefaults(t *testing.T) {
+	var args Arguments
+	args.SetToDefault()
+
+	assert.Equal(t, 1*time.Minute, args.ExplainPlansArguments.CollectInterval)
+}
+
+func TestExplainPlansEnabledByDefault(t *testing.T) {
+	var args Arguments
+	args.SetToDefault()
+
+	collectors := enableOrDisableCollectors(args)
+	assert.True(t, collectors[collector.ExplainPlansCollector])
+
+	args.DisableCollectors = []string{collector.ExplainPlansCollector}
+	collectors = enableOrDisableCollectors(args)
+	assert.False(t, collectors[collector.ExplainPlansCollector])
+}
+
+func TestValidateExplainPlans(t *testing.T) {
+	base := func() Arguments {
+		var args Arguments
+		args.SetToDefault()
+		args.DataSourceName = "sqlserver://user:pass@localhost:1433?database=app"
+		return args
+	}
+
+	t.Run("defaults are valid", func(t *testing.T) {
+		args := base()
+		require.NoError(t, args.Validate())
+	})
+
+	t.Run("non-positive collect_interval is rejected", func(t *testing.T) {
+		args := base()
+		args.ExplainPlansArguments.CollectInterval = 0
+		require.ErrorContains(t, args.Validate(), "explain_plans.collect_interval")
+	})
+
+	t.Run("invalid values are ignored when the collector is disabled", func(t *testing.T) {
+		args := base()
+		args.DisableCollectors = []string{collector.ExplainPlansCollector}
+		args.ExplainPlansArguments.CollectInterval = 0
+		require.NoError(t, args.Validate())
+	})
+}
+
+func TestExplainPlansConfigParsing(t *testing.T) {
+	exampleDBO11yAlloyConfig := `
+		data_source_name = "sqlserver://user:pass@localhost:1433"
+		forward_to       = []
+		targets          = []
+		explain_plans {
+			collect_interval = "5m"
+		}
+	`
+
+	var args Arguments
+	err := syntax.Unmarshal([]byte(exampleDBO11yAlloyConfig), &args)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, args.ExplainPlansArguments.CollectInterval)
 }


### PR DESCRIPTION
### Brief description of Pull Request

Adds an `explain_plans` collector to `database_observability.sql_server`, the last of the three `database_observability` engines to gain explain-plan support. It reads the execution plan Query Store already captured for each query tracked by `query_metrics` (no live plan compilation), parses SQL Server's showplan XML into the shared explain-plan model, and gates emission on the plan's structural hash changing or `EmitInterval` elapsing, to avoid the log-volume regression found in grafana-dbo11y-app#3409. Also adds an `engine` Loki label to sql_server's log lines (matching `connection_info`'s `engine` metric label) and drops the unused `databaseEngine`/`databaseVersion` metadata fields from sql_server's explain-plan output (mysql/postgres unchanged; to follow in a separate PR).

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

Fixes grafana/grafana-dbo11y-app#3024

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))