### PR TITLE
feat: switch systemd service type to notify

### DIFF
--- a/internal/alloycli/cmd_run.go
+++ b/internal/alloycli/cmd_run.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/fatih/color"
 	"github.com/grafana/ckit/advertise"
 	"github.com/grafana/ckit/peer"
@@ -523,6 +524,13 @@ func (fr *alloyRun) run(ctx context.Context, fset *pflag.FlagSet, params runPara
 		ReadyFunc: func() bool { return ready() },
 		ReloadFunc: func() error {
 			return reload()
+		},
+		NotifyFunc: func() {
+			if sent, err := daemon.SdNotify(false, daemon.SdNotifyReady); err != nil {
+				slogger.Warn("failed to send systemd readiness notification", "err", err)
+			} else if sent {
+				slogger.Debug("sent readiness notification to systemd")
+			}
 		},
 
 		HTTPListenAddr:   fr.httpListenAddr,

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -53,6 +53,11 @@ type Options struct {
 	ReadyFunc  func() bool
 	ReloadFunc func() error
 
+	// NotifyFunc, if non-nil, is called once after the HTTP listener is
+	// successfully bound and the server is ready to accept connections.
+	// It is intended for process-readiness signalling (e.g. sd_notify).
+	NotifyFunc func()
+
 	HTTPListenAddr   string                // Address to listen for HTTP traffic on.
 	MemoryListenAddr string                // Address to accept in-memory traffic on.
 	EnablePProf      bool                  // Whether pprof endpoints should be exposed.
@@ -300,6 +305,10 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 	srv := &http.Server{Handler: r, Protocols: protos}
 
 	s.log.Info("now listening for http traffic", "addr", s.opts.HTTPListenAddr)
+
+	if s.opts.NotifyFunc != nil {
+		s.opts.NotifyFunc()
+	}
 
 	listeners := []net.Listener{s.publicLis, s.memLis}
 	for _, lis := range listeners {

--- a/internal/service/http/http.go
+++ b/internal/service/http/http.go
@@ -306,10 +306,6 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 
 	s.log.Info("now listening for http traffic", "addr", s.opts.HTTPListenAddr)
 
-	if s.opts.NotifyFunc != nil {
-		s.opts.NotifyFunc()
-	}
-
 	listeners := []net.Listener{s.publicLis, s.memLis}
 	for _, lis := range listeners {
 		wg.Add(1)
@@ -324,6 +320,10 @@ func (s *Service) Run(ctx context.Context, host service.Host) error {
 	}
 
 	defer func() { _ = srv.Shutdown(ctx) }()
+
+	if s.opts.NotifyFunc != nil {
+		s.opts.NotifyFunc()
+	}
 
 	<-ctx.Done()
 	return nil

--- a/packaging/deb/alloy.service
+++ b/packaging/deb/alloy.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+Type=notify
 Restart=always
 User=alloy
 Environment=HOSTNAME=%H

--- a/packaging/rpm/alloy.service
+++ b/packaging/rpm/alloy.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+Type=notify
 Restart=always
 User=alloy
 Environment=HOSTNAME=%H


### PR DESCRIPTION
### Brief description of Pull Request

Send sd_notify(READY=1) via github.com/coreos/go-systemd/v22/daemon once the HTTP listener is bound. The call is wired through a new NotifyFunc callback on httpservice.Options, keeping the HTTP service decoupled from the systemd package.

Set Type=notify in packaging/deb/alloy.service and packaging/rpm/alloy.service so systemd waits for the readiness signal before considering the service started, rather than declaring it active the moment the process is forked.

### Pull Request Details

This change is intended to address potential race between systemd started alloy service and other processes trying to subsequently call e.g. `systemctl reload alloy`. Currently it could lead to the effect of alloy being killed with SIGHUP (default golang behavior) instead of initiating proper configuration reload, if SIGHUP comes in _before_ alloy sets its signal handlers (proved to be an issue on slow cloud VMs where alloy process could take 10-20 seconds to start due to the size of a binary).

With sd_notify, we clearly define at which point service is considered active and ready - when HTTP management API is up.

### Issue(s) fixed by this Pull Request

N/A

### Notes to the Reviewer

This was tested on Ubuntu 26.04 VM. Corresponding log entries:
```
Aug 24 23:32:42 ubuntu2604 systemd[1]: Starting alloy.service - Vendor-agnostic OpenTelemetry Collector distribution with programmable pipelines...
Aug 24 23:32:42 ubuntu2604 alloy[73860]: ts=2026-08-24T23:32:42.272951652Z level=info msg="Alloy is starting"
Aug 24 23:32:42 ubuntu2604 alloy[73860]: ts=2026-08-24T23:32:42.273013764Z level=info msg="boringcrypto enabled" enabled=false
Aug 24 23:32:42 ubuntu2604 alloy[73860]: ts=2026-08-24T23:32:42.27315794Z level=info msg="memory is not limited, skipping" package=github.com/KimMachineGun/automemlimit/memlimit
[..]
Aug 24 23:32:42 ubuntu2604 alloy[73860]: ts=2026-08-24T23:32:42.276251681Z level=info msg="{^_^} Alloy is running"
[..]
Aug 24 23:32:42 ubuntu2604 alloy[73860]: ts=2026-08-24T23:32:42.277128823Z level=info msg="now listening for http traffic" service=http addr=127.0.0.1:12345
Aug 24 23:32:42 ubuntu2604 alloy[73860]: ts=2026-08-24T23:32:42.277154609Z level=debug msg="sent readiness notification to systemd"
```

Service status:
```
root@ubuntu2604:/etc/alloy# systemctl status alloy
● alloy.service - Vendor-agnostic OpenTelemetry Collector distribution with programmable pipelines
     Loaded: loaded (/usr/lib/systemd/system/alloy.service; enabled; preset: enabled)
     Active: active (running) since Mon 2026-08-24 23:32:42 UTC; 16min ago
 Invocation: 1ed47aeb9d6b413882c46921f18c8cc4
       Docs: https://grafana.com/docs/alloy
   Main PID: 73860 (alloy)
      Tasks: 8 (limit: 15648)
     Memory: 52.8M (peak: 53.9M)
        CPU: 3.633s
     CGroup: /system.slice/alloy.service
             └─73860 /usr/bin/alloy run --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
[..]

root@ubuntu2604:/etc/alloy# systemctl show alloy -p Type -p ActiveEnterTimestamp
ActiveEnterTimestamp=Mon 2026-08-24 23:32:42 UTC
Type=notify
```

### PR Checklist

N/A