### PR TITLE
fix(loki.source.journal): Dont override configured job label

### DIFF
--- a/internal/component/loki/source/journal/journal_test.go
+++ b/internal/component/loki/source/journal/journal_test.go
@@ -13,6 +13,7 @@ import (
 	cjournal "github.com/coreos/go-systemd/v22/journal"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -63,6 +64,36 @@ func TestJournal(t *testing.T) {
 	`
 		err = testutil.GatherAndCompare(ctrl.PromRegistry, strings.NewReader(expectedMetrics))
 		require.NoError(t, err)
+	})
+
+	t.Run("job label from configured labels overrides component id", func(t *testing.T) {
+		ctrl, err := componenttest.NewControllerFromID(slog.New(slog.DiscardHandler), "loki.source.journal")
+		require.NoError(t, err)
+
+		collector := loki.NewCollectingHandler()
+		defer collector.Stop()
+
+		id := uuid.New()
+
+		go func() {
+			_ = ctrl.Run(t.Context(), Arguments{
+				ForwardTo: []loki.LogsReceiver{collector.Receiver()},
+				MaxAge:    7 * time.Hour,
+				Matches:   "ALLOY_TEST_ID=" + id.String(),
+				Labels:    map[string]string{"job": "custom"},
+			})
+		}()
+
+		err = cjournal.Send(strconv.Itoa(1), cjournal.PriInfo, map[string]string{
+			"ALLOY_TEST_ID": id.String(),
+		})
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			require.Len(c, collector.Received(), 1)
+		}, 5*time.Second, 100*time.Millisecond)
+
+		collected := collector.Received()
+		require.Equal(t, model.LabelValue("custom"), collected[0].Labels["job"])
 	})
 }
 

--- a/internal/component/loki/source/journal/tailer.go
+++ b/internal/component/loki/source/journal/tailer.go
@@ -58,7 +58,9 @@ func newTailer(opts tailerOptions) (*tailer, error) {
 func newTailerWithJournal(opts tailerOptions, journal journal) *tailer {
 	labelMap := make(map[string]string, len(opts.labels)+1)
 	maps.Copy(labelMap, opts.labels)
-	labelMap["job"] = opts.id
+	if labelMap["job"] == "" {
+		labelMap["job"] = opts.id
+	}
 	lbls := labels.FromMap(labelMap)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
### Brief description of Pull Request

Prefer job label from configured labels instead of always using component id.

### Pull Request Details

This is a regression from https://github.com/grafana/alloy/pull/6508.

### Issue(s) fixed by this Pull Request

Fixes: #6980

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
