### PR TITLE
docs(otel-engine): Document 3rd party collectors embedding of alloyengine extension

### DIFF
--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -100,8 +100,9 @@ This extension accepts a path to the {{< param "DEFAULT_ENGINE" >}} configuratio
 It starts a {{< param "DEFAULT_ENGINE" >}} pipeline alongside the {{< param "OTEL_ENGINE" >}} pipeline.
 
 You can also embed the `alloyengine` extension into any other OpenTelemetry Collector distribution using the OpenTelemetry Collector Builder (OCB).
-This requires an extra step to handle the {{< param "DEFAULT_ENGINE" >}} UI assets.
-Refer to the extension's [README](https://github.com/grafana/alloy/blob/main/extension/alloyengine/README.md#web-ui) for details.
+When you embed `alloyengine` into another OpenTelemetry Collector, the {{< param "DEFAULT_ENGINE" >}} UI needs an extra build step to work.
+If you don't intend to use the UI, you can skip it.
+Refer to the extension's [README](https://github.com/grafana/alloy/blob/main/extension/alloyengine/README.md#web-ui) for the steps to enable the {{< param "DEFAULT_ENGINE" >}} UI in this setup.
 
 The following example uses `config.path` to load the {{< param "DEFAULT_ENGINE" >}} configuration from a file or directory:
 

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -99,6 +99,10 @@ Modify your YAML configuration to include the `alloyengine` extension.
 This extension accepts a path to the {{< param "DEFAULT_ENGINE" >}} configuration or an inline {{< param "DEFAULT_ENGINE" >}} configuration.
 It starts a {{< param "DEFAULT_ENGINE" >}} pipeline alongside the {{< param "OTEL_ENGINE" >}} pipeline.
 
+You can also embed the `alloyengine` extension into any other OpenTelemetry Collector distribution using the OpenTelemetry Collector Builder (OCB).
+This requires an extra step to handle the {{< param "DEFAULT_ENGINE" >}} UI assets.
+Refer to the extension's [README](https://github.com/grafana/alloy/blob/main/extension/alloyengine/README.md#web-ui) for details.
+
 The following example uses `config.path` to load the {{< param "DEFAULT_ENGINE" >}} configuration from a file or directory:
 
 ```yaml

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -100,7 +100,7 @@ This extension accepts a path to the {{< param "DEFAULT_ENGINE" >}} configuratio
 It starts a {{< param "DEFAULT_ENGINE" >}} pipeline alongside the {{< param "OTEL_ENGINE" >}} pipeline.
 
 You can also embed the `alloyengine` extension into any other OpenTelemetry Collector distribution using the OpenTelemetry Collector Builder (OCB).
-See the extension's [README](https://github.com/grafana/alloy/blob/main/extension/alloyengine/README.md#include-alloyengine-extension-in-an-ocb-distribution) for the instructions how to do this.
+Refer to the `alloyengine` extension [README](https://github.com/grafana/alloy/blob/main/extension/alloyengine/README.md#include-alloyengine-extension-in-an-ocb-distribution) for the instructions how to do this.
 
 The following example uses `config.path` to load the {{< param "DEFAULT_ENGINE" >}} configuration from a file or directory:
 

--- a/docs/sources/set-up/otel_engine.md
+++ b/docs/sources/set-up/otel_engine.md
@@ -100,9 +100,7 @@ This extension accepts a path to the {{< param "DEFAULT_ENGINE" >}} configuratio
 It starts a {{< param "DEFAULT_ENGINE" >}} pipeline alongside the {{< param "OTEL_ENGINE" >}} pipeline.
 
 You can also embed the `alloyengine` extension into any other OpenTelemetry Collector distribution using the OpenTelemetry Collector Builder (OCB).
-When you embed `alloyengine` into another OpenTelemetry Collector, the {{< param "DEFAULT_ENGINE" >}} UI needs an extra build step to work.
-If you don't intend to use the UI, you can skip it.
-Refer to the extension's [README](https://github.com/grafana/alloy/blob/main/extension/alloyengine/README.md#web-ui) for the steps to enable the {{< param "DEFAULT_ENGINE" >}} UI in this setup.
+See the extension's [README](https://github.com/grafana/alloy/blob/main/extension/alloyengine/README.md#include-alloyengine-extension-in-an-ocb-distribution) for the instructions how to do this.
 
 The following example uses `config.path` to load the {{< param "DEFAULT_ENGINE" >}} configuration from a file or directory:
 

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -56,111 +56,6 @@ In this example, the extension:
 2. Passes the `--server.http.listen-addr=0.0.0.0:12345` and `--stability.level=experimental` flags to the `alloy run` command.
 3. Runs the Alloy configuration concurrently with the OpenTelemetry Collector pipeline.
 
-## Build with OCB
-
-To include the extension in an external OpenTelemetry Collector Builder (OCB) distribution, add it as an extension using the Alloy module plus the extension import path. The extension doesn't have its own Go module, so the one-line `gomod: github.com/grafana/alloy/extension/alloyengine ...` form doesn't work.
-
-```yaml
-dist:
-  name: custom-alloy-otel
-  output_path: ./dist
-  cgo_enabled: true
-
-extensions:
-  - gomod: github.com/grafana/alloy v<ALLOY_VERSION>
-    import: github.com/grafana/alloy/extension/alloyengine
-    name: alloyengine
-```
-
-Replace `v<ALLOY_VERSION>` with the Alloy version you want to embed.
-
-### OCB version
-
-OCB uses its own version in the generated distribution's `go.mod` for the OpenTelemetry Collector core dependencies. The build config currently has no field to change this. The deprecated `dist.otelcol_version` was removed from OCB in [opentelemetry-collector#11405](https://github.com/open-telemetry/opentelemetry-collector/issues/11405) and is now silently ignored.
-
-To avoid compatibility issues between components and extensions, use an OCB version that matches the OpenTelemetry Collector version Alloy depends on.
-
-First, read the version of the `go.opentelemetry.io/collector/otelcol` dependency from the root `go.mod` of the Alloy version you're embedding the extension from. For example, in a local checkout of Alloy:
-
-```shell
-grep 'go.opentelemetry.io/collector/otelcol ' go.mod
-# go.opentelemetry.io/collector/otelcol v0.158.0
-```
-
-And then use this same version as your `<OCB_VERSION>` to run a compatible version of OCB:
-
-```shell
-go run go.opentelemetry.io/collector/cmd/builder@<OCB_VERSION> --help
-```
-
-### Replace directives
-
-If you copy from Alloy repository's `collector/builder-config.yaml` file, don't copy the local module replaces unchanged. These paths are relative and only work from Alloy's `collector/` directory:
-
-```yaml
-replaces:
-  - github.com/grafana/alloy => ../
-  - github.com/grafana/alloy/syntax => ../syntax
-```
-
-For a build that uses a released Alloy version, remove both local module replaces.
-
-For a build that uses a local Alloy checkout, keep both replaces but point them at your checkout:
-
-```yaml
-replaces:
-  - github.com/grafana/alloy => /path/to/alloy
-  - github.com/grafana/alloy/syntax => /path/to/alloy/syntax
-```
-
-The `github.com/grafana/alloy/syntax` replace must point at the `syntax` submodule in the same checkout as the Alloy module.
-
-If you copy additional replace directives from Alloy's `collector/builder-config.yaml`, keep the shared remote replaces between the `<BEGIN_SHARED_REPLACE_DIRECTIVES>` and `<END_SHARED_REPLACE_DIRECTIVES>` markers. Those replaces track dependency forks and pins that Alloy needs during OCB builds.
-
-### CGO
-
-Set `dist.cgo_enabled: true` in the OCB builder config. OCB disables CGO by default, while Alloy builds assume CGO is enabled unless you intentionally opt out. On Linux, make sure the build environment has the required system development libraries, such as `libsystemd-dev`.
-
-### Web UI
-
-The embedded Default Engine serves a web UI, by default available on port `12345`. The UI assets aren't included in the Alloy Go module, so an OCB build needs an extra step to include them. You can only build these assets from a local Alloy checkout, not from a released Alloy version pinned in your builder config. Without this step, the UI returns `404 Not Found`. Other endpoints, such as the REST and GraphQL APIs, still work.
-
-To get a working UI, build the assets from an Alloy checkout and include them in your binary:
-
-1. Clone the Alloy repository and check out the version you want:
-
-   ```shell
-   git clone https://github.com/grafana/alloy.git
-   cd alloy
-   git checkout <ALLOY_VERSION_OR_TAG>
-   ```
-
-1. Build the UI assets. We use [mise](https://mise.jdx.dev), which installs the local toolchain, including the Node.js version that Alloy builds with. Versions are pinned in [`mise.toml`](../../mise.toml). Other versions may fail to build.
-
-   ```shell
-   mise install
-   make generate-ui
-   ```
-
-1. Point your OCB builder config's `replaces` at this checkout, as described in [Replace directives](#replace-directives):
-
-   ```yaml
-   replaces:
-     - github.com/grafana/alloy => /path/to/alloy
-     - github.com/grafana/alloy/syntax => /path/to/alloy/syntax
-   ```
-
-   You must also copy the shared replace directives from Alloy's `collector/builder-config.yaml`, between the `<BEGIN_SHARED_REPLACE_DIRECTIVES>` and `<END_SHARED_REPLACE_DIRECTIVES>` markers. The build fails without them, because Go ignores the replace directives of the modules it depends on.
-
-1. Add the `embedalloyui` build tag, which embeds the assets you built into the binary:
-
-   ```yaml
-   dist:
-     build_tags: embedalloyui
-   ```
-
-   If you already set other build tags, add `embedalloyui` to the comma-separated list: `build_tags: "<other_tags>,embedalloyui"`.
-
 ## Lifecycle
 
 The extension manages the lifecycle of the embedded default engine:
@@ -179,8 +74,190 @@ If `config.inline.module_path` isn't defined, `config.inline` resolves the `modu
 
 The `remotecfg` Alloy configuration block can't be used with the alloyengine extension. Use OpenTelemetry OpAMP for Collector configuration management instead.
 
-The UI assets aren't included in the Alloy Go module, so an OCB build needs an extra step to serve the web UI. See [Web UI](#web-ui) for details.
+The UI assets aren't included in the Alloy Go module, so an OCB build needs an extra step to serve the web UI. See [Build with the UI embedded](#build-with-the-ui-embedded) for details.
 
 ## Stability
 
 This extension is currently marked as **experimental** stability level. The API and behavior may change in future releases.
+
+## Include `alloyengine` extension in an OCB distribution
+
+You can include the `alloyengine` extension in a custom OpenTelemetry Collector distribution built with [OpenTelemetry Collector Builder (OCB)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) by following the steps below.
+
+### Choose the Alloy version
+
+The `alloyengine` extension is released and versioned together with the rest of Alloy. Choose the version you want to embed from the [releases page](https://github.com/grafana/alloy/releases). We recommend the latest version.
+
+The rest of these steps refer to this version as `<ALLOY_VERSION>`.
+
+### Use a compatible OCB version
+
+OCB uses a fixed version of the OpenTelemetry Collector core dependencies in the generated distribution's `go.mod`. The build config has no field to change this. The deprecated `dist.otelcol_version` was removed from OCB in [opentelemetry-collector#11405](https://github.com/open-telemetry/opentelemetry-collector/issues/11405) and is now silently ignored.
+
+To avoid compatibility issues between components and extensions, use an OCB version that matches the OpenTelemetry Collector version Alloy depends on. Read the version of the `go.opentelemetry.io/collector/otelcol` dependency from Alloy's root `go.mod` at `<ALLOY_VERSION>`:
+
+```shell
+curl -s https://raw.githubusercontent.com/grafana/alloy/<ALLOY_VERSION>/go.mod | grep 'go.opentelemetry.io/collector/otelcol '
+# go.opentelemetry.io/collector/otelcol v0.158.0
+```
+
+Use this version as `<OCB_VERSION>` to fetch OCB and verify that it runs:
+
+```shell
+go run go.opentelemetry.io/collector/cmd/builder@<OCB_VERSION> version
+# ocb version <OCB_VERSION>
+```
+
+### Add the extension to the OCB builder config
+
+Add the `alloyengine` extension to your OCB builder YAML config file. It's important to set the `import` field as the extension doesn't have its own Go module. For example:
+
+```yaml
+extensions:
+  - gomod: github.com/grafana/alloy <ALLOY_VERSION>
+    import: github.com/grafana/alloy/extension/alloyengine
+    name: alloyengine
+```
+
+Replace `<ALLOY_VERSION>` with the version you chose.
+
+### Include replace directives from Alloy
+
+The `alloyengine` extension needs a set of replace directives to work correctly. Go ignores the replace directives of the modules it depends on, so you must carry them in your own builder config. The build fails without them.
+
+Copy the whole `replaces` block from Alloy's `collector/builder-config.yaml` at `<ALLOY_VERSION>` into your own distribution's `builder-config.yaml`. This includes the replaces between the `<BEGIN_SHARED_REPLACE_DIRECTIVES>` and `<END_SHARED_REPLACE_DIRECTIVES>` markers.
+
+These replaces change between Alloy versions, so use the file at the version you chose:
+
+```shell
+curl -s https://raw.githubusercontent.com/grafana/alloy/<ALLOY_VERSION>/collector/builder-config.yaml
+```
+
+### Enable CGO
+
+Set `dist.cgo_enabled: true` in the OCB builder config. OCB disables CGO by default, while Alloy builds assume CGO is enabled unless you intentionally opt out. On Linux, make sure the build environment has the required system development libraries, such as `libsystemd-dev`.
+
+### Choose how to build
+
+The remaining steps depend on whether you want the Default Engine web UI, by default served on port `12345`.
+
+The UI assets aren't included in the Alloy Go module, so you can only build them from a local Alloy checkout. Without them the UI returns `404 Not Found`, while other endpoints, such as the HTTP API and GraphQL, still work.
+
+Follow one of these sections:
+
+- [Build without the UI](#build-without-the-ui) uses a released Alloy version and needs no checkout.
+- [Build with the UI embedded](#build-with-the-ui-embedded) needs a local Alloy checkout and Node.js.
+
+### Build without the UI
+
+1. Remove these two local module replaces from the `replaces` block you copied earlier:
+
+   ```yaml
+   replaces:
+     - github.com/grafana/alloy => ../
+     - github.com/grafana/alloy/syntax => ../syntax
+   ```
+
+   Their paths are relative and only work from Alloy's `collector/` directory. Your build then uses the released Alloy version you set in `gomod`.
+
+1. Run OCB with the version you chose earlier:
+
+   ```shell
+   go run go.opentelemetry.io/collector/cmd/builder@<OCB_VERSION> --config=builder-config.yaml
+   ```
+
+OCB writes the binary into the `dist.output_path` directory, named after `dist.name`.
+
+### Build with the UI embedded
+
+1. Clone the Alloy repository and check out `<ALLOY_VERSION>`:
+
+   ```shell
+   git clone https://github.com/grafana/alloy.git
+   cd alloy
+   git checkout <ALLOY_VERSION>
+   ```
+
+1. Build the UI assets. We use [mise](https://mise.jdx.dev), which installs the local toolchain, including the Node.js version that Alloy builds with. Versions are pinned in [`mise.toml`](../../mise.toml). Other versions may fail to build.
+
+   ```shell
+   mise install
+   make generate-ui
+   ```
+
+1. Point these two local module replaces at your local Alloy checkout:
+
+   ```yaml
+   replaces:
+     - github.com/grafana/alloy => ../              # <- Change this to your checkout path
+     - github.com/grafana/alloy/syntax => ../syntax # <- Change this to your checkout path + /syntax
+   ```
+
+   Change both to absolute paths to your checkout. For example, if you cloned Alloy into `/path/to/alloy`, use:
+
+   ```yaml
+   replaces:
+     - github.com/grafana/alloy => /path/to/alloy
+     - github.com/grafana/alloy/syntax => /path/to/alloy/syntax
+   ```
+
+1. Add the `embedalloyui` build tag, which embeds the assets you built into the binary:
+
+   ```yaml
+   dist:
+     build_tags: embedalloyui
+   ```
+
+   If you already set other build tags, add `embedalloyui` to the comma-separated list: `build_tags: "<other_tags>,embedalloyui"`.
+
+1. Run OCB with the version you chose earlier:
+
+   ```shell
+   go run go.opentelemetry.io/collector/cmd/builder@<OCB_VERSION> --config=builder-config.yaml
+   ```
+
+OCB writes the binary into the `dist.output_path` directory, named after `dist.name`.
+
+### Verify the extension works
+
+Start your distribution with a collector configuration that enables the `alloyengine` extension. The following configuration runs a `alloyengine` with minimal config and serves the Default Engine HTTP server on port `12345`:
+
+```yaml
+extensions:
+  alloyengine:
+    config:
+      inline:
+        content: |
+          logging {
+            level = "info"
+          }
+    flags:
+      server.http.listen-addr: 127.0.0.1:12345
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+
+exporters:
+  debug:
+
+service:
+  extensions: [alloyengine]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+```
+
+This example uses `otlp` receiver and a `debug` exporter, which may not be included in your distribution. Replace them with your own pipeline if needed.
+
+Check that it's running:
+
+```shell
+curl localhost:12345/-/ready
+# Alloy is ready.
+```
+
+If you built with the UI, open `http://localhost:12345` in a browser to check that it loads.

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -102,6 +102,46 @@ If you copy additional replace directives from Alloy's `collector/builder-config
 
 Set `dist.cgo_enabled: true` in the OCB builder config. OCB disables CGO by default, while Alloy builds assume CGO is enabled unless you intentionally opt out. On Linux, make sure the build environment has the required system development libraries, such as `libsystemd-dev`.
 
+### Web UI
+
+The embedded Default Engine serves a web UI, by default available on port `12345`. The UI assets aren't included in the Alloy Go module, so an OCB build needs an extra step to include them. Without this step, the UI returns `404 Not Found`. Other endpoints, such as the REST and GraphQL APIs, still work.
+
+To get a working UI, build the assets from an Alloy checkout and include them in your binary:
+
+1. Clone the Alloy repository and check out the version you want:
+
+   ```shell
+   git clone https://github.com/grafana/alloy.git
+   cd alloy
+   git checkout <ALLOY_VERSION_OR_TAG>
+   ```
+
+1. Build the UI assets. This step needs Node.js and npm:
+
+   ```shell
+   cd internal/web/ui
+   npm ci --no-audit --no-fund
+   npm run build
+   cd ../../..
+   ```
+
+1. Point your OCB builder config's `replaces` at this checkout, as described in [Replace directives](#replace-directives):
+
+   ```yaml
+   replaces:
+     - github.com/grafana/alloy => /path/to/alloy
+     - github.com/grafana/alloy/syntax => /path/to/alloy/syntax
+   ```
+
+1. Set the `embedalloyui` build tag, which embeds the assets you built into the binary:
+
+   ```yaml
+   dist:
+     build_tags: embedalloyui
+   ```
+
+These steps need a local Alloy checkout. They don't work for a build pinned to a released Alloy version through the module proxy, because the module cache doesn't contain the built assets and is read-only.
+
 ## Lifecycle
 
 The extension manages the lifecycle of the embedded default engine:
@@ -119,6 +159,8 @@ Please note that if extensions fail to start, the collector will also fail to st
 If `config.inline.module_path` isn't defined, `config.inline` resolves the `module_path` Alloy config keyword to the current working directory of the OpenTelemetry Collector process.
 
 The `remotecfg` Alloy configuration block can't be used with the alloyengine extension. Use OpenTelemetry OpAMP for Collector configuration management instead.
+
+The UI assets aren't included in the Alloy Go module, so an OCB build needs an extra step to serve the web UI. See [Web UI](#web-ui) for details.
 
 ## Stability
 

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -74,6 +74,25 @@ extensions:
 
 Replace `v<ALLOY_VERSION>` with the Alloy version you want to embed.
 
+### OCB version
+
+OCB uses its own version in the generated distribution's `go.mod` for the OpenTelemetry Collector core dependencies. The build config currently has no field to change this. The deprecated `dist.otelcol_version` was removed from OCB in [opentelemetry-collector#11405](https://github.com/open-telemetry/opentelemetry-collector/issues/11405) and is now silently ignored.
+
+To avoid compatibility issues between components and extensions, use an OCB version that matches the OpenTelemetry Collector version Alloy depends on.
+
+First, read the version of the `go.opentelemetry.io/collector/otelcol` dependency from the root `go.mod` of the Alloy version you're embedding the extension from. For example, in a local checkout of Alloy:
+
+```shell
+grep 'go.opentelemetry.io/collector/otelcol ' go.mod
+# go.opentelemetry.io/collector/otelcol v0.158.0
+```
+
+And then use this same version as your `<OCB_VERSION>` to run a compatible version of OCB:
+
+```shell
+go run go.opentelemetry.io/collector/cmd/builder@<OCB_VERSION> --help
+```
+
 ### Replace directives
 
 If you copy from Alloy repository's `collector/builder-config.yaml` file, don't copy the local module replaces unchanged. These paths are relative and only work from Alloy's `collector/` directory:

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -76,7 +76,7 @@ Replace `v<ALLOY_VERSION>` with the Alloy version you want to embed.
 
 ### Replace directives
 
-If you copy from Alloy's in-tree `collector/builder-config.yaml`, don't copy the local module replaces unchanged. These paths only work from Alloy's `collector/` directory:
+If you copy from Alloy repository's `collector/builder-config.yaml` file, don't copy the local module replaces unchanged. These paths are relative and only work from Alloy's `collector/` directory:
 
 ```yaml
 replaces:
@@ -104,7 +104,7 @@ Set `dist.cgo_enabled: true` in the OCB builder config. OCB disables CGO by defa
 
 ### Web UI
 
-The embedded Default Engine serves a web UI, by default available on port `12345`. The UI assets aren't included in the Alloy Go module, so an OCB build needs an extra step to include them. Without this step, the UI returns `404 Not Found`. Other endpoints, such as the REST and GraphQL APIs, still work.
+The embedded Default Engine serves a web UI, by default available on port `12345`. The UI assets aren't included in the Alloy Go module, so an OCB build needs an extra step to include them. You can only build these assets from a local Alloy checkout, not from a released Alloy version pinned in your builder config. Without this step, the UI returns `404 Not Found`. Other endpoints, such as the REST and GraphQL APIs, still work.
 
 To get a working UI, build the assets from an Alloy checkout and include them in your binary:
 
@@ -116,13 +116,11 @@ To get a working UI, build the assets from an Alloy checkout and include them in
    git checkout <ALLOY_VERSION_OR_TAG>
    ```
 
-1. Build the UI assets. This step needs Node.js and npm:
+1. Build the UI assets. We use [mise](https://mise.jdx.dev), which installs the local toolchain, including the Node.js version that Alloy builds with. Versions are pinned in [`mise.toml`](../../mise.toml). Other versions may fail to build.
 
    ```shell
-   cd internal/web/ui
-   npm ci --no-audit --no-fund
-   npm run build
-   cd ../../..
+   mise install
+   make generate-ui
    ```
 
 1. Point your OCB builder config's `replaces` at this checkout, as described in [Replace directives](#replace-directives):
@@ -133,14 +131,16 @@ To get a working UI, build the assets from an Alloy checkout and include them in
      - github.com/grafana/alloy/syntax => /path/to/alloy/syntax
    ```
 
-1. Set the `embedalloyui` build tag, which embeds the assets you built into the binary:
+   You must also copy the shared replace directives from Alloy's `collector/builder-config.yaml`, between the `<BEGIN_SHARED_REPLACE_DIRECTIVES>` and `<END_SHARED_REPLACE_DIRECTIVES>` markers. The build fails without them, because Go ignores the replace directives of the modules it depends on.
+
+1. Add the `embedalloyui` build tag, which embeds the assets you built into the binary:
 
    ```yaml
    dist:
      build_tags: embedalloyui
    ```
 
-These steps need a local Alloy checkout. They don't work for a build pinned to a released Alloy version through the module proxy, because the module cache doesn't contain the built assets and is read-only.
+   If you already set other build tags, add `embedalloyui` to the comma-separated list: `build_tags: "<other_tags>,embedalloyui"`.
 
 ## Lifecycle
 

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -1,6 +1,6 @@
 # Alloy Engine Extension
 
-The `alloy engine` extension embeds the **Default Engine** (the underlying Alloy runtime used by `alloy run`) within the **OTel Engine** (the OpenTelemetry Collector runtime exposed via the `otel` subcommand).
+The `alloyengine` extension embeds the **Default Engine** (the underlying Alloy runtime used by `alloy run`) within the **OTel Engine** (the OpenTelemetry Collector runtime exposed via the `otel` subcommand).
 
 This extension allows you to run a Default Engine pipeline set up with Alloy configuration alongside the OTel Engine set up with YAML configuration. These two pipelines run in parallel, and can't natively interact with one another.
 
@@ -17,7 +17,7 @@ The extension accepts the following configuration fields:
 
 ### Config Object
 
-The `config` object specifies the Alloy configuration source. Exactly one of `path` (or the deprecated `file`) or `inline.content` must be set.
+The `config` object specifies the Alloy configuration source. Exactly one of `path` or `inline.content` must be set.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -61,7 +61,7 @@ In this example, the extension:
 The extension manages the lifecycle of the embedded default engine:
 
 - **Start**: When the extension starts, it launches the default engine in a separate goroutine and runs the Alloy configuration.
-- **Ready**: The extension reports ready once the default engine has successfully started.
+- **Ready**: The extension reports ready to the OpenTelemetry Collector as soon as it starts. It doesn't wait for the Alloy configuration to load, and it stays ready while it retries a failed load. This stops a broken Alloy configuration from blocking the Collector. For more visibility into the state of the default engine, use the `/-/ready` or `/-/healthy` endpoints of its HTTP server. You set the address of this server with the `server.http.listen-addr` flag.
 - **Shutdown**: When the extension shuts down, it gracefully terminates the default engine and waits for it to exit.
 
 ## Limitations

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -66,15 +66,15 @@ The extension manages the lifecycle of the embedded default engine:
 
 ## Limitations
 
-Only one alloyengine instance can be active per process. The embedded Default Engine uses process-global state (Prometheus registry, controller ID, storage path and so forth), so running multiple instances will cause conflicts. If you configure multiple alloyengine extensions, only the first to start will succeed; subsequent instances will fail at startup with a clear error.
+Only one `alloyengine` instance can be active per process. The embedded Default Engine uses process-global state (Prometheus registry, controller ID, storage path and so forth), so running multiple instances will cause conflicts. If you configure multiple `alloyengine` extensions, only the first to start will succeed; subsequent instances will fail at startup with a clear error.
 
-Please note that if extensions fail to start, the collector will also fail to start. This means that the errors described above will ultimately mean you cannot start the collector without ensuring that you specify which of the alloyengine extensions you wish to run.
+Please note that if extensions fail to start, the collector will also fail to start. This means that the errors described above will ultimately mean you cannot start the collector without ensuring that you specify which of the `alloyengine` extensions you wish to run.
 
 If `config.inline.module_path` isn't defined, `config.inline` resolves the `module_path` Alloy config keyword to the current working directory of the OpenTelemetry Collector process.
 
 The `remotecfg` Alloy configuration block can't be used with the alloyengine extension. Use OpenTelemetry OpAMP for Collector configuration management instead.
 
-The UI assets aren't included in the Alloy Go module, so an OCB build needs an extra step to serve the web UI. See [Build with the UI embedded](#build-with-the-ui-embedded) for details.
+The compiled UI assets aren't included in the Alloy Go module, so an OCB build needs an extra step to serve the web UI. See [Build with the UI embedded](#build-with-the-ui-embedded) for details.
 
 ## Stability
 
@@ -141,12 +141,12 @@ Set `dist.cgo_enabled: true` in the OCB builder config. OCB disables CGO by defa
 
 The remaining steps depend on whether you want the Default Engine web UI, by default served on port `12345`.
 
-The UI assets aren't included in the Alloy Go module, so you can only build them from a local Alloy checkout. Without them the UI returns `404 Not Found`, while other endpoints, such as the HTTP API and GraphQL, still work.
+The compiled UI assets aren't included in the Alloy Go module, so you can only build them from a local copy of the Alloy source. Without them the UI returns `404 Not Found`, while other endpoints, such as the HTTP API and GraphQL, still work.
 
 Follow one of these sections:
 
-- [Build without the UI](#build-without-the-ui) uses a released Alloy version and needs no checkout.
-- [Build with the UI embedded](#build-with-the-ui-embedded) needs a local Alloy checkout and Node.js.
+- [Build without the UI](#build-without-the-ui) uses a released Alloy version and does not need a local copy of the Alloy source.
+- [Build with the UI embedded](#build-with-the-ui-embedded) needs a local copy of the Alloy source and Node.js.
 
 ### Build without the UI
 
@@ -185,7 +185,7 @@ OCB writes the binary into the `dist.output_path` directory, named after `dist.n
    make generate-ui
    ```
 
-1. Point these two local module replaces at your local Alloy checkout:
+1. Point these two local module replaces at your local copy of the Alloy source:
 
    ```yaml
    replaces:
@@ -193,7 +193,7 @@ OCB writes the binary into the `dist.output_path` directory, named after `dist.n
      - github.com/grafana/alloy/syntax => ../syntax # <- Change this to your checkout path + /syntax
    ```
 
-   Change both to absolute paths to your checkout. For example, if you cloned Alloy into `/path/to/alloy`, use:
+   Change both to absolute paths to your local copy of the Alloy source. For example, if you cloned Alloy into `/path/to/alloy`, use:
 
    ```yaml
    replaces:
@@ -251,13 +251,13 @@ service:
       exporters: [debug]
 ```
 
-This example uses `otlp` receiver and a `debug` exporter, which may not be included in your distribution. Replace them with your own pipeline if needed.
+This example uses an `otlp` receiver and a `debug` exporter, which may not be included in your distribution. Replace them with your own pipeline if needed.
 
 Check that it's running:
 
 ```shell
-curl localhost:12345/-/ready
+curl 127.0.0.1:12345/-/ready
 # Alloy is ready.
 ```
 
-If you built with the UI, open `http://localhost:12345` in a browser to check that it loads.
+If you built with the UI, open `http://127.0.0.1:12345` in a browser to check that it loads.

--- a/extension/alloyengine/README.md
+++ b/extension/alloyengine/README.md
@@ -185,15 +185,7 @@ OCB writes the binary into the `dist.output_path` directory, named after `dist.n
    make generate-ui
    ```
 
-1. Point these two local module replaces at your local copy of the Alloy source:
-
-   ```yaml
-   replaces:
-     - github.com/grafana/alloy => ../              # <- Change this to your checkout path
-     - github.com/grafana/alloy/syntax => ../syntax # <- Change this to your checkout path + /syntax
-   ```
-
-   Change both to absolute paths to your local copy of the Alloy source. For example, if you cloned Alloy into `/path/to/alloy`, use:
+1. Point the local module replaces at your local copy of the Alloy source. Find the `replaces` block you copied earlier in your builder config. Change the `github.com/grafana/alloy` and `github.com/grafana/alloy/syntax` paths to point to your local copy. For example, if you cloned Alloy into `/path/to/alloy`, use:
 
    ```yaml
    replaces:


### PR DESCRIPTION
### Brief description of Pull Request

Documents how to get UI working when embedding `alloyengine` extension to a 3rd party OTel Collector via OCB. 

Adds the steps to `extension/alloyengine/README.md` and a pointer to them from the OpenTelemetry Engine set-up page.


### Issue(s) fixed by this Pull Request

Fixes #5823



### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
