### PR TITLE
ci: Add Sanity Tests For Windows Builds

### DIFF
--- a/.github/workflows/check-windows-release-build.yml
+++ b/.github/workflows/check-windows-release-build.yml
@@ -1,0 +1,71 @@
+name: Check Windows release build
+
+# Builds alloy-windows-amd64.exe through the same toolchain the real release
+# pipeline uses (grafana/alloy-build-image, cross-compiling from Linux via
+# viceroy), then actually runs it on Windows to make sure it starts
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile.windows'
+      - 'scripts/docker-containers-windows'
+      - '.github/workflows/check-windows-container.yml'
+      - '.github/workflows/publish-alloy.yml'
+      - '.github/workflows/publish-alloy-devel.yml'
+      - '.github/workflows/release-publish-alloy-artifacts.yml'
+      - '.github/workflows/publish-alloy-windows.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile.windows'
+      - 'scripts/docker-containers-windows'
+      - '.github/workflows/check-windows-container.yml'
+      - '.github/workflows/publish-alloy.yml'
+      - '.github/workflows/publish-alloy-devel.yml'
+      - '.github/workflows/release-publish-alloy-artifacts.yml'
+      - '.github/workflows/publish-alloy-windows.yml'
+permissions:
+  contents: read
+
+jobs:
+  build_windows_binary:
+    name: Build alloy-windows-amd64.exe
+    container: grafana/alloy-build-image:v0.1.35@sha256:9fa2a341b53503ce42cf9900c401d689a68ea67cdec6a20f53d72e3665fb8dc6
+    runs-on:
+      labels: github-hosted-ubuntu-x64-large
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+
+    - name: Set ownership
+      # https://github.com/actions/runner/issues/2033#issuecomment-1204205989
+      run: |
+        chown -R $(id -u):$(id -g) $PWD
+
+    - name: Build
+      run: make dist/alloy-windows-amd64.exe
+      env:
+        RELEASE_BUILD: "1"
+
+    - name: Upload alloy-windows-amd64.exe
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: windows-binary-smoke-test
+        path: ./dist/alloy-windows-amd64.exe
+        if-no-files-found: error
+
+  smoke_test_windows_binary:
+    name: Smoke test
+    needs: [build_windows_binary]
+    runs-on: windows-latest
+    steps:
+    - name: Download alloy-windows-amd64.exe
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: windows-binary-smoke-test
+        path: .
+
+    - name: Run alloy.exe --version
+      run: .\alloy-windows-amd64.exe --version

--- a/.github/workflows/check-windows-release-build.yml
+++ b/.github/workflows/check-windows-release-build.yml
@@ -68,4 +68,8 @@ jobs:
         path: .
 
     - name: Run alloy.exe --version
-      run: .\alloy-windows-amd64.exe --version
+      # Scrub PATH down to the stock Windows locations so this
+      # check reflects a plain Windows install, not this runner's tooling.
+      run: |
+        $env:Path = "$env:SystemRoot\System32;$env:SystemRoot;$env:SystemRoot\System32\Wbem;$env:SystemRoot\System32\WindowsPowerShell\v1.0\"
+        .\alloy-windows-amd64.exe --version

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -66,7 +66,7 @@ SHELL ["cmd", "/S", "/C"]
 
 # Creating new layers can be really slow on Windows so we clean up any caches
 # we can before moving on to the next step.
-RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS=\"embedalloyui ${GO_TAGS}\" make alloy && rm -rf internal/web/ui/node_modules""
+RUN ""C:\Program Files\git\bin\bash.exe" -c "RELEASE_BUILD=${RELEASE_BUILD} VERSION=${VERSION} GO_TAGS=\"embedalloyui ${GO_TAGS}\" CGO_LDFLAGS=\"-static\" make alloy && rm -rf internal/web/ui/node_modules""
 
 # In this case, we're separating the clean command from make alloy to avoid an issue where access to some mod cache
 # files is denied immediately after make alloy, for example:

--- a/build-tools/make/packaging.mk
+++ b/build-tools/make/packaging.mk
@@ -29,8 +29,8 @@ PACKAGING_VARS = RELEASE_BUILD=1 GO_TAGS="$(GO_TAGS)" GOOS=$(GOOS) GOARCH=$(GOAR
 # own. It has no standalone libssp.a to link against. Passing -lssp there
 # fails the link with "cannot find -lssp".
 #
-# Add -lssp only when the build does not run natively on Windows.
-WINDOWS_CGO_LDFLAGS := $(if $(filter windows,$(shell go env GOHOSTOS)),,-lssp)
+# Add -static -lssp only when the build does not run natively on Windows.
+WINDOWS_CGO_LDFLAGS := $(if $(filter windows,$(shell go env GOHOSTOS)),,-static -lssp)
 
 .PHONY: dist-alloy-mixin-zip
 dist-alloy-mixin-zip:

--- a/scripts/docker-containers-windows
+++ b/scripts/docker-containers-windows
@@ -85,6 +85,10 @@ case "$TARGET_CONTAINER" in
       -f ./Dockerfile.windows                \
       .
 
+    # Sanity check: make sure the image can actually start (e.g. catches a
+    # missing DLL at process launch) before we push it.
+    docker run --rm "$RELEASE_ALLOY_IMAGE:$VERSION_TAG" --version
+
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
       docker push "$RELEASE_ALLOY_IMAGE:$VERSION_TAG"
       docker push "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"
@@ -108,6 +112,8 @@ case "$TARGET_CONTAINER" in
       -f ./Dockerfile.windows                \
       .
 
+    docker run --rm "$RELEASE_ALLOY_IMAGE:$VERSION_TAG-cngcrypto" --version
+
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
       docker push "$RELEASE_ALLOY_IMAGE:$VERSION_TAG"
       docker push "$RELEASE_ALLOY_IMAGE:$BRANCH_TAG"
@@ -124,6 +130,8 @@ case "$TARGET_CONTAINER" in
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       -f ./Dockerfile.windows              \
       .
+
+    docker run --rm "$DEVEL_ALLOY_IMAGE:$VERSION_TAG" --version
 
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
       docker push "$DEVEL_ALLOY_IMAGE:$VERSION_TAG"
@@ -148,6 +156,8 @@ case "$TARGET_CONTAINER" in
       -f ./Dockerfile.windows              \
       .
 
+    docker run --rm "$DEVEL_ALLOY_IMAGE:$VERSION_TAG-cngcrypto" --version
+
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
       docker push "$DEVEL_ALLOY_IMAGE:$VERSION_TAG"
       docker push "$DEVEL_ALLOY_IMAGE:$BRANCH_TAG"
@@ -165,6 +175,8 @@ case "$TARGET_CONTAINER" in
       --build-arg BASE_IMAGE_WINDOWS="$BASE_IMAGE_WINDOWS" \
       -f ./Dockerfile.windows              \
       .
+
+    docker run --rm "$DEVEL_ALLOY_IMAGE:$TAG" --version
 
     if [[ $PUSH_ALLOY_IMAGE == "true"  ]]; then
       docker push "$DEVEL_ALLOY_IMAGE:$TAG"


### PR DESCRIPTION
### Brief description of Pull Request
Fixes some dynamic linking failures we're seeing in Alloy v1.19.0, due to the switch from `TDM-GCC` to `mingw-w64` toolchains in our build pipeline

### Pull Request Details
There are two different paths to consider, both broke due to missing dll's in the final release (in Alloy v1.19.0). 

[Standalone executable/service installation](https://github.com/grafana/alloy/blob/4cd37219590b1623c6843402cfddde5ad4d6ce12/build-tools/build-image/Dockerfile#L54-L56)
This build path includes an older version of `mingw-64` via the viceroy base image. This build has the [-lssp](https://github.com/grafana/alloy/blob/66ee50305df5f3f60b58e7150a53848ab4310867/build-tools/make/packaging.mk#L33) `CGO_LDFLAGS ` flag enabled so that it can properly build alloy, _but_ the dll that this requires, `libssp-0.dll`, isn't shipped anywhere. This PR enforces static linking so that we don't need to ship any extra dll's

[Image build](https://github.com/grafana/alloy/blob/f001028f246b526c59b9af0149260c58808f79d2/Dockerfile.windows#L39)
This build path has a newer version of the `mingw-64` (migrated from `TDM-GCC`) which OOTB statically links against `libssp` , so we don't get the same issue as above. But the introduction of the new toolchain also introduced a new dynamic dependency that was not included in the container runtime (according to claude: `libwinpthread-1.dll`). This PR enforces static linking in order to prevent those errors.

`TDM-GCC` defaulted to static linking by default, whilst `mingw-w64` defaulted to dynamic linking

BEGIN_COMMIT_OVERRIDE
fix(windows): Statically link Windows builds to fix missing DLL errors on startup (#6972)
END_COMMIT_OVERRIDE

### Issue(s) fixed by this Pull Request
https://github.com/grafana/alloy/issues/6970

### PR Checklist
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))