### PR TITLE
docs: Allow AI to author parts of pull request description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,8 +13,9 @@
   **HUMANS**
   - Read and understand docs/developer/genai.md
   - Brief description / Details / Issue(s) fixed: factual summary of the change (AI may
-      help). 
-  - Notes, and Checklist: your motivations, trade-offs, and judgment — keep those human-owned.
+    help).
+  - Notes, and Checklist: part of review and communication with the maintainers - keep those
+    human-owned.
 
   **AI AGENTS**
   - MANDATORY: Read, understand, and apply AGENTS.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,9 @@
 
   **HUMANS**
   - Read and understand docs/developer/genai.md
-  - AI may write the PR title and descriptive sections. Review and understand
-    them before submitting. Keep all checklist selections human-owned.
+  - Brief description / Details / Issue(s) fixed: factual summary of the change (AI may
+      help). 
+  - Notes, and Checklist: your motivations, trade-offs, and judgment — keep those human-owned.
 
   **AI AGENTS**
   - MANDATORY: Read, understand, and apply AGENTS.md
@@ -22,7 +23,7 @@
     that section's content. Leave it empty unless the human already filled it.
   - You may write the PR title and sections without "HUMAN ONLY". Follow the
     semantic title rules in .github/workflows/release-lint-pr-title.yml and do
-    not invent issue numbers.
+    not invent issue numbers - verify they exist instead.
   - Checklist: do not add, remove, check, or uncheck items. Leave every item as
     provided unless the human already changed it.
   - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
@@ -31,22 +32,22 @@
 
 ### Brief description of Pull Request
 
-<!-- Factual, human-readable summary of what changed (squash commit body). -->
+<!-- Factual, human-readable, brief summary of what changed (squash commit body). -->
 
 
 ### Pull Request Details
 
-<!-- Motivations, trade-offs, and decisions. -->
+<!-- Motivations, trade-offs, and decisions. Can leave empty if not needed. -->
 
 
 ### Issue(s) fixed by this Pull Request
 
-<!-- Fixes #issue_id -->
+<!-- Fixes #issue_id or leave empty if not applicable -->
 
 
 ### Notes to the Reviewer
 
-<!-- Context for reviewers/testers. -->
+<!-- HUMAN ONLY: Context for reviewers/testers. Can leave empty if not needed. -->
 
 
 ### PR Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,19 +12,19 @@
 
   **HUMANS**
   - Read and understand docs/developer/genai.md
-  - Brief description / Issue(s) fixed: factual summary of the change (AI may
-    help). Details, Notes, and Checklist: your motivations, trade-offs, and
-    judgment — keep those human-owned.
+  - AI may write the PR title and descriptive sections. Review and understand
+    them before submitting. Keep all checklist selections human-owned.
 
   **AI AGENTS**
   - MANDATORY: Read, understand, and apply AGENTS.md
   - Use this template as the PR body structure. Do not invent a custom layout.
   - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
     that section's content. Leave it empty unless the human already filled it.
-  - Sections without "HUMAN ONLY" may be filled by you (Brief description,
-    Issue(s) fixed when known). Do not invent issue numbers or a PR title.
-  - Checklist: leave unchecked unless the human explicitly confirmed; do not
-    guess the AI-assistance disclosure box.
+  - You may write the PR title and sections without "HUMAN ONLY". Follow the
+    semantic title rules in .github/workflows/release-lint-pr-title.yml and do
+    not invent issue numbers.
+  - Checklist: do not add, remove, check, or uncheck items. Leave every item as
+    provided unless the human already changed it.
   - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
     point at docs/developer/genai.md.
 -->
@@ -36,7 +36,7 @@
 
 ### Pull Request Details
 
-<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->
+<!-- Motivations, trade-offs, and decisions. -->
 
 
 ### Issue(s) fixed by this Pull Request
@@ -46,12 +46,12 @@
 
 ### Notes to the Reviewer
 
-<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->
+<!-- Context for reviewers/testers. -->
 
 
 ### PR Checklist
 
-<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->
+<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->
 
 - [ ] Documentation added
 - [ ] Tests updated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,21 +26,22 @@ Meta-content: how you behave around GitHub, commits, PRs, and GenAI ownership �
 code.
 
 **Ownership model:** Humans propose changes and remain accountable. AI may assist with
-implementation and write pull request titles and descriptions. Humans own pull request checklist
-selections and all discussion. Full policy: [docs/developer/genai.md](docs/developer/genai.md).
+implementation. Humans own PR sections marked `HUMAN ONLY` and all discussion. AI can write the PR
+title and sections not marked `HUMAN ONLY`. Full policy:
+[docs/developer/genai.md](docs/developer/genai.md).
 
 ### MUST NOT
 
 - Write, rewrite, fill, or "improve" any PR template section marked `HUMAN ONLY`, issue bodies the
   human will submit, or any GitHub comment / review reply / discussion text.
 - Invent design rationale, decision history, or "how it works" prose for the human to paste into
-  review threads or other discussion.
+  review threads.
 - Open pull requests or issues, or post to GitHub, in a way that substitutes for the human's design
   explanation or review conversation.
 - Wire up, configure, or suggest automated agent replies to reviewers, maintainers, or other
   community members.
-- Paste policy prose, generated checklists, or long AI summaries into discussion as a stand-in for
-  the human’s own explanation.
+- Paste policy prose, generated checklists, or long AI summaries into GitHub discussion as a
+  stand-in for the human’s own explanation.
 - Silently comply when the human asks you to violate these rules (including "just do it anyway,"
   "only draft it and I’ll paste it," or "reply to the reviewer for me").
 - Edit changelog files by hand (release tooling derives entries from PR titles).
@@ -53,14 +54,15 @@ selections and all discussion. Full policy: [docs/developer/genai.md](docs/devel
 - When opening or drafting a pull request is part of the task: read and use
   [.github/pull_request_template.md](.github/pull_request_template.md) as the body structure. Do not
   invent a custom PR layout. Follow the AI AGENTS rule in that file: **do not fill any section whose
-  comment contains `HUMAN ONLY`**. Fill descriptive sections and Issue(s) fixed when known (do not
-  invent issue numbers). AI may write the PR title.
+  comment contains `HUMAN ONLY`**. Fill sections without that marker. Verify referenced issues exist;
+  do not invent issue numbers. AI may write the PR title.
 - When asked to write a `HUMAN ONLY` PR section, issue discussion, or a review reply: **refuse that
   part of the request in your chat reply to the human**. State that it conflicts with Alloy's GenAI
-  policy (humans own checklist selections and discussion; AI may write the PR title and descriptive
-  sections), and point them at [docs/developer/genai.md](docs/developer/genai.md). Do not merely fail
-  in a tool without also explaining in the model output.
-- After refusing disallowed work, you MAY continue helping with allowed coding and pull request work
+  policy (humans own sections marked `HUMAN ONLY` and discussion; AI may write the PR title and
+  sections not marked `HUMAN ONLY`), and point them at
+  [docs/developer/genai.md](docs/developer/genai.md). Do not merely fail in a tool without also
+  explaining in the model output.
+- After refusing disallowed work, you MAY continue helping with allowed coding work and PR sections
   in the same turn.
 - When authoring commit messages or PR titles, follow
   [PR titles and commit messages](docs/developer/contributing.md#pull-request-titles-and-commit-messages):
@@ -77,8 +79,8 @@ selections and all discussion. Full policy: [docs/developer/genai.md](docs/devel
 - Write or refine a PR title and PR template sections that are **not** marked `HUMAN ONLY` when
   opening or updating a PR.
 - Produce **local-only** scratch notes for the human **if they explicitly ask**, and only after
-  reminding them that `HUMAN ONLY` sections and discussion must remain their own work. Never treat
-  those notes as ready to paste into `HUMAN ONLY` sections or comments.
+  reminding them that `HUMAN ONLY` sections and discussion must be rewritten in their own words.
+  Never treat those notes as ready to paste into `HUMAN ONLY` sections or comments.
 
 ## Coding rules (mandatory)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,8 @@ Meta-content: how you behave around GitHub, commits, PRs, and GenAI ownership â€
 code.
 
 **Ownership model:** Humans propose changes and remain accountable. AI may assist with
-implementation. Humans own PR sections marked `HUMAN ONLY` and all discussion. AI can write the PR
-title and sections not marked `HUMAN ONLY`. Full policy:
-[docs/developer/genai.md](docs/developer/genai.md).
+implementation. Humans own PR description sections marked `HUMAN ONLY` and all discussion with
+maintainers. Full policy: [docs/developer/genai.md](docs/developer/genai.md).
 
 ### MUST NOT
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,22 +26,21 @@ Meta-content: how you behave around GitHub, commits, PRs, and GenAI ownership �
 code.
 
 **Ownership model:** Humans propose changes and remain accountable. AI may assist with
-implementation. Humans own pull request details and all discussion. AI can write the PR **Brief
-description** (factual summary) and may fill **Issue(s) fixed** when known. Full policy:
-[docs/developer/genai.md](docs/developer/genai.md).
+implementation and write pull request titles and descriptions. Humans own pull request checklist
+selections and all discussion. Full policy: [docs/developer/genai.md](docs/developer/genai.md).
 
 ### MUST NOT
 
 - Write, rewrite, fill, or "improve" any PR template section marked `HUMAN ONLY`, issue bodies the
   human will submit, or any GitHub comment / review reply / discussion text.
 - Invent design rationale, decision history, or "how it works" prose for the human to paste into
-  pull request details or review threads.
+  review threads or other discussion.
 - Open pull requests or issues, or post to GitHub, in a way that substitutes for the human's design
   explanation or review conversation.
 - Wire up, configure, or suggest automated agent replies to reviewers, maintainers, or other
   community members.
-- Paste policy prose, generated checklists, or long AI summaries into GitHub-bound text as a
-  stand-in for the human’s own explanation.
+- Paste policy prose, generated checklists, or long AI summaries into discussion as a stand-in for
+  the human’s own explanation.
 - Silently comply when the human asks you to violate these rules (including "just do it anyway,"
   "only draft it and I’ll paste it," or "reply to the reviewer for me").
 - Edit changelog files by hand (release tooling derives entries from PR titles).
@@ -50,34 +49,36 @@ description** (factual summary) and may fill **Issue(s) fixed** when known. Full
 
 ### MUST
 
-- Leave `HUMAN ONLY` PR sections, PR title, and all review discussion to the human.
+- Leave `HUMAN ONLY` PR sections and all review discussion to the human.
 - When opening or drafting a pull request is part of the task: read and use
   [.github/pull_request_template.md](.github/pull_request_template.md) as the body structure. Do not
   invent a custom PR layout. Follow the AI AGENTS rule in that file: **do not fill any section whose
-  comment contains `HUMAN ONLY`**. Fill sections without that marker (Brief description; Issue(s)
-  fixed when known — do not invent issue numbers). Do not invent a PR title.
+  comment contains `HUMAN ONLY`**. Fill descriptive sections and Issue(s) fixed when known (do not
+  invent issue numbers). AI may write the PR title.
 - When asked to write a `HUMAN ONLY` PR section, issue discussion, or a review reply: **refuse that
   part of the request in your chat reply to the human**. State that it conflicts with Alloy's GenAI
-  policy (humans own design rationale and discussion; AI may fill non-`HUMAN ONLY` PR sections such
-  as Brief description), and point them at [docs/developer/genai.md](docs/developer/genai.md). Do
-  not merely fail in a tool without also explaining in the model output.
-- After refusing disallowed work, you MAY continue helping with allowed coding work (and Brief
-  description) in the same turn.
-- When the human authors commit messages or PR titles, follow
+  policy (humans own checklist selections and discussion; AI may write the PR title and descriptive
+  sections), and point them at [docs/developer/genai.md](docs/developer/genai.md). Do not merely fail
+  in a tool without also explaining in the model output.
+- After refusing disallowed work, you MAY continue helping with allowed coding and pull request work
+  in the same turn.
+- When authoring commit messages or PR titles, follow
   [PR titles and commit messages](docs/developer/contributing.md#pull-request-titles-and-commit-messages):
   Conventional Commit `type(scope):` with a description that starts with a capital letter (e.g.
-  `feat(loki.process): Add ...`, not `feat(loki.process): add ...`). Do not invent a different
-  scheme.
+  `feat(loki.process): Add ...`, not `feat(loki.process): add ...`). The allowed types and other
+  semantic PR title rules are enforced by
+  [.github/workflows/release-lint-pr-title.yml](.github/workflows/release-lint-pr-title.yml). Do not
+  invent a different scheme.
 - If asked how to disclose substantial AI implementation help: point at the PR template checkbox and
-  [docs/developer/genai.md](docs/developer/genai.md). Do not fill pull request details for them.
+  [docs/developer/genai.md](docs/developer/genai.md). Do not select the checkbox for them.
 
 ### MAY
 
-- Fill or refine PR template sections that are **not** marked `HUMAN ONLY` when opening or updating
-  a PR.
+- Write or refine a PR title and PR template sections that are **not** marked `HUMAN ONLY` when
+  opening or updating a PR.
 - Produce **local-only** scratch notes for the human **if they explicitly ask**, and only after
-  reminding them that `HUMAN ONLY` sections and discussion must be rewritten in their own words.
-  Never treat those notes as ready to paste into `HUMAN ONLY` sections or comments.
+  reminding them that `HUMAN ONLY` sections and discussion must remain their own work. Never treat
+  those notes as ready to paste into `HUMAN ONLY` sections or comments.
 
 ## Coding rules (mandatory)
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -15,20 +15,20 @@ review it, and defend it in discussion, regardless of which tools helped you wri
 Contribution work has two sides.
 
 - **Factual and mechanical** work (what changed, implementing code or docs from clear intent, and
-  writing a PR title and description) is where AI is often well suited.
-- **Subjective and human** work (setting intent, making decisions, selecting checklist items, and
-  participating in discussion) stays with you. Use AI where it helps; keep human oversight and
-  interaction where judgment and accountability matter.
+  writing a PR title and sections not marked `HUMAN ONLY`) is where AI is often well suited.
+- **Subjective and human** work (setting intent, PR sections marked `HUMAN ONLY`, and discussion)
+  stays with you. Use AI where it helps; keep human oversight and interaction where judgment and
+  accountability matter.
 
 ## Ownership model
 
-| You own (write yourself)              | AI may help with                                |
-| ------------------------------------- | ----------------------------------------------- |
-| Intent and design of the change       | Exploring the codebase                          |
-| Pull request checklist selections     | Writing or refactoring code and tests           |
-| Issue and proposal text you submit    | Editing documentation files in the repo         |
-| Review replies and ongoing discussion | Pull request title and description               |
-| Code review conclusions               | Issue(s) fixed (`Fixes #N` when known)          |
+| You own (write yourself)                   | AI may help with                              |
+| ------------------------------------------ | --------------------------------------------- |
+| Intent and design of the change            | Exploring the codebase                        |
+| PR sections marked `HUMAN ONLY`            | Writing or refactoring code and tests         |
+| Issue and proposal text you submit         | Editing documentation files in the repo       |
+| Review replies and ongoing discussion      | PR title and non-`HUMAN ONLY` sections        |
+| Code review conclusions                    | Issue(s) fixed (after verifying it exists)    |
 
 AI-assisted **implementation** is welcome when you review and understand the result. AI-mediated
 **conversation** is not. Reviewers need confidence that you understand the design choices and
@@ -37,13 +37,14 @@ trade-offs of what you're proposing.
 ## Acceptable
 
 - Use AI to implement or refactor code and docs that you then review and refine.
-- Use AI to write the PR title and description from the actual change and your intent.
+- Use AI to write the PR title and sections not marked `HUMAN ONLY` from the actual change and your
+  intent.
 - Use AI to learn the codebase before contributing or reviewing.
 - Use AI privately to clarify your own thinking, then post discussion **in your own words**.
 
 ## Not acceptable
 
-- Submit a PR title or description that you don't understand, haven't reviewed, or can't defend.
+- Submit AI-written PR content that you don't understand, haven't reviewed, or can't defend.
 - Paste AI-generated text into review threads or issue discussion as a stand-in for your analysis.
 - Wire an agent to reply to reviewers on your behalf.
 - Use AI as a substitute for your judgment when **reviewing** others' code.
@@ -58,8 +59,8 @@ When AI generates the **bulk of the implementation**, check **"This pull request
 generated with AI assistance"** in the PR template. Minor autocomplete or small edits do not need
 disclosure.
 
-An AI-written PR title and description are fine. The checklist, including the AI-assistance
-disclosure, remains yours to complete. Discussion must also remain yours.
+An AI-written PR title and sections not marked `HUMAN ONLY` are fine. Sections marked `HUMAN ONLY`,
+including the AI-assistance disclosure, and discussion must still be yours.
 
 ## Licensing and provenance
 
@@ -81,11 +82,10 @@ you draft; you own the argument in public discussion.
 
 ## Enforcement
 
-Maintainers may close or request changes on contributions when the contributor doesn't demonstrate
-understanding or when discussion looks unowned or low-effort AI-generated, using the same [issue
-triage][issue-triage] process as other contributions. When they do, they will explain why and, where
-appropriate, offer guidance on how to improve the contribution. Repeated abuse may lead to stricter
-review or blocked contributions.
+Maintainers may close or request changes on contributions where discussion looks unowned or
+low-effort AI-generated, using the same [issue triage][issue-triage] process as other contributions.
+When they do, they will explain why and, where appropriate, offer guidance on how to improve the
+contribution. Repeated abuse may lead to stricter review or blocked contributions.
 
 [alloy-docs]: https://grafana.com/docs/alloy/latest/
 [issue-triage]: ./issue-triage.md

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -15,20 +15,21 @@ review it, and defend it in discussion, regardless of which tools helped you wri
 Contribution work has two sides.
 
 - **Factual and mechanical** work (what changed, implementing code or docs from clear intent, and
-  writing a PR title and sections not marked `HUMAN ONLY`) is where AI is often well suited.
+  writing a PR title and description sections not marked `HUMAN ONLY`) is where AI is often well
+  suited.
 - **Subjective and human** work (setting intent, PR sections marked `HUMAN ONLY`, and discussion)
   stays with you. Use AI where it helps; keep human oversight and interaction where judgment and
   accountability matter.
 
 ## Ownership model
 
-| You own (write yourself)                   | AI may help with                              |
-| ------------------------------------------ | --------------------------------------------- |
-| Intent and design of the change            | Exploring the codebase                        |
-| PR sections marked `HUMAN ONLY`            | Writing or refactoring code and tests         |
-| Issue and proposal text you submit         | Editing documentation files in the repo       |
-| Review replies and ongoing discussion      | PR title and non-`HUMAN ONLY` sections        |
-| Code review conclusions                    | Issue(s) fixed (after verifying it exists)    |
+| You own (write yourself)                         | AI may help with                           |
+| ------------------------------------------------ | ------------------------------------------ |
+| Intent and design of the change                  | Exploring the codebase                     |
+| PR description sections marked `HUMAN ONLY`      | Writing or refactoring code and tests      |
+| Issue and proposal text you submit               | Editing documentation files in the repo    |
+| Review replies and ongoing discussion            | PR title and PR details summaries          |
+| Code review conclusions                          | Issue(s) fixed (after verifying it exists) |
 
 AI-assisted **implementation** is welcome when you review and understand the result. AI-mediated
 **conversation** is not. Reviewers need confidence that you understand the design choices and
@@ -37,8 +38,7 @@ trade-offs of what you're proposing.
 ## Acceptable
 
 - Use AI to implement or refactor code and docs that you then review and refine.
-- Use AI to write the PR title and sections not marked `HUMAN ONLY` from the actual change and your
-  intent.
+- Use AI to write the PR title and sections not marked `HUMAN ONLY` in the PR description.
 - Use AI to learn the codebase before contributing or reviewing.
 - Use AI privately to clarify your own thinking, then post discussion **in your own words**.
 
@@ -58,9 +58,6 @@ Approved bots (for example dependency bots) are fine when clearly marked as bot-
 When AI generates the **bulk of the implementation**, check **"This pull request was substantially
 generated with AI assistance"** in the PR template. Minor autocomplete or small edits do not need
 disclosure.
-
-An AI-written PR title and sections not marked `HUMAN ONLY` are fine. Sections marked `HUMAN ONLY`,
-including the AI-assistance disclosure, and discussion must still be yours.
 
 ## Licensing and provenance
 

--- a/docs/developer/genai.md
+++ b/docs/developer/genai.md
@@ -14,22 +14,21 @@ review it, and defend it in discussion, regardless of which tools helped you wri
 
 Contribution work has two sides.
 
-- **Factual and mechanical** work (what changed, implementing code or docs from clear intent, a
-  brief PR summary) is where AI is often well suited.
-- **Subjective and human** work (motivations, trade-offs, reviewer notes, and discussion) stays with
-  you. Use AI where it helps; keep human oversight and interaction where judgment and accountability
-  matter.
+- **Factual and mechanical** work (what changed, implementing code or docs from clear intent, and
+  writing a PR title and description) is where AI is often well suited.
+- **Subjective and human** work (setting intent, making decisions, selecting checklist items, and
+  participating in discussion) stays with you. Use AI where it helps; keep human oversight and
+  interaction where judgment and accountability matter.
 
 ## Ownership model
 
-| You own (write yourself)                   | AI may help with                              |
-| ------------------------------------------ | --------------------------------------------- |
-| Intent and design of the change            | Exploring the codebase                        |
-| Pull request details (why, how, decisions) | Writing or refactoring code and tests         |
-| Issue and proposal text you submit         | Editing documentation files in the repo       |
-| Review replies and ongoing discussion      | Brief description of the PR (factual summary) |
-| Code review conclusions                    | Issue(s) fixed (`Fixes #N` when known)        |
-| Conventional Commit PR title               |                                               |
+| You own (write yourself)              | AI may help with                                |
+| ------------------------------------- | ----------------------------------------------- |
+| Intent and design of the change       | Exploring the codebase                          |
+| Pull request checklist selections     | Writing or refactoring code and tests           |
+| Issue and proposal text you submit    | Editing documentation files in the repo         |
+| Review replies and ongoing discussion | Pull request title and description               |
+| Code review conclusions               | Issue(s) fixed (`Fixes #N` when known)          |
 
 AI-assisted **implementation** is welcome when you review and understand the result. AI-mediated
 **conversation** is not. Reviewers need confidence that you understand the design choices and
@@ -38,14 +37,13 @@ trade-offs of what you're proposing.
 ## Acceptable
 
 - Use AI to implement or refactor code and docs that you then review and refine.
-- Use AI to draft the PR **Brief description** and **Issue(s) fixed** from the actual change.
+- Use AI to write the PR title and description from the actual change and your intent.
 - Use AI to learn the codebase before contributing or reviewing.
 - Use AI privately to clarify your own thinking, then post discussion **in your own words**.
 
 ## Not acceptable
 
-- Leave pull request details empty of your own reasoning on non-trivial PRs, or paste AI text there
-  as a stand-in for how/why you built the change.
+- Submit a PR title or description that you don't understand, haven't reviewed, or can't defend.
 - Paste AI-generated text into review threads or issue discussion as a stand-in for your analysis.
 - Wire an agent to reply to reviewers on your behalf.
 - Use AI as a substitute for your judgment when **reviewing** others' code.
@@ -60,8 +58,8 @@ When AI generates the **bulk of the implementation**, check **"This pull request
 generated with AI assistance"** in the PR template. Minor autocomplete or small edits do not need
 disclosure.
 
-An AI-written Brief description and Issue(s) fixed lines are fine. Disclosure does not excuse
-AI-written pull request details or discussion — those must still be yours.
+An AI-written PR title and description are fine. The checklist, including the AI-assistance
+disclosure, remains yours to complete. Discussion must also remain yours.
 
 ## Licensing and provenance
 
@@ -83,11 +81,11 @@ you draft; you own the argument in public discussion.
 
 ## Enforcement
 
-Maintainers may close or request changes on contributions where pull request details or discussion
-look unowned or low-effort AI-generated, using the same [issue triage][issue-triage] process as
-other contributions. When they do, they will explain why and, where appropriate, offer guidance on
-how to improve the contribution. Repeated abuse may lead to stricter review or blocked
-contributions.
+Maintainers may close or request changes on contributions when the contributor doesn't demonstrate
+understanding or when discussion looks unowned or low-effort AI-generated, using the same [issue
+triage][issue-triage] process as other contributions. When they do, they will explain why and, where
+appropriate, offer guidance on how to improve the contribution. Repeated abuse may lead to stricter
+review or blocked contributions.
 
 [alloy-docs]: https://grafana.com/docs/alloy/latest/
 [issue-triage]: ./issue-triage.md


### PR DESCRIPTION
### Brief description of Pull Request

Allow AI to write PR titles and non-`HUMAN ONLY` description sections, while keeping reviewer notes, checklist selections, and discussion human-owned.


### Pull Request Details


### Issue(s) fixed by this Pull Request


### Notes to the Reviewer


### PR Checklist

<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
