### PR TITLE
feat: Distroless Alloy docker image using chisel

### DIFF
--- a/.github/workflows/check-linux-container.yml
+++ b/.github/workflows/check-linux-container.yml
@@ -5,11 +5,13 @@ on:
       - main
     paths:
       - 'Dockerfile'
+      - 'Dockerfile.chisel'
       - 'scripts/docker-containers'
       - '.github/workflows/check-linux-container.yml'
   pull_request:
     paths:
       - 'Dockerfile'
+      - 'Dockerfile.chisel'
       - 'scripts/docker-containers'
       - '.github/workflows/check-linux-container.yml'
 
@@ -33,4 +35,22 @@ jobs:
       id-token: write
     with:
       img-name: alloy-devel-boringcrypto
+      push: false
+
+  check-linux-distroless-container:
+    uses: ./.github/workflows/publish-alloy-linux.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      img-name: alloy-devel-distroless
+      push: false
+
+  check-linux-boringcrypto-distroless-container:
+    uses: ./.github/workflows/publish-alloy-linux.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      img-name: alloy-devel-boringcrypto-distroless
       push: false

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - Dockerfile
+      - Dockerfile.chisel
       - Dockerfile.windows
       - Makefile
       - 'build-tools/make/*'
@@ -26,6 +27,9 @@ jobs:
       - name: Build image
         run: |
           docker build -t alloy-test:latest -f Dockerfile .
+      - name: Build distroless image
+        run: |
+          make ALLOY_IMAGE_DISTROLESS=alloy-test:distroless alloy-image-distroless
 
   windows:
     runs-on: windows-2022

--- a/.github/workflows/publish-alloy-devel-pr.yml
+++ b/.github/workflows/publish-alloy-devel-pr.yml
@@ -29,6 +29,28 @@ jobs:
       dev: true
       pr-number: ${{ github.event.pull_request.number }}
 
+  publish_linux_distroless_container:
+    if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:linux-distroless')}}
+    uses: ./.github/workflows/publish-alloy-linux.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      img-name: alloy-devel-distroless-pr
+      dev: true
+      pr-number: ${{ github.event.pull_request.number }}
+
+  publish_linux_boringcrypto_distroless_container:
+    if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:linux-bc-distroless')}}
+    uses: ./.github/workflows/publish-alloy-linux.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      img-name: alloy-devel-boringcrypto-distroless-pr
+      dev: true
+      pr-number: ${{ github.event.pull_request.number }}
+
   publish_windows_container:
     if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:windows')}}
     uses: ./.github/workflows/publish-alloy-windows.yml

--- a/.github/workflows/publish-alloy-devel-pr.yml
+++ b/.github/workflows/publish-alloy-devel-pr.yml
@@ -29,28 +29,6 @@ jobs:
       dev: true
       pr-number: ${{ github.event.pull_request.number }}
 
-  publish_linux_distroless_container:
-    if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:linux-distroless')}}
-    uses: ./.github/workflows/publish-alloy-linux.yml
-    permissions:
-      contents: read
-      id-token: write
-    with:
-      img-name: alloy-devel-distroless-pr
-      dev: true
-      pr-number: ${{ github.event.pull_request.number }}
-
-  publish_linux_boringcrypto_distroless_container:
-    if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:linux-bc-distroless')}}
-    uses: ./.github/workflows/publish-alloy-linux.yml
-    permissions:
-      contents: read
-      id-token: write
-    with:
-      img-name: alloy-devel-boringcrypto-distroless-pr
-      dev: true
-      pr-number: ${{ github.event.pull_request.number }}
-
   publish_windows_container:
     if: ${{ github.repository == 'grafana/alloy' && contains(github.event.pull_request.labels.*.name, 'publish-dev:windows')}}
     uses: ./.github/workflows/publish-alloy-windows.yml

--- a/.github/workflows/publish-alloy-devel.yml
+++ b/.github/workflows/publish-alloy-devel.yml
@@ -31,6 +31,24 @@ jobs:
       img-name:  alloy-devel-boringcrypto
       dev: true
 
+  publish_linux_distroless_container:
+    uses: ./.github/workflows/publish-alloy-linux.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      img-name: alloy-devel-distroless
+      dev: true
+
+  publish_linux_boringcrypto_distroless_container:
+    uses: ./.github/workflows/publish-alloy-linux.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      img-name: alloy-devel-boringcrypto-distroless
+      dev: true
+
   publish_windows_container:
     uses: ./.github/workflows/publish-alloy-windows.yml
     permissions:
@@ -46,6 +64,8 @@ jobs:
     needs:
     - publish_linux_container
     - publish_linux_boringcrypto_container
+    - publish_linux_distroless_container
+    - publish_linux_boringcrypto_distroless_container
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -38,7 +38,7 @@ jobs:
         fi
         if [[ "$DRY_RUN" == "true" ]]; then
           echo "Dry run enabled for $REF_NAME. The following would run:"
-          echo "  - Publish Linux container images"
+          echo "  - Publish regular, BoringCrypto, distroless, and BoringCrypto-distroless Linux container images"
           echo "  - Publish Windows container image"
           echo "  - Build and sign Windows executables and installer"
           echo "  - Upload release artifacts to GitHub"
@@ -64,6 +64,24 @@ jobs:
       id-token: write
     with:
       img-name: alloy-boringcrypto
+
+  publish_linux_distroless_container:
+    needs: validate
+    uses: ./.github/workflows/publish-alloy-linux.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      img-name: alloy-distroless
+
+  publish_linux_boringcrypto_distroless_container:
+    needs: validate
+    uses: ./.github/workflows/publish-alloy-linux.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      img-name: alloy-boringcrypto-distroless
 
   publish_windows_container:
     needs: validate

--- a/.github/workflows/release-publish-alloy-artifacts.yml
+++ b/.github/workflows/release-publish-alloy-artifacts.yml
@@ -38,7 +38,7 @@ jobs:
         fi
         if [[ "$DRY_RUN" == "true" ]]; then
           echo "Dry run enabled for $REF_NAME. The following would run:"
-          echo "  - Publish regular, BoringCrypto, distroless, and BoringCrypto-distroless Linux container images"
+          echo "  - Publish Linux container images"
           echo "  - Publish Windows container image"
           echo "  - Build and sign Windows executables and installer"
           echo "  - Upload release artifacts to GitHub"

--- a/Dockerfile.chisel
+++ b/Dockerfile.chisel
@@ -1,0 +1,140 @@
+# syntax=docker/dockerfile:1.23@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+# NOTE: This Dockerfile can only be built using BuildKit. BuildKit is used by
+# default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
+# in environment variables.
+
+ARG UBUNTU_RELEASE=24.04
+ARG CHISEL_VERSION=v1.4.2
+
+# Checksums for each asset are available at GitHub release page: https://github.com/canonical/chisel/releases
+FROM scratch AS chisel-amd64
+ARG CHISEL_VERSION
+ADD --checksum=sha256:3b3d86ea38045e54a13334e358ab8da12e6dd33342163c5c1ba13525f1070cfe --unpack \
+    "https://github.com/canonical/chisel/releases/download/${CHISEL_VERSION}/chisel_${CHISEL_VERSION}_linux_amd64.tar.gz" /
+
+FROM scratch AS chisel-arm64
+ARG CHISEL_VERSION
+ADD --checksum=sha256:398050085cf32d7718ba1e2fad144b179e0943d0e0376b2a0614577c51d331e8 --unpack \
+    "https://github.com/canonical/chisel/releases/download/${CHISEL_VERSION}/chisel_${CHISEL_VERSION}_linux_arm64.tar.gz" /
+
+FROM scratch AS chisel-ppc64le
+ARG CHISEL_VERSION
+ADD --checksum=sha256:5271bb65e4cbb16838a234bc2a5d87fd6c96199926490e57a1ea7115e10f2a3d --unpack \
+    "https://github.com/canonical/chisel/releases/download/${CHISEL_VERSION}/chisel_${CHISEL_VERSION}_linux_ppc64le.tar.gz" /
+
+FROM scratch AS chisel-s390x
+ARG CHISEL_VERSION
+ADD --checksum=sha256:125337a9d038763bef3e7ccd2e53bc08accafa2b1b108809a5560ed037e94cb9 --unpack \
+    "https://github.com/canonical/chisel/releases/download/${CHISEL_VERSION}/chisel_${CHISEL_VERSION}_linux_s390x.tar.gz" /
+
+FROM chisel-${TARGETARCH} AS chisel
+
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.35@sha256:9fa2a341b53503ce42cf9900c401d689a68ea67cdec6a20f53d72e3665fb8dc6 AS ui-build
+ARG BUILDPLATFORM
+COPY ./internal/web/ui /ui
+WORKDIR /ui
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm ci --no-audit --no-fund                         \
+    && npm run build
+
+FROM --platform=$BUILDPLATFORM grafana/alloy-build-image:v0.1.35@sha256:9fa2a341b53503ce42cf9900c401d689a68ea67cdec6a20f53d72e3665fb8dc6 AS build
+
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG RELEASE_BUILD=1
+ARG VERSION
+ARG GOEXPERIMENT
+
+COPY . /src/alloy
+WORKDIR /src/alloy
+
+COPY --from=ui-build /ui/dist /src/alloy/internal/web/ui/dist
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    GOOS="$TARGETOS" GOARCH="$TARGETARCH" GOARM=${TARGETVARIANT#v} \
+    RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} \
+    GO_TAGS="netgo embedalloyui promtail_journal_enabled" \
+    GOEXPERIMENT=${GOEXPERIMENT} \
+    SKIP_UI_BUILD=1 \
+    make alloy
+
+###
+
+FROM public.ecr.aws/ubuntu/ubuntu:noble@sha256:748740465d0aadaa69ab6e6c295892f17d7a8f44a85090dbb571ec0bb8c5674f AS slicer
+
+# Username and uid for alloy user
+ARG UID="473"
+ARG USERNAME="alloy"
+ARG UBUNTU_RELEASE
+SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qy --no-install-recommends ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=chisel /chisel /usr/bin/chisel
+# base-files_chisel generates the Chisel manifest. Keep the package cache until
+# its Debian control records have populated the dpkg status file for scanners.
+RUN mkdir -p /rootfs/var/lib/dpkg \
+    && XDG_CACHE_HOME=/tmp/chisel-cache chisel cut --release "ubuntu-${UBUNTU_RELEASE}" --root /rootfs \
+        base-files_base \
+        base-files_chisel \
+        base-files_release-info \
+        ca-certificates_data \
+        dash_bins \
+        libc6_libs \
+        libsystemd0_libs \
+        tzdata_zoneinfo \
+    && for archive in /tmp/chisel-cache/chisel/sha256/*; do \
+        if dpkg-deb --field "$archive" Package >/dev/null 2>&1; then \
+            dpkg-deb --field "$archive" >> /rootfs/var/lib/dpkg/status; \
+            printf '\n' >> /rootfs/var/lib/dpkg/status; \
+        fi; \
+    done \
+    && rm -rf /tmp/chisel-cache
+
+# Create the Alloy user directly because the chiseled rootfs has no useradd.
+RUN cat >>/rootfs/etc/passwd <<EOF
+root:x:0:0:root:/root:/sbin/nologin
+${USERNAME}:x:${UID}:${UID}::/home/${USERNAME}:/sbin/nologin
+EOF
+RUN cat >>/rootfs/etc/group <<EOF
+root:x:0:
+${USERNAME}:x:${UID}:
+EOF
+
+COPY --from=build --chown=${UID}:${UID} /src/alloy/build/alloy /rootfs/usr/bin/alloy
+COPY --chown=${UID}:${UID} example-config.alloy /rootfs/etc/alloy/config.alloy
+
+# Provide /bin/otelcol compatibility entrypoint. Useful when using Alloy's OTel Engine with
+# OpenTelemetry Collector helm chart and other ecosystem tools that expect otelcol binary.
+COPY --chmod=755 --chown=${UID}:${UID} packaging/docker/otelcol.sh /rootfs/usr/bin/otelcol
+
+# Provide /bin/otel-supervisor entrypoint to run Alloy's embedded OpAMP supervisor as PID 1
+COPY --chmod=755 --chown=${UID}:${UID} packaging/docker/otel-supervisor.sh /rootfs/usr/bin/otel-supervisor
+
+# Create Alloy's writable directories, but do not set the user as default.
+#
+# NOTE: non-root support in Docker containers is an experimental,
+# undocumented feature; use at your own risk.
+RUN mkdir -p /rootfs/var/lib/alloy/data /rootfs/var/lib/alloy/supervisor /rootfs/home/${USERNAME} \
+    && chown -R ${UID}:${UID} /rootfs/var/lib/alloy /rootfs/home/${USERNAME} \
+    && chmod -R 770 /rootfs/var/lib/alloy
+
+###
+
+FROM scratch
+
+LABEL org.opencontainers.image.source="https://github.com/grafana/alloy"
+
+COPY --from=slicer /rootfs/ /
+
+ENTRYPOINT ["/bin/alloy"]
+ENV ALLOY_DEPLOY_MODE=docker
+CMD ["run", "/etc/alloy/config.alloy", "--storage.path=/var/lib/alloy/data"]

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@
 ##   images               Builds all (Linux) Docker images.
 ##   images-windows       Builds all (Windows) Docker images.
 ##   alloy-image          Builds alloy Docker image.
+##   alloy-image-distroless Builds distroless alloy Docker image.
 ##   alloy-image-windows  Builds alloy Docker image for Windows.
 ##
 ## Targets for packaging:
@@ -70,6 +71,7 @@
 ##
 ##   USE_CONTAINER        Set to 1 to enable proxying commands to build container
 ##   ALLOY_IMAGE          Image name:tag built by `make alloy-image`
+##   ALLOY_IMAGE_DISTROLESS Image name:tag built by `make alloy-image-distroless`
 ##   ALLOY_IMAGE_WINDOWS  Image name:tag built by `make alloy-image-windows`
 ##   BUILD_IMAGE          Image name:tag used by USE_CONTAINER=1
 ##   ALLOY_BINARY         Output path of `make alloy` (default build/alloy)
@@ -91,6 +93,7 @@
 include build-tools/make/*.mk
 
 ALLOY_IMAGE          		?= grafana/alloy:latest
+ALLOY_IMAGE_DISTROLESS		?= grafana/alloy:latest-distroless
 ALLOY_IMAGE_WINDOWS  		?= grafana/alloy:windowsservercore-ltsc2022
 ALLOY_BINARY         		?= build/alloy
 SERVICE_BINARY       		?= build/alloy-service
@@ -339,17 +342,20 @@ endif
 # Targets for building Docker images
 #
 
-DOCKER_FLAGS := --build-arg RELEASE_BUILD=$(RELEASE_BUILD) --build-arg VERSION=$(VERSION)
+DOCKER_FLAGS := --build-arg RELEASE_BUILD=$(RELEASE_BUILD) --build-arg VERSION=$(VERSION) --build-arg GOEXPERIMENT=$(GOEXPERIMENT)
 
 ifneq ($(DOCKER_PLATFORM),)
 DOCKER_FLAGS += --platform=$(DOCKER_PLATFORM)
 endif
 
-.PHONY: images alloy-image
-images: alloy-image
+.PHONY: images alloy-image alloy-image-distroless
+images: alloy-image alloy-image-distroless
 
 alloy-image:
 	DOCKER_BUILDKIT=1 docker build $(DOCKER_FLAGS) -t $(ALLOY_IMAGE) -f Dockerfile .
+
+alloy-image-distroless:
+	DOCKER_BUILDKIT=1 docker build $(DOCKER_FLAGS) -t $(ALLOY_IMAGE_DISTROLESS) -f Dockerfile.chisel .
 
 # Test fixture image used by the k8s integration tests as a Prometheus scrape
 # target. The runner builds this alongside alloy-image so the tests don't have
@@ -359,7 +365,7 @@ prom-gen-image:
 	DOCKER_BUILDKIT=1 docker build $(DOCKER_FLAGS) -t prom-gen:latest -f integration-tests/docker/configs/prom-gen/Dockerfile .
 
 .PHONY: images-windows alloy-image-windows
-images: alloy-image-windows
+images-windows: alloy-image-windows
 
 alloy-image-windows:
 	docker build $(DOCKER_FLAGS) -t $(ALLOY_IMAGE_WINDOWS) -f Dockerfile.windows .

--- a/docs/sources/set-up/install/docker.md
+++ b/docs/sources/set-up/install/docker.md
@@ -72,6 +72,23 @@ BoringCrypto images are published with every release starting with version 1.1:
   `grafana/alloy:<VERSION>-boringcrypto`, such as
   `grafana/alloy:v1.1.0-boringcrypto`.
 
+### Distroless images
+
+{{< admonition type="note" >}}
+Distroless images are experimental.
+BoringCrypto variants of distroless images are only available on AMD64 and ARM64 platforms.
+{{< /admonition >}}
+
+Distroless images are published with every release:
+
+* The current distroless image is published as `grafana/alloy:latest-distroless`.
+* A specific version of the distroless image is published as
+  `grafana/alloy:<VERSION>-distroless`.
+* The current BoringCrypto distroless image is published as
+  `grafana/alloy:boringcrypto-distroless`.
+* A specific version of the BoringCrypto distroless image is published as
+  `grafana/alloy:<VERSION>-boringcrypto-distroless`.
+
 ## Run a Windows Docker container
 
 To run {{< param "PRODUCT_NAME" >}} as a Windows Docker container, run the following command in a terminal window:

--- a/docs/sources/set-up/install/docker.md
+++ b/docs/sources/set-up/install/docker.md
@@ -74,20 +74,21 @@ BoringCrypto images are published with every release starting with version 1.1:
 
 ### Distroless images
 
+> **EXPERIMENTAL**: Distroless images are [experimental][].
+> Experimental features are subject to frequent breaking changes, and may be removed with no equivalent replacement.
+
+[experimental]: https://grafana.com/docs/release-life-cycle/
+
 {{< admonition type="note" >}}
-Distroless images are experimental.
 BoringCrypto variants of distroless images are only available on AMD64 and ARM64 platforms.
 {{< /admonition >}}
 
 Distroless images are published with every release:
 
 * The current distroless image is published as `grafana/alloy:latest-distroless`.
-* A specific version of the distroless image is published as
-  `grafana/alloy:<VERSION>-distroless`.
-* The current BoringCrypto distroless image is published as
-  `grafana/alloy:boringcrypto-distroless`.
-* A specific version of the BoringCrypto distroless image is published as
-  `grafana/alloy:<VERSION>-boringcrypto-distroless`.
+* A specific version of the distroless image is published as `grafana/alloy:<VERSION>-distroless`.
+* The current BoringCrypto distroless image is published as `grafana/alloy:boringcrypto-distroless`.
+* A specific version of the BoringCrypto distroless image is published as `grafana/alloy:<VERSION>-boringcrypto-distroless`.
 
 ## Run a Windows Docker container
 

--- a/docs/sources/set-up/install/podman.md
+++ b/docs/sources/set-up/install/podman.md
@@ -171,6 +171,20 @@ BoringCrypto images are published with every release starting with version 1.1:
 * The current BoringCrypto image is published as `docker.io/grafana/alloy:boringcrypto`.
 * A specific version of the BoringCrypto image is published as `docker.io/grafana/alloy:<VERSION>-boringcrypto`, such as `docker.io/grafana/alloy:v1.1.0-boringcrypto`.
 
+## Distroless images
+
+{{< admonition type="note" >}}
+Distroless images are experimental.
+BoringCrypto variants of distroless images are only available on AMD64 and ARM64 platforms.
+{{< /admonition >}}
+
+Distroless images are published with every release:
+
+* The current distroless image is published as `docker.io/grafana/alloy:latest-distroless`.
+* A specific version of the distroless image is published as `docker.io/grafana/alloy:<VERSION>-distroless`.
+* The current BoringCrypto distroless image is published as `docker.io/grafana/alloy:boringcrypto-distroless`.
+* A specific version of the BoringCrypto distroless image is published as `docker.io/grafana/alloy:<VERSION>-boringcrypto-distroless`.
+
 ## Verify
 
 To verify that {{< param "PRODUCT_NAME" >}} is running successfully, navigate to <http://localhost:12345> and make sure the {{< param "PRODUCT_NAME" >}} [UI][] loads without error.

--- a/docs/sources/set-up/install/podman.md
+++ b/docs/sources/set-up/install/podman.md
@@ -173,8 +173,12 @@ BoringCrypto images are published with every release starting with version 1.1:
 
 ## Distroless images
 
+> **EXPERIMENTAL**: Distroless images are [experimental][].
+> Experimental features are subject to frequent breaking changes, and may be removed with no equivalent replacement.
+
+[experimental]: https://grafana.com/docs/release-life-cycle/
+
 {{< admonition type="note" >}}
-Distroless images are experimental.
 BoringCrypto variants of distroless images are only available on AMD64 and ARM64 platforms.
 {{< /admonition >}}
 

--- a/packaging/docker/otel-supervisor.sh
+++ b/packaging/docker/otel-supervisor.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/sh
 # Wrapper to run Alloy's embedded OpAMP supervisor as PID 1.
 # Delegate to Alloy's otel-supervisor subcommand and pass through all arguments.
 # Using exec makes the supervisor PID 1 so it receives SIGTERM directly

--- a/packaging/docker/otelcol.sh
+++ b/packaging/docker/otelcol.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/sh
 # Compatibility wrapper for OpenTelemetry Collector integrations.
 # Delegate to Alloy's OTel engine and pass through all arguments.
 exec /bin/alloy otel "$@"

--- a/scripts/docker-containers
+++ b/scripts/docker-containers
@@ -49,6 +49,8 @@ fi
 # DEFAULT_LATEST is the default tag to use for the "latest" tag.
 DEFAULT_LATEST=latest
 BORINGCRYPTO_LATEST=boringcrypto
+DISTROLESS_LATEST=latest-distroless
+BORINGCRYPTO_DISTROLESS_LATEST=boringcrypto-distroless
 
 # The TAG_VERSION is the version to use for the Docker tag. It is sanitized to
 # force it to be a valid Docker tag name (primarily by removing the +
@@ -102,6 +104,41 @@ case "$TARGET_CONTAINER" in
       .
     ;;
 
+  alloy-distroless)
+    if [[ "$BRANCH_TAG" == "$DEFAULT_LATEST" ]]; then
+      BRANCH_TAG=$DISTROLESS_LATEST
+    else
+      BRANCH_TAG=$BRANCH_TAG-distroless
+    fi
+
+    docker buildx build $DOCKER_FLAGS                    \
+      --platform $BUILD_PLATFORMS                        \
+      --build-arg RELEASE_BUILD=1                        \
+      --build-arg VERSION="$VERSION"                    \
+      -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION-distroless" \
+      -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"             \
+      -f Dockerfile.chisel                               \
+      .
+    ;;
+
+  alloy-boringcrypto-distroless)
+    if [[ "$BRANCH_TAG" == "$DEFAULT_LATEST" ]]; then
+      BRANCH_TAG=$BORINGCRYPTO_DISTROLESS_LATEST
+    else
+      BRANCH_TAG=$BRANCH_TAG-boringcrypto-distroless
+    fi
+
+    docker buildx build $DOCKER_FLAGS                                 \
+      --platform $BUILD_PLATFORMS_BORINGCRYPTO                        \
+      --build-arg RELEASE_BUILD=1                                     \
+      --build-arg VERSION="$VERSION"                                 \
+      --build-arg GOEXPERIMENT=boringcrypto                           \
+      -t "$RELEASE_ALLOY_IMAGE:$TAG_VERSION-boringcrypto-distroless" \
+      -t "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"                          \
+      -f Dockerfile.chisel                                            \
+      .
+    ;;
+
   alloy-devel)
     docker buildx build $DOCKER_FLAGS      \
       --platform $BUILD_PLATFORMS          \
@@ -126,6 +163,41 @@ case "$TARGET_CONTAINER" in
       -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION-boringcrypto" \
       -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"               \
       -f Dockerfile                                     \
+      .
+    ;;
+
+  alloy-devel-distroless)
+    if [[ "$BRANCH_TAG" == "$DEFAULT_LATEST" ]]; then
+      BRANCH_TAG=$DISTROLESS_LATEST
+    else
+      BRANCH_TAG=$BRANCH_TAG-distroless
+    fi
+
+    docker buildx build $DOCKER_FLAGS                  \
+      --platform $BUILD_PLATFORMS                      \
+      --build-arg RELEASE_BUILD=1                      \
+      --build-arg VERSION="$VERSION"                  \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION-distroless" \
+      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"             \
+      -f Dockerfile.chisel                             \
+      .
+    ;;
+
+  alloy-devel-boringcrypto-distroless)
+    if [[ "$BRANCH_TAG" == "$DEFAULT_LATEST" ]]; then
+      BRANCH_TAG=$BORINGCRYPTO_DISTROLESS_LATEST
+    else
+      BRANCH_TAG=$BRANCH_TAG-boringcrypto-distroless
+    fi
+
+    docker buildx build $DOCKER_FLAGS                               \
+      --platform $BUILD_PLATFORMS_BORINGCRYPTO                      \
+      --build-arg RELEASE_BUILD=1                                   \
+      --build-arg VERSION="$VERSION"                               \
+      --build-arg GOEXPERIMENT=boringcrypto                         \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG_VERSION-boringcrypto-distroless" \
+      -t "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"                          \
+      -f Dockerfile.chisel                                          \
       .
     ;;
 
@@ -154,9 +226,33 @@ case "$TARGET_CONTAINER" in
       .
     ;;
 
+  alloy-devel-distroless-pr)
+	TAG="pr-${GITHUB_PR_NUMBER}-${TAG_VERSION}"
+
+    docker buildx build $DOCKER_FLAGS             \
+      --platform $BUILD_PLATFORMS                 \
+      --build-arg RELEASE_BUILD=1                 \
+      --build-arg VERSION="$VERSION"             \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG-distroless"     \
+      -f Dockerfile.chisel                        \
+      .
+    ;;
+
+  alloy-devel-boringcrypto-distroless-pr)
+	TAG="pr-${GITHUB_PR_NUMBER}-${TAG_VERSION}"
+
+    docker buildx build $DOCKER_FLAGS                          \
+      --platform $BUILD_PLATFORMS_BORINGCRYPTO                 \
+      --build-arg RELEASE_BUILD=1                              \
+      --build-arg VERSION="$VERSION"                          \
+      --build-arg GOEXPERIMENT=boringcrypto                    \
+      -t "$DEVEL_ALLOY_IMAGE:$TAG-boringcrypto-distroless"     \
+      -f Dockerfile.chisel                                     \
+      .
+    ;;
+
   *)
-    echo "Usage: $0 alloy|alloy-boringcrypto|alloy-devel|alloy-devel-boringcrypto|alloy-devel-pr|alloy-devel-boringcrypto-pr"
+    echo "Usage: $0 alloy|alloy-boringcrypto|alloy-distroless|alloy-boringcrypto-distroless|alloy-devel|alloy-devel-boringcrypto|alloy-devel-distroless|alloy-devel-boringcrypto-distroless|alloy-devel-pr|alloy-devel-boringcrypto-pr|alloy-devel-distroless-pr|alloy-devel-boringcrypto-distroless-pr"
     exit 1
     ;;
 esac
-

--- a/tools/goversion/command.go
+++ b/tools/goversion/command.go
@@ -186,9 +186,13 @@ func bumpBuildImage(root string) error {
 	if err != nil {
 		return err
 	}
+	return updateBuildImageRefs(root, refs)
+}
 
+func updateBuildImageRefs(root string, refs *buildImageRefs) error {
 	var paths = []string{
 		"Dockerfile",
+		"Dockerfile.chisel",
 		".github/workflows/build.yml",
 		".github/workflows/release-publish-alloy-artifacts.yml",
 		".github/workflows/test_full.yml",


### PR DESCRIPTION
### Brief description of Pull Request

Add an experimental distroless Alloy Docker image variant

### Pull Request Details

This PR adds an experimental distroless Alloy Docker image.
The distroless variant is created using [chisel](https://ubuntu.com/blog/craft-custom-chiselled-ubuntu-distroless).

The docs are also updated to mention a new experimental distroless image. 

Reasoning and proposal are described in the issue linked to the PR (#6662).

#### Docker Tags

Distroless version is created both for regular and boringcrypto variants and published under a separate tag:

- **Regular image:** `:latest-distroless`, `:vX.Y.Z-distroless`
- **boringcrypto:** `:boringcrypto-distroless`, `:vX.Y.Z-boringcrypto-distroless`

The `distroless` label name was chosen, as [`grafana/grafana`](https://hub.docker.com/r/grafana/grafana) uses a similar tag suffix for their distroless variant.


#### Image Contents

Due to distroless nature, this image doesn't ship a package manager.

Image bundles:
- `ca-certificates`
- `tzdata`
- `libc` + `libsystemd`: for CGO, `dlopen` and `loki.source.journal`
- `dash`: bare minimal POSIX interpreter, needed for `otelcol` custom entrypoint.

Curl is not shiped, as the original image didn't provide it as well.

Core shell commands like `ls` or `cat` are not present.

See "Notes to the Reviewer" and "Debugging/Troubleshooting" sections regarding shell commands.

#### Security Scanners Support

Chisel doesn't use apt/dpkg package manager and pulls package slices directly, therefore it doesn't generate `/var/lib/dpkg/status` file which is used as a source for most security scanners.

Although some security scanners support Chisel's manifest (`/var/lib/chisel/manifest.wall`), I've added a piece of logic to generate the `status` file to make image scannable by all security scanners.

In addition to that, if we would like to publish a separate SBOM file - there is [ssbom](https://github.com/canonical/ssbom) project from Canonical to build SBOM from a chisel manifest.

<details>
<summary>Trivy image scan output</summary>

```

Report Summary

┌─────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│               Target                │   Type   │ Vulnerabilities │ Secrets │
├─────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ grafana/alloy:latest (ubuntu 24.04) │  ubuntu  │        2        │    -    │
├─────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/bin/alloy                       │ gobinary │        6        │    -    │
└─────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


grafana/alloy:latest (ubuntu 24.04)
===================================
Total: 2 (UNKNOWN: 0, LOW: 2, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────────┬────────────────┬──────────┬──────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────┐
│   Library   │ Vulnerability  │ Severity │  Status  │ Installed Version │ Fixed Version │                        Title                         │
├─────────────┼────────────────┼──────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────┤
│ libgcrypt20 │ CVE-2024-2236  │ LOW      │ affected │ 1.10.3-2ubuntu0.1 │               │ libgcrypt: vulnerable to Marvin Attack               │
│             │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2236            │
├─────────────┼────────────────┤          │          ├───────────────────┼───────────────┼──────────────────────────────────────────────────────┤
│ libsystemd0 │ CVE-2026-40228 │          │          │ 255.4-1ubuntu8.17 │               │ systemd: systemd-journald: Unintended output to user │
│             │                │          │          │                   │               │ terminals via logger command                         │
│             │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2026-40228           │
└─────────────┴────────────────┴──────────┴──────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────┘

usr/bin/alloy (gobinary)
========================
Total: 6 (UNKNOWN: 1, LOW: 0, MEDIUM: 2, HIGH: 3, CRITICAL: 0)

┌──────────────────────────┬────────────────┬──────────┬──────────┬──────────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│         Library          │ Vulnerability  │ Severity │  Status  │  Installed Version   │ Fixed Version │                            Title                             │
├──────────────────────────┼────────────────┼──────────┼──────────┼──────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/docker/docker │ CVE-2026-34040 │ HIGH     │ fixed    │ v28.5.2+incompatible │ 29.3.1        │ Moby: Moby: Authorization bypass vulnerability               │
│                          │                │          │          │                      │               │ https://avd.aquasec.com/nvd/cve-2026-34040                   │
│                          ├────────────────┤          ├──────────┤                      ├───────────────┼──────────────────────────────────────────────────────────────┤
│                          │ CVE-2026-41567 │          │ affected │                      │               │ docker: Moby/Docker Engine: Arbitrary Code Execution via     │
│                          │                │          │          │                      │               │ malicious container image and compressed...                  │
│                          │                │          │          │                      │               │ https://avd.aquasec.com/nvd/cve-2026-41567                   │
│                          ├────────────────┤          │          │                      ├───────────────┼──────────────────────────────────────────────────────────────┤
│                          │ CVE-2026-42306 │          │          │                      │               │ github.com/docker/docker: github.com/moby/moby: Moby         │
│                          │                │          │          │                      │               │ container framework: Host file overwrite via race condition  │
│                          │                │          │          │                      │               │ in...                                                        │
│                          │                │          │          │                      │               │ https://avd.aquasec.com/nvd/cve-2026-42306                   │
│                          ├────────────────┼──────────┼──────────┤                      ├───────────────┼──────────────────────────────────────────────────────────────┤
│                          │ CVE-2026-33997 │ MEDIUM   │ fixed    │                      │ 29.3.1        │ moby: docker: github.com/moby/moby: Moby: Privilege          │
│                          │                │          │          │                      │               │ validation bypass during plugin installation                 │
│                          │                │          │          │                      │               │ https://avd.aquasec.com/nvd/cve-2026-33997                   │
│                          ├────────────────┤          ├──────────┤                      ├───────────────┼──────────────────────────────────────────────────────────────┤
│                          │ CVE-2026-41568 │          │ affected │                      │               │ github.com/docker/docker: github.com/moby/moby: Moby: Denial │
│                          │                │          │          │                      │               │ of Service via race condition in docker cp...                │
│                          │                │          │          │                      │               │ https://avd.aquasec.com/nvd/cve-2026-41568                   │
├──────────────────────────┼────────────────┼──────────┤          ├──────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto      │ GO-2026-5932   │ UNKNOWN  │          │ v0.55.0              │               │ The golang.org/x/crypto/openpgp package is unmaintained,     │
│                          │                │          │          │                      │               │ unsafe by design, and has known security...                  │
└──────────────────────────┴────────────────┴──────────┴──────────┴──────────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```
</details>

#### Debugging/Troubleshooting

Although the image doesn't ship any shell commands or package manager, the image can be debugged on k8s using ephemeral containers (`kubectl debug`).

```
kubectl debug <podname> -it --image=busybox
```

Docker (only in enterprise version) provides a similar `docker debug` command.

Podman and nerdctl don't provide a similar helper, but this can be workaround-ed with namespace sharing.

#### Testing

For testing, I've used a minimal Alloy config that uses `loki.source.journal` component:

<details>
<summary>Click to expand</summary>

```hcl
// Smoke-test config exercising loki.source.journal — proves libsystemd dlopen
// resolved correctly. We don't actually need the writes to reach a backend, we
// only need component init to succeed.
loki.source.journal "smoketest" {
  forward_to = [loki.write.nullsink.receiver]
}

loki.write "nullsink" {
  endpoint {
    url = "http://127.0.0.1:9999/loki/api/v1/push"
  }
}
```
</details>

The reason to use `loki.source.journal` component for a smoke test, is that there were multiple attempts to make a distroless Alloy image, but bundling `libsystemd0` was the main blocker.



### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->

Fixes #6662


### Notes to the Reviewer

#### Shell Commands

The image doesn't include coreutils or other extra tools, therefore core commands like `ls`, `cat` or `sleep` are not available.

If necessary, I can replace `dash` with `busybox` which provides more tools.



### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
