### PR TITLE
docs: Add recovery steps for a release publish blocked by tag rules

### DIFF
--- a/docs/developer/shepherding-releases.md
+++ b/docs/developer/shepherding-releases.md
@@ -151,6 +151,20 @@ The process for this is exactly the same as a minor release with a few notable e
    necessary.
 4. Patch releases typically do not have RCs.
 
+## Publishing fails with a tag rule violation
+
+Publishing a draft can fail with:
+
+```
+Cannot create ref due to creations being restricted.
+Published releases must have a valid tag
+```
+
+The draft has lost its tag and is trying to publish against its `untagged-<hash>` placeholder. A tag
+ruleset blocks that, so the release stays a draft and nothing has become permanent.
+
+To recover, edit the draft, select the correct tag from the tag dropdown, and publish again.
+
 ## Modifying a PR's CHANGELOG entry post-merge
 
 By default, the semantics of each commit message (derived from PR titles) become the basis for


### PR DESCRIPTION
### Brief description of Pull Request

Documents how to recover when publishing a draft release fails from the new ruleset validation preventing untagged releases, https://github.com/grafana/alloy/settings/rules/21567245. 

### Pull Request Details

We had this happen with the most recent v1.19.1 release, https://github.com/grafana/alloy/releases/tag/untagged-ce745838f1ebd9f128d4, because I ended the release notes through `gh api PATCH`. When doing this if you do not include the tag the release moves to untagged which is not documented AFAICT. There might be other ways to have this happen but the new ruleset should prevent it in the future.


### PR Checklist

- [x] Documentation added
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
