### PR TITLE
docs: Frontend observability link on otelcol.exporter.faro and otelcol.receiver.faro pages

### DIFF
--- a/docs/sources/reference/components/faro/faro.receiver.md
+++ b/docs/sources/reference/components/faro/faro.receiver.md
@@ -21,7 +21,7 @@ This component does not work with [Grafana Cloud Frontend Observability][fronten
 For more information, refer to the [Choose a component][frontend-telemetry] guide.
 
 [frontend-telemetry]: ../../../../collect/choose-component/#frontend-telemetry
-[frontend-observability]: https://grafana.com/products/cloud/frontend-observability-for-real-user-monitoring/
+[frontend-observability]: https://grafana.com/products/cloud/frontend-observability/
 {{< /admonition >}}
 
 ## Usage

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.faro.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.faro.md
@@ -176,4 +176,4 @@ Refer to the linked documentation for more details.
 <!-- END GENERATED COMPATIBLE COMPONENTS -->
 
 [Faro]: https://grafana.com/oss/faro/
-[Frontend Observability]: https://grafana.com/products/cloud/frontend-observability-for-real-user-monitoring/
+[Frontend Observability]: https://grafana.com/products/cloud/frontend-observability/

--- a/docs/sources/shared/reference/components/otelcol-faro-component-note.md
+++ b/docs/sources/shared/reference/components/otelcol-faro-component-note.md
@@ -8,6 +8,6 @@ headless: true
 This component is necessary for [Grafana Cloud Frontend Observability][frontend-observability] to work.
 For more information, refer to the [Choose a component][frontend-telemetry] guide.
 
-[frontend-observability]: https://grafana.com/products/cloud/frontend-observability-for-real-user-monitoring/
+[frontend-observability]: https://grafana.com/products/cloud/frontend-observability/
 [frontend-telemetry]: https://grafana.com/docs/alloy/latest/collect/choose-component/#frontend-telemetry
 {{< /admonition >}}


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
    description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.

  **HUMANS**
  - Read and understand docs/developer/genai.md
  - Brief description / Issue(s) fixed: factual summary of the change (AI may
    help). Details, Notes, and Checklist: your motivations, trade-offs, and
    judgment — keep those human-owned.

  **AI AGENTS**
  - MANDATORY: Read, understand, and apply AGENTS.md
  - Use this template as the PR body structure. Do not invent a custom layout.
  - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
    that section's content. Leave it empty unless the human already filled it.
  - Sections without "HUMAN ONLY" may be filled by you (Brief description,
    Issue(s) fixed when known). Do not invent issue numbers or a PR title.
  - Checklist: leave unchecked unless the human explicitly confirmed; do not
    guess the AI-assistance disclosure box.
  - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
    point at docs/developer/genai.md.
-->

### Brief description of Pull Request

<!-- Factual, human-readable summary of what changed (squash commit body). -->
The link to the Frontend Observability opens 404 page on pages:
* https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.faro/
* https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.faro/

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->

Changed the link from https://grafana.com/products/cloud/frontend-observability-for-real-user-monitoring/ to https://grafana.com/products/cloud/frontend-observability/

