### PR TITLE
fix(database_observability.mysql): Resolve query-parsed table names against known-table casing

### DIFF
--- a/internal/component/database_observability/mysql/collector/query_details.go
+++ b/internal/component/database_observability/mysql/collector/query_details.go
@@ -158,15 +158,16 @@ func (c *QueryDetails) tablesFromEventsStatements(ctx context.Context) error {
 		)
 
 		for _, table := range tables {
+			validated := false
 			resolvedTable := table
 			if c.tableRegistry != nil {
-				resolvedTable, _ = c.tableRegistry.IsValid(schema, table)
+				resolvedTable, validated = c.tableRegistry.IsValid(schema, table)
 			}
 
 			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
 				OP_QUERY_PARSED_TABLE_NAME,
-				fmt.Sprintf(`schema="%s" digest="%s" table="%s"`, schema, digest, resolvedTable),
+				fmt.Sprintf(`schema="%s" digest="%s" table="%s" validated="%t"`, schema, digest, resolvedTable, validated),
 			)
 		}
 	}

--- a/internal/component/database_observability/mysql/collector/query_details.go
+++ b/internal/component/database_observability/mysql/collector/query_details.go
@@ -41,6 +41,7 @@ type QueryDetailsArguments struct {
 	StatementsLimit int
 	ExcludeSchemas  []string
 	EntryHandler    loki.EntryHandler
+	TableRegistry   *TableRegistry
 
 	Logger *slog.Logger
 }
@@ -53,6 +54,7 @@ type QueryDetails struct {
 	entryHandler    loki.EntryHandler
 	sqlParser       parser.Parser
 	normalizer      *sqllexer.Normalizer
+	tableRegistry   *TableRegistry
 
 	logger  *slog.Logger
 	running *atomic.Bool
@@ -70,6 +72,7 @@ func NewQueryDetails(args QueryDetailsArguments) (*QueryDetails, error) {
 		entryHandler:    args.EntryHandler,
 		sqlParser:       parser.NewTiDBSqlParser(),
 		normalizer:      sqllexer.NewNormalizer(sqllexer.WithCollectTables(true)),
+		tableRegistry:   args.TableRegistry,
 		logger:          args.Logger.With("collector", QueryDetailsCollector),
 		running:         &atomic.Bool{},
 	}
@@ -155,10 +158,15 @@ func (c *QueryDetails) tablesFromEventsStatements(ctx context.Context) error {
 		)
 
 		for _, table := range tables {
+			resolvedTable := table
+			if c.tableRegistry != nil {
+				resolvedTable, _ = c.tableRegistry.IsValid(schema, table)
+			}
+
 			c.entryHandler.Chan() <- database_observability.BuildLokiEntry(
 				logging.LevelInfo,
 				OP_QUERY_PARSED_TABLE_NAME,
-				fmt.Sprintf(`schema="%s" digest="%s" table="%s"`, schema, digest, table),
+				fmt.Sprintf(`schema="%s" digest="%s" table="%s"`, schema, digest, resolvedTable),
 			)
 		}
 	}

--- a/internal/component/database_observability/mysql/collector/query_details_test.go
+++ b/internal/component/database_observability/mysql/collector/query_details_test.go
@@ -655,3 +655,70 @@ func TestQueryDetailsExcludeSchemas(t *testing.T) {
 	c.tablesFromEventsStatements(t.Context())
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestQueryDetails_ResolvesTableNameCasingViaTableRegistry(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+
+	tableRegistry := NewTableRegistry()
+	tableRegistry.SetTables([]*tableInfo{
+		// e.g. information_schema.tables reports this lowercased because the cluster is
+		// configured with lower_case_table_names=1, but the query below references it with
+		// its literal, mixed-case spelling.
+		{schema: "some_schema", tableName: "emailageconsumer"},
+	})
+
+	collector, err := NewQueryDetails(QueryDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Second,
+		StatementsLimit: 250,
+		EntryHandler:    lokiClient,
+		TableRegistry:   tableRegistry,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+
+	mock.ExpectQuery(fmt.Sprintf(selectQueryTablesSamples, exclusionClause, 250)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"digest",
+				"digest_text",
+				"schema_name",
+				"query_sample_text",
+			}).AddRow(
+				"abc123",
+				"SELECT * FROM `EmailAgeConsumer` WHERE `id` = ?",
+				"some_schema",
+				"select * from EmailAgeConsumer where id = 1",
+			),
+		)
+
+	err = collector.Start(t.Context())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 2
+	}, 5*time.Second, 100*time.Millisecond)
+
+	collector.Stop()
+	lokiClient.Stop()
+
+	require.Eventually(t, func() bool {
+		return collector.Stopped()
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	lokiEntries := lokiClient.Received()
+	require.Len(t, lokiEntries, 2)
+	require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
+	// Resolved to the registry's canonical (lowercased) casing rather than the query's
+	// literal mixed-case spelling.
+	require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="emailageconsumer"`, lokiEntries[1].Line)
+}

--- a/internal/component/database_observability/mysql/collector/query_details_test.go
+++ b/internal/component/database_observability/mysql/collector/query_details_test.go
@@ -787,3 +787,70 @@ func TestQueryDetails_MarksAnUnresolvedParsedNameAsNotValidated(t *testing.T) {
 	require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
 	require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="not_a_real_table" validated="false"`, lokiEntries[1].Line)
 }
+
+func TestQueryDetails_ResolvesASchemaQualifiedCrossDatabaseReference(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+
+	// The query below runs against "some_schema" but references a table in a different
+	// database ("other_schema"), casing-mismatched the same way an unqualified reference
+	// can be.
+	tableRegistry := NewTableRegistry()
+	tableRegistry.SetTables([]*tableInfo{
+		{schema: "other_schema", tableName: "emailageconsumer"},
+	})
+
+	collector, err := NewQueryDetails(QueryDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Second,
+		StatementsLimit: 250,
+		EntryHandler:    lokiClient,
+		TableRegistry:   tableRegistry,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+
+	mock.ExpectQuery(fmt.Sprintf(selectQueryTablesSamples, exclusionClause, 250)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"digest",
+				"digest_text",
+				"schema_name",
+				"query_sample_text",
+			}).AddRow(
+				"abc123",
+				"SELECT * FROM `other_schema`.`EmailAgeConsumer` WHERE `id` = ?",
+				"some_schema",
+				"select * from other_schema.EmailAgeConsumer where id = 1",
+			),
+		)
+
+	err = collector.Start(t.Context())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 2
+	}, 5*time.Second, 100*time.Millisecond)
+
+	collector.Stop()
+	lokiClient.Stop()
+
+	require.Eventually(t, func() bool {
+		return collector.Stopped()
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	lokiEntries := lokiClient.Received()
+	require.Len(t, lokiEntries, 2)
+	require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
+	// The "schema" field stays the connection's active schema ("some_schema"); the resolved
+	// table carries its own schema qualifier ("other_schema"), lowercased to match the registry.
+	require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="other_schema.emailageconsumer" validated="true"`, lokiEntries[1].Line)
+}

--- a/internal/component/database_observability/mysql/collector/query_details_test.go
+++ b/internal/component/database_observability/mysql/collector/query_details_test.go
@@ -38,7 +38,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -55,7 +55,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"INSERT INTO `some_table` (`id`, `name`) VALUES (...)\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -72,7 +72,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"UPDATE `some_table` SET `active` = false, `reason` = ? WHERE `id` = ? AND `name` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -89,7 +89,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"DELETE FROM `some_table` WHERE `id` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -107,8 +107,8 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT `t`.`id`, `t`.`val1`, `o`.`val2` FROM `some_table` `t` INNER JOIN `other_table` AS `o` ON `t`.`id` = `o`.`id` WHERE `o`.`val2` = ? ORDER BY `t`.`val1` DESC\"",
-				`level="info" schema="some_schema" digest="abc123" table="other_table"`,
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="other_table" validated="false"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -132,9 +132,9 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"false\" digest=\"xyz456\" digest_text=\"INSERT INTO `some_table`...\"",
-				`level="info" schema="some_schema" digest="xyz456" table="some_table"`,
+				`level="info" schema="some_schema" digest="xyz456" table="some_table" validated="false"`,
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `another_table` WHERE `id` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="another_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="another_table" validated="false"`,
 			},
 		},
 		{
@@ -151,7 +151,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -168,7 +168,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"false\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ? AND `name` =\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -205,7 +205,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -229,9 +229,9 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 				"level=\"info\" schema=\"other_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
-				`level="info" schema="other_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="other_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -250,9 +250,9 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM (SELECT `id`, `name` FROM `employees_us_east` UNION SELECT `id`, `name` FROM `employees_us_west`) AS `employees_us` UNION SELECT `id`, `name` FROM `employees_emea`\"",
-				`level="info" schema="some_schema" digest="abc123" table="employees_emea"`,
-				`level="info" schema="some_schema" digest="abc123" table="employees_us_east"`,
-				`level="info" schema="some_schema" digest="abc123" table="employees_us_west"`,
+				`level="info" schema="some_schema" digest="abc123" table="employees_emea" validated="false"`,
+				`level="info" schema="some_schema" digest="abc123" table="employees_us_east" validated="false"`,
+				`level="info" schema="some_schema" digest="abc123" table="employees_us_west" validated="false"`,
 			},
 		},
 		{
@@ -269,7 +269,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SHOW CREATE TABLE `some_table`\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -301,7 +301,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -318,7 +318,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -335,7 +335,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"false\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -352,7 +352,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"false\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 		{
@@ -369,7 +369,7 @@ func TestQueryTables(t *testing.T) {
 			},
 			logsLines: []string{
 				"level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"",
-				`level="info" schema="some_schema" digest="abc123" table="some_table"`,
+				`level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`,
 			},
 		},
 	}
@@ -499,7 +499,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, lokiEntries[0].Labels)
 		require.Equal(t, "level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"", lokiEntries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
-		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[1].Line)
+		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`, lokiEntries[1].Line)
 	})
 
 	t.Run("result set iteration error", func(t *testing.T) {
@@ -562,7 +562,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, lokiEntries[0].Labels)
 		require.Equal(t, "level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"", lokiEntries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
-		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[1].Line)
+		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`, lokiEntries[1].Line)
 	})
 
 	t.Run("connection error recovery", func(t *testing.T) {
@@ -622,7 +622,7 @@ func TestQueryTablesSQLDriverErrors(t *testing.T) {
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_ASSOCIATION}, lokiEntries[0].Labels)
 		require.Equal(t, "level=\"info\" schema=\"some_schema\" parseable=\"true\" digest=\"abc123\" digest_text=\"SELECT * FROM `some_table` WHERE `id` = ?\"", lokiEntries[0].Line)
 		require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
-		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table"`, lokiEntries[1].Line)
+		require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="some_table" validated="false"`, lokiEntries[1].Line)
 	})
 }
 
@@ -720,5 +720,70 @@ func TestQueryDetails_ResolvesTableNameCasingViaTableRegistry(t *testing.T) {
 	require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
 	// Resolved to the registry's canonical (lowercased) casing rather than the query's
 	// literal mixed-case spelling.
-	require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="emailageconsumer"`, lokiEntries[1].Line)
+	require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="emailageconsumer" validated="true"`, lokiEntries[1].Line)
+}
+
+func TestQueryDetails_MarksAnUnresolvedParsedNameAsNotValidated(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+
+	// The registry only knows about a real table; it never contains whatever the query below
+	// parses out as a "table" name, standing in for the SQL parser/tokenizer occasionally
+	// misidentifying something else (a column, an alias, a function) as a table reference.
+	tableRegistry := NewTableRegistry()
+	tableRegistry.SetTables([]*tableInfo{
+		{schema: "some_schema", tableName: "some_table"},
+	})
+
+	collector, err := NewQueryDetails(QueryDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Second,
+		StatementsLimit: 250,
+		EntryHandler:    lokiClient,
+		TableRegistry:   tableRegistry,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+
+	mock.ExpectQuery(fmt.Sprintf(selectQueryTablesSamples, exclusionClause, 250)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"digest",
+				"digest_text",
+				"schema_name",
+				"query_sample_text",
+			}).AddRow(
+				"abc123",
+				"SELECT * FROM `not_a_real_table` WHERE `id` = ?",
+				"some_schema",
+				"select * from not_a_real_table where id = 1",
+			),
+		)
+
+	err = collector.Start(t.Context())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(lokiClient.Received()) == 2
+	}, 5*time.Second, 100*time.Millisecond)
+
+	collector.Stop()
+	lokiClient.Stop()
+
+	require.Eventually(t, func() bool {
+		return collector.Stopped()
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	lokiEntries := lokiClient.Received()
+	require.Len(t, lokiEntries, 2)
+	require.Equal(t, model.LabelSet{"op": OP_QUERY_PARSED_TABLE_NAME}, lokiEntries[1].Labels)
+	require.Equal(t, `level="info" schema="some_schema" digest="abc123" table="not_a_real_table" validated="false"`, lokiEntries[1].Line)
 }

--- a/internal/component/database_observability/mysql/collector/schema_details.go
+++ b/internal/component/database_observability/mysql/collector/schema_details.go
@@ -242,11 +242,20 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	now := c.now()
 	tables := []*tableInfo{}
 	seenTables := map[string]struct{}{}
+	// scanComplete tracks whether we scanned every row without bailing out early. If false,
+	// tables is a partial view of information_schema.tables, so we must skip replacing the
+	// table registry and pruning throttle entries below: doing either from a partial list
+	// would incorrectly mark existing-but-unscanned tables as unknown/unvalidated, or evict
+	// their throttle entries as if they no longer existed. The per-table create_statement
+	// processing further down still runs over whatever partial list we did get — those rows
+	// scanned fine and are real tables, just possibly not an exhaustive set this tick.
+	scanComplete := true
 	for rs.Next() {
 		var schema, tableName, tableType string
 		var createTime, updateTime time.Time
 		if err := rs.Scan(&schema, &tableName, &tableType, &createTime, &updateTime); err != nil {
 			c.logger.Error("failed to scan tables", "err", err)
+			scanComplete = false
 			break
 		}
 		tables = append(tables, &tableInfo{
@@ -271,14 +280,16 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 		return fmt.Errorf("failed to iterate over tables result set: %w", err)
 	}
 
-	c.tableRegistry.SetTables(tables)
+	if scanComplete {
+		c.tableRegistry.SetTables(tables)
 
-	// Cleanup: drop throttle entries for tables that no longer exist (e.g.
-	// tables dropped or renamed). Done before the empty-tables early return so
-	// the map is also pruned when every monitored table disappears.
-	for k := range c.lastEmittedAt {
-		if _, ok := seenTables[k]; !ok {
-			delete(c.lastEmittedAt, k)
+		// Cleanup: drop throttle entries for tables that no longer exist (e.g.
+		// tables dropped or renamed). Done before the empty-tables early return so
+		// the map is also pruned when every monitored table disappears.
+		for k := range c.lastEmittedAt {
+			if _, ok := seenTables[k]; !ok {
+				delete(c.lastEmittedAt, k)
+			}
 		}
 	}
 
@@ -571,12 +582,19 @@ type TableRegistry struct {
 	// reference an existing table with a casing that doesn't exact-match what
 	// information_schema reports.
 	byLower map[string]map[string]string
+	// schemaByLower holds lowercased schema name -> canonical schema name. Resolves a
+	// schema-qualified reference's schema part the same way byLower resolves a table name,
+	// since a query's literal schema-qualifier is as susceptible to the same identifier
+	// folding as a table name is (it isn't server-reported the way the *connection's active*
+	// schema is).
+	schemaByLower map[string]string
 }
 
 func NewTableRegistry() *TableRegistry {
 	return &TableRegistry{
-		exact:   make(map[string]map[string]struct{}),
-		byLower: make(map[string]map[string]string),
+		exact:         make(map[string]map[string]struct{}),
+		byLower:       make(map[string]map[string]string),
+		schemaByLower: make(map[string]string),
 	}
 }
 
@@ -587,6 +605,7 @@ func (tr *TableRegistry) SetTables(tables []*tableInfo) {
 
 	tr.exact = make(map[string]map[string]struct{}, len(tables))
 	tr.byLower = make(map[string]map[string]string, len(tables))
+	tr.schemaByLower = make(map[string]string, len(tables))
 	for _, t := range tables {
 		if tr.exact[t.schema] == nil {
 			tr.exact[t.schema] = make(map[string]struct{})
@@ -594,30 +613,88 @@ func (tr *TableRegistry) SetTables(tables []*tableInfo) {
 		}
 		tr.exact[t.schema][t.tableName] = struct{}{}
 		tr.byLower[t.schema][strings.ToLower(t.tableName)] = t.tableName
+		tr.schemaByLower[strings.ToLower(t.schema)] = t.schema
 	}
 }
 
-// IsValid returns whether a given schema and parsed table name exist in the source-of-truth
-// table registry. It also returns the resolved table name, which may differ from the input
-// (e.g. lowercased or otherwise-cased, per MySQL's identifier folding for the schema). Exact
-// matches take priority over the case-insensitive fallback so that a MySQL cluster with the
-// default lower_case_table_names=0 (where table names are genuinely case-sensitive and two
-// tables can differ only by case) isn't resolved to the wrong table.
+// IsValid resolves a query-parsed table name — optionally schema-qualified as
+// "schema.table" — against the source-of-truth table registry. It returns the resolved
+// name and whether a match was found.
+//
+// For an unqualified name, the given `schema` (typically the connection's active schema,
+// which is server-reported and not subject to the query-text folding problem described
+// below) scopes the lookup. For a schema-qualified name (a cross-database reference), the
+// qualifier is resolved against known schema names instead — it isn't scoped by the
+// connection's active schema, and unlike that active schema, it comes from parsing the
+// query's literal text, so it needs the same resolution as the table name.
+//
+// Both the schema and table parts match exactly first, then fall back to a
+// case-insensitive match: unlike PostgreSQL, MySQL's identifier folding isn't a fixed
+// rule. A cluster configured with lower_case_table_names=1 or 2 folds/compares names
+// case-insensitively regardless of the case used at creation time, so a query can
+// reference an existing schema/table with a casing that doesn't exact-match what
+// information_schema reports. Exact matches take priority over the case-insensitive
+// fallback so that a MySQL cluster with the default lower_case_table_names=0 (where names
+// are genuinely case-sensitive and two objects can differ only by case) isn't resolved to
+// the wrong one.
 func (tr *TableRegistry) IsValid(schema, parsedTableName string) (string, bool) {
 	tr.mu.RLock()
 	defer tr.mu.RUnlock()
 
-	if tables, ok := tr.exact[schema]; ok {
-		if _, ok := tables[parsedTableName]; ok {
-			return parsedTableName, true
-		}
+	lookupSchema, lookupTable, qualified := schema, parsedTableName, false
+	if s, t, ok := splitSchemaQualified(parsedTableName); ok {
+		qualified = true
+		lookupTable = t
+		lookupSchema = tr.resolveSchemaLocked(s)
 	}
 
+	resolvedTable, ok := tr.resolveTableLocked(lookupSchema, lookupTable)
+	if !ok {
+		return parsedTableName, false
+	}
+
+	if qualified {
+		return lookupSchema + "." + resolvedTable, true
+	}
+	return resolvedTable, true
+}
+
+// resolveSchemaLocked resolves a schema name against known schema names, exact match
+// first, falling back to a case-insensitive match. Returns the input unchanged if neither
+// matches, so a subsequent table lookup against it predictably misses too. Callers must
+// hold tr.mu.
+func (tr *TableRegistry) resolveSchemaLocked(schema string) string {
+	if _, ok := tr.exact[schema]; ok {
+		return schema
+	}
+	if canonical, ok := tr.schemaByLower[strings.ToLower(schema)]; ok {
+		return canonical
+	}
+	return schema
+}
+
+// resolveTableLocked resolves a table name within a schema, exact match first, falling
+// back to a case-insensitive match. Callers must hold tr.mu.
+func (tr *TableRegistry) resolveTableLocked(schema, table string) (string, bool) {
+	if tables, ok := tr.exact[schema]; ok {
+		if _, ok := tables[table]; ok {
+			return table, true
+		}
+	}
 	if byLower, ok := tr.byLower[schema]; ok {
-		if canonical, ok := byLower[strings.ToLower(parsedTableName)]; ok {
+		if canonical, ok := byLower[strings.ToLower(table)]; ok {
 			return canonical, true
 		}
 	}
+	return table, false
+}
 
-	return parsedTableName, false
+// splitSchemaQualified splits a parsed table name of the form "schema.table" into its two
+// parts. Returns ok=false if the name isn't schema-qualified.
+func splitSchemaQualified(parsedTableName string) (schema, table string, ok bool) {
+	idx := strings.LastIndex(parsedTableName, ".")
+	if idx < 0 {
+		return "", "", false
+	}
+	return parsedTableName[:idx], parsedTableName[idx+1:], true
 }

--- a/internal/component/database_observability/mysql/collector/schema_details.go
+++ b/internal/component/database_observability/mysql/collector/schema_details.go
@@ -113,6 +113,8 @@ type SchemaDetails struct {
 	// now allows overriding time.Now() in tests
 	now func() time.Time
 
+	tableRegistry *TableRegistry
+
 	logger  *slog.Logger
 	running *atomic.Bool
 	ctx     context.Context
@@ -168,6 +170,7 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 		entryHandler:    args.EntryHandler,
 		lastEmittedAt:   map[string]time.Time{},
 		now:             time.Now,
+		tableRegistry:   NewTableRegistry(),
 		logger:          args.Logger.With("collector", SchemaDetailsCollector),
 		running:         &atomic.Bool{},
 	}
@@ -177,6 +180,13 @@ func NewSchemaDetails(args SchemaDetailsArguments) (*SchemaDetails, error) {
 
 func (c *SchemaDetails) Name() string {
 	return SchemaDetailsCollector
+}
+
+// GetTableRegistry returns the source-of-truth table registry populated by this
+// collector from information_schema.tables. QueryDetails uses it to resolve a
+// query-parsed table name to its canonical casing.
+func (c *SchemaDetails) GetTableRegistry() *TableRegistry {
+	return c.tableRegistry
 }
 
 func (c *SchemaDetails) Start(ctx context.Context) error {
@@ -260,6 +270,8 @@ func (c *SchemaDetails) extractSchema(ctx context.Context) error {
 	if err := rs.Err(); err != nil {
 		return fmt.Errorf("failed to iterate over tables result set: %w", err)
 	}
+
+	c.tableRegistry.SetTables(tables)
 
 	// Cleanup: drop throttle entries for tables that no longer exist (e.g.
 	// tables dropped or renamed). Done before the empty-tables early return so
@@ -544,4 +556,68 @@ func (c *SchemaDetails) fetchSchemaSpecs(ctx context.Context, schema string, tab
 
 func fullyQualifiedName(schema, table string) string {
 	return fmt.Sprintf("`%s`.`%s`", schema, table)
+}
+
+// TableRegistry is a source-of-truth cache of schemas and their tables, as reported by
+// information_schema.tables.
+type TableRegistry struct {
+	mu sync.RWMutex
+	// exact holds schema -> canonical table name -> presence.
+	exact map[string]map[string]struct{}
+	// byLower holds schema -> lowercased table name -> canonical table name. Used as a
+	// case-insensitive fallback: unlike PostgreSQL, MySQL's identifier folding isn't a fixed
+	// rule. A cluster configured with lower_case_table_names=1 or 2 folds/compares names
+	// case-insensitively regardless of the case used at CREATE TABLE time, so a query can
+	// reference an existing table with a casing that doesn't exact-match what
+	// information_schema reports.
+	byLower map[string]map[string]string
+}
+
+func NewTableRegistry() *TableRegistry {
+	return &TableRegistry{
+		exact:   make(map[string]map[string]struct{}),
+		byLower: make(map[string]map[string]string),
+	}
+}
+
+// SetTables replaces the registry contents with the given tables, grouped by schema.
+func (tr *TableRegistry) SetTables(tables []*tableInfo) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	tr.exact = make(map[string]map[string]struct{}, len(tables))
+	tr.byLower = make(map[string]map[string]string, len(tables))
+	for _, t := range tables {
+		if tr.exact[t.schema] == nil {
+			tr.exact[t.schema] = make(map[string]struct{})
+			tr.byLower[t.schema] = make(map[string]string)
+		}
+		tr.exact[t.schema][t.tableName] = struct{}{}
+		tr.byLower[t.schema][strings.ToLower(t.tableName)] = t.tableName
+	}
+}
+
+// IsValid returns whether a given schema and parsed table name exist in the source-of-truth
+// table registry. It also returns the resolved table name, which may differ from the input
+// (e.g. lowercased or otherwise-cased, per MySQL's identifier folding for the schema). Exact
+// matches take priority over the case-insensitive fallback so that a MySQL cluster with the
+// default lower_case_table_names=0 (where table names are genuinely case-sensitive and two
+// tables can differ only by case) isn't resolved to the wrong table.
+func (tr *TableRegistry) IsValid(schema, parsedTableName string) (string, bool) {
+	tr.mu.RLock()
+	defer tr.mu.RUnlock()
+
+	if tables, ok := tr.exact[schema]; ok {
+		if _, ok := tables[parsedTableName]; ok {
+			return parsedTableName, true
+		}
+	}
+
+	if byLower, ok := tr.byLower[schema]; ok {
+		if canonical, ok := byLower[strings.ToLower(parsedTableName)]; ok {
+			return canonical, true
+		}
+	}
+
+	return parsedTableName, false
 }

--- a/internal/component/database_observability/mysql/collector/schema_details.go
+++ b/internal/component/database_observability/mysql/collector/schema_details.go
@@ -580,21 +580,33 @@ type TableRegistry struct {
 	// rule. A cluster configured with lower_case_table_names=1 or 2 folds/compares names
 	// case-insensitively regardless of the case used at CREATE TABLE time, so a query can
 	// reference an existing table with a casing that doesn't exact-match what
-	// information_schema reports.
+	// information_schema reports. Absent an entry here for any lowercased name present in
+	// ambiguousLower.
 	byLower map[string]map[string]string
+	// ambiguousLower holds schema -> lowercased table name -> presence, for a lowercased name
+	// shared by two or more distinct exact-case tables (possible under the MySQL default
+	// lower_case_table_names=0, where two such tables can genuinely coexist). The
+	// case-insensitive fallback exists to bridge identifier folding, not to guess between two
+	// real, different tables, so resolveTableLocked treats an ambiguous name as no match
+	// rather than arbitrarily picking one.
+	ambiguousLower map[string]map[string]struct{}
 	// schemaByLower holds lowercased schema name -> canonical schema name. Resolves a
 	// schema-qualified reference's schema part the same way byLower resolves a table name,
 	// since a query's literal schema-qualifier is as susceptible to the same identifier
 	// folding as a table name is (it isn't server-reported the way the *connection's active*
 	// schema is).
 	schemaByLower map[string]string
+	// ambiguousSchemaLower mirrors ambiguousLower, for schema names instead of table names.
+	ambiguousSchemaLower map[string]struct{}
 }
 
 func NewTableRegistry() *TableRegistry {
 	return &TableRegistry{
-		exact:         make(map[string]map[string]struct{}),
-		byLower:       make(map[string]map[string]string),
-		schemaByLower: make(map[string]string),
+		exact:                make(map[string]map[string]struct{}),
+		byLower:              make(map[string]map[string]string),
+		ambiguousLower:       make(map[string]map[string]struct{}),
+		schemaByLower:        make(map[string]string),
+		ambiguousSchemaLower: make(map[string]struct{}),
 	}
 }
 
@@ -605,15 +617,31 @@ func (tr *TableRegistry) SetTables(tables []*tableInfo) {
 
 	tr.exact = make(map[string]map[string]struct{}, len(tables))
 	tr.byLower = make(map[string]map[string]string, len(tables))
+	tr.ambiguousLower = make(map[string]map[string]struct{})
 	tr.schemaByLower = make(map[string]string, len(tables))
+	tr.ambiguousSchemaLower = make(map[string]struct{})
+
 	for _, t := range tables {
 		if tr.exact[t.schema] == nil {
 			tr.exact[t.schema] = make(map[string]struct{})
 			tr.byLower[t.schema] = make(map[string]string)
+			tr.ambiguousLower[t.schema] = make(map[string]struct{})
 		}
 		tr.exact[t.schema][t.tableName] = struct{}{}
-		tr.byLower[t.schema][strings.ToLower(t.tableName)] = t.tableName
-		tr.schemaByLower[strings.ToLower(t.schema)] = t.schema
+
+		lowerTable := strings.ToLower(t.tableName)
+		if existing, ok := tr.byLower[t.schema][lowerTable]; ok && existing != t.tableName {
+			tr.ambiguousLower[t.schema][lowerTable] = struct{}{}
+		} else {
+			tr.byLower[t.schema][lowerTable] = t.tableName
+		}
+
+		lowerSchema := strings.ToLower(t.schema)
+		if existing, ok := tr.schemaByLower[lowerSchema]; ok && existing != t.schema {
+			tr.ambiguousSchemaLower[lowerSchema] = struct{}{}
+		} else {
+			tr.schemaByLower[lowerSchema] = t.schema
+		}
 	}
 }
 
@@ -661,28 +689,41 @@ func (tr *TableRegistry) IsValid(schema, parsedTableName string) (string, bool) 
 
 // resolveSchemaLocked resolves a schema name against known schema names, exact match
 // first, falling back to a case-insensitive match. Returns the input unchanged if neither
-// matches, so a subsequent table lookup against it predictably misses too. Callers must
+// matches — including when the lowercased name is ambiguous between two or more distinct
+// schemas — so a subsequent table lookup against it predictably misses too. Callers must
 // hold tr.mu.
 func (tr *TableRegistry) resolveSchemaLocked(schema string) string {
 	if _, ok := tr.exact[schema]; ok {
 		return schema
 	}
-	if canonical, ok := tr.schemaByLower[strings.ToLower(schema)]; ok {
+	lowerSchema := strings.ToLower(schema)
+	if _, ambiguous := tr.ambiguousSchemaLower[lowerSchema]; ambiguous {
+		return schema
+	}
+	if canonical, ok := tr.schemaByLower[lowerSchema]; ok {
 		return canonical
 	}
 	return schema
 }
 
 // resolveTableLocked resolves a table name within a schema, exact match first, falling
-// back to a case-insensitive match. Callers must hold tr.mu.
+// back to a case-insensitive match. Returns ok=false if neither matches, including when
+// the lowercased name is ambiguous between two or more distinct tables in the schema.
+// Callers must hold tr.mu.
 func (tr *TableRegistry) resolveTableLocked(schema, table string) (string, bool) {
 	if tables, ok := tr.exact[schema]; ok {
 		if _, ok := tables[table]; ok {
 			return table, true
 		}
 	}
+	lowerTable := strings.ToLower(table)
+	if ambiguous, ok := tr.ambiguousLower[schema]; ok {
+		if _, isAmbiguous := ambiguous[lowerTable]; isAmbiguous {
+			return table, false
+		}
+	}
 	if byLower, ok := tr.byLower[schema]; ok {
-		if canonical, ok := byLower[strings.ToLower(table)]; ok {
+		if canonical, ok := byLower[lowerTable]; ok {
 			return canonical, true
 		}
 	}

--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -1431,3 +1431,152 @@ func TestSchemaDetailsExcludeSchemas(t *testing.T) {
 	c.extractSchema(t.Context())
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestSchemaDetails_PopulatesTableRegistry(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewSchemaDetails(SchemaDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Millisecond,
+		EntryHandler:    lokiClient,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"table_schema",
+				"table_name",
+				"table_type",
+				"create_time",
+				"update_time",
+			}).AddRow(
+				"some_schema",
+				"MyTable",
+				"BASE TABLE",
+				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+			),
+		)
+
+	// The registry is populated from information_schema.tables before the per-table
+	// metadata queries run, so it's asserted below without mocking the rest of
+	// extractSchema's round trip; those queries fail against the unmocked driver, which
+	// extractSchema logs and otherwise ignores.
+	require.NoError(t, c.extractSchema(t.Context()))
+
+	resolvedTable, valid := c.GetTableRegistry().IsValid("some_schema", "MYTABLE")
+	require.True(t, valid)
+	require.Equal(t, "MyTable", resolvedTable)
+}
+
+func Test_TableRegistry_IsValid(t *testing.T) {
+	t.Run("returns true and the same name for an exact match", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "users"},
+			{schema: "some_schema", tableName: "orders"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "users")
+		require.True(t, valid)
+		require.Equal(t, "users", resolvedTable)
+	})
+
+	t.Run("returns false and the input name when the table doesn't exist in the schema", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "users"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "nonexistent")
+		require.False(t, valid)
+		require.Equal(t, "nonexistent", resolvedTable)
+	})
+
+	t.Run("returns false given an unknown schema", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "users"},
+		})
+
+		resolvedTable, valid := tr.IsValid("other_schema", "users")
+		require.False(t, valid)
+		require.Equal(t, "users", resolvedTable)
+	})
+
+	t.Run("returns false for an empty registry", func(t *testing.T) {
+		tr := NewTableRegistry()
+
+		resolvedTable, valid := tr.IsValid("some_schema", "users")
+		require.False(t, valid)
+		require.Equal(t, "users", resolvedTable)
+	})
+
+	t.Run("resolves a differently-cased name to the registry's canonical casing", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			// e.g. information_schema.tables reports this lowercased because the cluster is
+			// configured with lower_case_table_names=1, but a query referenced it mixed-case.
+			{schema: "some_schema", tableName: "emailageconsumer"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "EmailAgeConsumer")
+		require.True(t, valid)
+		require.Equal(t, "emailageconsumer", resolvedTable)
+	})
+
+	t.Run("resolves against a mixed-case canonical name too", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "MyTable"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "mytable")
+		require.True(t, valid)
+		require.Equal(t, "MyTable", resolvedTable)
+	})
+
+	t.Run("prefers an exact match over the case-insensitive fallback", func(t *testing.T) {
+		tr := NewTableRegistry()
+		// Two tables differing only by case can coexist under the MySQL default
+		// (lower_case_table_names=0), where names are genuinely case-sensitive.
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "Orders"},
+			{schema: "some_schema", tableName: "orders"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "Orders")
+		require.True(t, valid)
+		require.Equal(t, "Orders", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("some_schema", "orders")
+		require.True(t, valid)
+		require.Equal(t, "orders", resolvedTable)
+	})
+
+	t.Run("SetTables replaces prior contents rather than merging", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "old_table"},
+		})
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "new_table"},
+		})
+
+		_, valid := tr.IsValid("some_schema", "old_table")
+		require.False(t, valid)
+
+		resolvedTable, valid := tr.IsValid("some_schema", "new_table")
+		require.True(t, valid)
+		require.Equal(t, "new_table", resolvedTable)
+	})
+}

--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -1478,6 +1478,72 @@ func TestSchemaDetails_PopulatesTableRegistry(t *testing.T) {
 	require.Equal(t, "MyTable", resolvedTable)
 }
 
+func TestSchemaDetails_SkipsRegistryAndThrottleUpdatesOnPartialScan(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	lokiClient := loki.NewCollectingHandler()
+	defer lokiClient.Stop()
+
+	c, err := NewSchemaDetails(SchemaDetailsArguments{
+		DB:              db,
+		CollectInterval: time.Millisecond,
+		EntryHandler:    lokiClient,
+		Logger:          util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	// Seed state as if a prior, complete tick had already run: the registry knows about a
+	// table that this tick's (partial) scan below won't reach, and its throttle entry is fresh.
+	c.tableRegistry.SetTables([]*tableInfo{
+		{schema: "some_schema", tableName: "previously_known_table"},
+	})
+	previouslyKnownKey := fullyQualifiedName("some_schema", "previously_known_table")
+	c.lastEmittedAt[previouslyKnownKey] = c.now()
+
+	mock.ExpectQuery(fmt.Sprintf(selectTablesTemplate, exclusionClause)).WithoutArgs().WillReturnRows(
+		sqlmock.NewRows([]string{
+			"table_schema",
+			"table_name",
+			"table_type",
+			"create_time",
+			"update_time",
+		}).AddRow(
+			"some_schema",
+			"some_table",
+			"BASE TABLE",
+			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+		).AddRow(
+			// A value that can't Scan into the create_time destination fails the second
+			// row's Scan call itself (unlike RowError, which fails iteration and surfaces
+			// via rs.Err() — a case extractSchema already handles by returning early,
+			// before ever reaching the registry/throttle updates below).
+			"some_schema",
+			"another_table",
+			"BASE TABLE",
+			"not-a-valid-time",
+			time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC),
+		),
+	)
+
+	require.NoError(t, c.extractSchema(t.Context()))
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	// The registry must retain its prior, complete state rather than being replaced by
+	// this tick's partial list, which never got far enough to see this table again.
+	_, valid := c.tableRegistry.IsValid("some_schema", "previously_known_table")
+	require.True(t, valid)
+
+	// The throttle entry for that same table must survive too: a partial scan doesn't
+	// prove the table is gone, only that this tick didn't get far enough to re-see it.
+	_, throttled := c.lastEmittedAt[previouslyKnownKey]
+	require.True(t, throttled)
+}
+
 func Test_TableRegistry_IsValid(t *testing.T) {
 	t.Run("returns true and the same name for an exact match", func(t *testing.T) {
 		tr := NewTableRegistry()
@@ -1578,5 +1644,66 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 		resolvedTable, valid := tr.IsValid("some_schema", "new_table")
 		require.True(t, valid)
 		require.Equal(t, "new_table", resolvedTable)
+	})
+
+	t.Run("resolves a schema-qualified name against the qualifier's own schema, not the connection's active schema", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "other_schema", tableName: "orders"},
+		})
+
+		// The active schema ("some_schema") differs from the cross-database reference's
+		// own schema ("other_schema") — the qualifier, not the active schema, must scope
+		// the lookup.
+		resolvedTable, valid := tr.IsValid("some_schema", "other_schema.orders")
+		require.True(t, valid)
+		require.Equal(t, "other_schema.orders", resolvedTable)
+	})
+
+	t.Run("resolves a schema-qualified name whose table casing differs from the registry's", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "other_schema", tableName: "emailageconsumer"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "other_schema.EmailAgeConsumer")
+		require.True(t, valid)
+		require.Equal(t, "other_schema.emailageconsumer", resolvedTable)
+	})
+
+	t.Run("resolves a schema-qualified name whose schema casing differs from the registry's", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "OtherSchema", tableName: "orders"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "otherschema.orders")
+		require.True(t, valid)
+		require.Equal(t, "OtherSchema.orders", resolvedTable)
+	})
+
+	t.Run("returns false for a schema-qualified name whose schema doesn't exist", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "other_schema", tableName: "orders"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "nonexistent_schema.orders")
+		require.False(t, valid)
+		require.Equal(t, "nonexistent_schema.orders", resolvedTable)
+	})
+
+	t.Run("returns false for a schema-qualified name whose table doesn't exist in that schema", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "other_schema", tableName: "orders"},
+			{schema: "some_schema", tableName: "customers"},
+		})
+
+		// "customers" exists, but not in "other_schema" — the qualifier must not fall
+		// through to matching a same-named table in a different schema.
+		resolvedTable, valid := tr.IsValid("some_schema", "other_schema.customers")
+		require.False(t, valid)
+		require.Equal(t, "other_schema.customers", resolvedTable)
 	})
 }

--- a/internal/component/database_observability/mysql/collector/schema_details_test.go
+++ b/internal/component/database_observability/mysql/collector/schema_details_test.go
@@ -1706,4 +1706,93 @@ func Test_TableRegistry_IsValid(t *testing.T) {
 		require.False(t, valid)
 		require.Equal(t, "other_schema.customers", resolvedTable)
 	})
+
+	t.Run("treats a case-insensitive table collision as unresolvable rather than guessing", func(t *testing.T) {
+		tr := NewTableRegistry()
+		// Two tables differing only by case, coexisting under lower_case_table_names=0.
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "Orders"},
+			{schema: "some_schema", tableName: "orders"},
+		})
+
+		// Neither exact-cased table is "ORDERS", so this can only resolve via the
+		// case-insensitive fallback — which can't tell which of the two it means.
+		resolvedTable, valid := tr.IsValid("some_schema", "ORDERS")
+		require.False(t, valid)
+		require.Equal(t, "ORDERS", resolvedTable)
+	})
+
+	t.Run("a case-insensitive table collision doesn't affect an exact match against either table", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "Orders"},
+			{schema: "some_schema", tableName: "orders"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "Orders")
+		require.True(t, valid)
+		require.Equal(t, "Orders", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("some_schema", "orders")
+		require.True(t, valid)
+		require.Equal(t, "orders", resolvedTable)
+	})
+
+	t.Run("a table collision in one schema doesn't make the same lowercased name ambiguous in another", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "schema_a", tableName: "Orders"},
+			{schema: "schema_a", tableName: "orders"},
+			{schema: "schema_b", tableName: "Orders"},
+		})
+
+		resolvedTable, valid := tr.IsValid("schema_b", "ORDERS")
+		require.True(t, valid)
+		require.Equal(t, "Orders", resolvedTable)
+	})
+
+	t.Run("a resolved ambiguity from a prior tick doesn't linger after SetTables replaces the registry", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "Orders"},
+			{schema: "some_schema", tableName: "orders"},
+		})
+		// "orders" was dropped (or renamed) since the last scan.
+		tr.SetTables([]*tableInfo{
+			{schema: "some_schema", tableName: "Orders"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "ORDERS")
+		require.True(t, valid)
+		require.Equal(t, "Orders", resolvedTable)
+	})
+
+	t.Run("treats a case-insensitive schema collision as unresolvable rather than guessing", func(t *testing.T) {
+		tr := NewTableRegistry()
+		// Two schemas differing only by case, coexisting under lower_case_table_names=0.
+		tr.SetTables([]*tableInfo{
+			{schema: "Sales", tableName: "orders"},
+			{schema: "sales", tableName: "orders"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "SALES.orders")
+		require.False(t, valid)
+		require.Equal(t, "SALES.orders", resolvedTable)
+	})
+
+	t.Run("a case-insensitive schema collision doesn't affect a schema-qualified exact match", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTables([]*tableInfo{
+			{schema: "Sales", tableName: "orders"},
+			{schema: "sales", tableName: "orders"},
+		})
+
+		resolvedTable, valid := tr.IsValid("some_schema", "Sales.orders")
+		require.True(t, valid)
+		require.Equal(t, "Sales.orders", resolvedTable)
+
+		resolvedTable, valid = tr.IsValid("some_schema", "sales.orders")
+		require.True(t, valid)
+		require.Equal(t, "sales.orders", resolvedTable)
+	})
 }

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -840,24 +840,7 @@ func (c *Component) startCollectors(inst *dbInstance, serverID string, engineVer
 
 	collectors := enableOrDisableCollectors(c.args)
 
-	if collectors[collector.QueryDetailsCollector] {
-		qtCollector, err := collector.NewQueryDetails(collector.QueryDetailsArguments{
-			DB:              inst.dbConnection,
-			CollectInterval: c.args.QueryDetailsArguments.CollectInterval,
-			StatementsLimit: c.args.QueryDetailsArguments.StatementsLimit,
-			ExcludeSchemas:  c.args.ExcludeSchemas,
-			EntryHandler:    entryHandler,
-			Logger:          c.opts.Logger,
-		})
-		if err != nil {
-			logStartError(collector.QueryDetailsCollector, "create", err)
-		} else {
-			if err := qtCollector.Start(context.Background()); err != nil {
-				logStartError(collector.QueryDetailsCollector, "start", err)
-			}
-			inst.collectors = append(inst.collectors, qtCollector)
-		}
-	}
+	var tableRegistry *collector.TableRegistry
 
 	if collectors[collector.SchemaDetailsCollector] {
 		if c.args.SchemaDetailsArguments.CacheEnabled != nil {
@@ -880,10 +863,31 @@ func (c *Component) startCollectors(inst *dbInstance, serverID string, engineVer
 		if err != nil {
 			logStartError(collector.SchemaDetailsCollector, "create", err)
 		} else {
+			tableRegistry = stCollector.GetTableRegistry()
 			if err := stCollector.Start(context.Background()); err != nil {
 				logStartError(collector.SchemaDetailsCollector, "start", err)
 			}
 			inst.collectors = append(inst.collectors, stCollector)
+		}
+	}
+
+	if collectors[collector.QueryDetailsCollector] {
+		qtCollector, err := collector.NewQueryDetails(collector.QueryDetailsArguments{
+			DB:              inst.dbConnection,
+			CollectInterval: c.args.QueryDetailsArguments.CollectInterval,
+			StatementsLimit: c.args.QueryDetailsArguments.StatementsLimit,
+			ExcludeSchemas:  c.args.ExcludeSchemas,
+			EntryHandler:    entryHandler,
+			TableRegistry:   tableRegistry,
+			Logger:          c.opts.Logger,
+		})
+		if err != nil {
+			logStartError(collector.QueryDetailsCollector, "create", err)
+		} else {
+			if err := qtCollector.Start(context.Background()); err != nil {
+				logStartError(collector.QueryDetailsCollector, "start", err)
+			}
+			inst.collectors = append(inst.collectors, qtCollector)
 		}
 	}
 


### PR DESCRIPTION
### Brief description of Pull Request

query_details.go emits `query_parsed_table_name` using the table name's literal casing as it appears in the query text, while schema_details.go emits `create_statement` using `information_schema`'s casing for the table. On a MySQL cluster configured with `lower_case_table_names=1` or `2`, these two casings can differ for the same table, so anything matching the two labels together (e.g. an exact-match join/filter) can miss an existing table.

This PR adds a `TableRegistry` to `schema_details.go`, populated from `information_schema.tables` and shared with `query_details.go` (mirroring the `TableRegistry` the postgres collector already uses for its own identifier-folding case). `query_details.go` now resolves each parsed table name against the registry — exact match first, case-insensitive fallback — before emitting `query_parsed_table_name`, so it's emitted with the same casing as `create_statement` whenever the table exists.

`query_details.go` also now emits a `validated="true"/"false"` field on `query_parsed_table_name` (mirroring the postgres collector), based on whether the parsed name was actually found in the `TableRegistry`. This lets a downstream consumer filter out a table name the SQL parser/tokenizer misidentified (e.g. a column or alias parsed as if it were a table reference) the same way it already does for postgres.

Follow-ups from review:
- `TableRegistry.IsValid` now splits a schema-qualified parsed table name (a cross-database reference like `otherdb.sometable`) and resolves the schema part against known schema names the same way the table part is resolved, instead of treating the whole qualified string as an opaque, never-matching table name scoped to the connection's active schema.
- `extractSchema` now tracks whether it scanned every `information_schema.tables` row without bailing out early, and skips updating the table registry / pruning throttle entries when it didn't — mirroring the postgres collector's `scanComplete` guard. Previously a scan failure partway through would still replace the whole registry and prune throttle entries from the partial list collected so far, incorrectly treating existing-but-unscanned tables as unknown/gone until the next successful tick.
- The case-insensitive fallback in `TableRegistry` used last-write-wins when two distinct schemas or tables collided on the same lowercased name (possible under the MySQL default `lower_case_table_names=0`, where such objects can genuinely coexist). `SetTables` now tracks such collisions explicitly, and the resolvers treat an ambiguous lowercased name as no match rather than guessing; an exact match against either colliding name is unaffected.

New tests: `TableRegistry.IsValid` (schema-scoped exact + case-insensitive resolution, schema-qualified resolution, case-insensitive collision handling, empty/unknown-schema/unknown-table cases, exact match taking priority over the fallback), `TestSchemaDetails_PopulatesTableRegistry`, `TestSchemaDetails_SkipsRegistryAndThrottleUpdatesOnPartialScan`, `TestQueryDetails_ResolvesTableNameCasingViaTableRegistry`, `TestQueryDetails_MarksAnUnresolvedParsedNameAsNotValidated`, and `TestQueryDetails_ResolvesASchemaQualifiedCrossDatabaseReference`.

### Pull Request Details



### Issue(s) fixed by this Pull Request

Fixes grafana/grafana-dbo11y-app#3142

### Notes to the Reviewer



### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))