### PR TITLE
fix(controller): Connect data flow edges for module components

### DIFF
--- a/internal/runtime/internal/controller/loader.go
+++ b/internal/runtime/internal/controller/loader.go
@@ -1009,6 +1009,16 @@ func splitPath(id string) (string, string) {
 	return "/" + parent, id
 }
 
+// setDataFlowEdges inspects the given component references and adds data flow
+// edges so that graph views can display how data flows between components.
+//
+// Module components (declared with declare blocks or imported with import.*
+// blocks) only publish their exports once they are evaluated, which happens
+// after the graph has been wired. Since wiring runs only once, the exports of
+// a module component can never be matched against a struct field here; when a
+// reference points at an export field of a module component, a data flow edge
+// is added directly instead, with the module component as the source of the
+// edge.
 func setDataFlowEdges(n dag.Node, refs []astutil.Reference) {
 	otelConsumerType := reflect.TypeOf((*otelcol.Consumer)(nil)).Elem()
 	appendableType := reflect.TypeOf((*storage.Appendable)(nil)).Elem()
@@ -1019,12 +1029,25 @@ func setDataFlowEdges(n dag.Node, refs []astutil.Reference) {
 			if tn, ok := ref.Target.(ComponentNode); ok {
 				exports := tn.Exports()
 				if exports == nil {
+					// The exports of module components are only published
+					// after evaluation, so there is nothing to match against
+					// at wiring time. Referencing an export field still
+					// implies a data flow from the component providing it.
+					if len(ref.Traversal) > 0 {
+						tn.AddDataFlowEdgeTo(cn.NodeID())
+					}
 					continue
 				}
 
 				t := reflect.TypeOf(exports)
 
 				if t.Kind() != reflect.Struct {
+					// Exports published as a map (module components) cannot
+					// be matched against struct fields; connect the edge
+					// directly for the same reason as above.
+					if len(ref.Traversal) > 0 {
+						tn.AddDataFlowEdgeTo(cn.NodeID())
+					}
 					continue
 				}
 

--- a/internal/runtime/internal/controller/loader_dataflow_module_test.go
+++ b/internal/runtime/internal/controller/loader_dataflow_module_test.go
@@ -1,0 +1,181 @@
+package controller
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/syntax/ast"
+	"github.com/grafana/alloy/syntax/diag"
+	"github.com/grafana/alloy/syntax/parser"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// newReproLoader builds a Loader for the issue #4062 regression test. It
+// reuses the in-package test facilities (NewModuleControllerMock backs custom
+// component instantiation); MinStability must be below GenerallyAvailable for
+// testcomponents to load.
+func newReproLoader(t *testing.T) *Loader {
+	t.Helper()
+
+	logger, _ := logging.New(os.Stderr, logging.DefaultOptions)
+	l, err := NewLoader(LoaderOptions{
+		ComponentGlobals: ComponentGlobals{
+			Logger:            logger,
+			TraceProvider:     noop.NewTracerProvider(),
+			DataPath:          t.TempDir(),
+			MinStability:      featuregate.StabilityPublicPreview,
+			OnBlockNodeUpdate: func(BlockNode) {},
+			Registerer:        prometheus.NewRegistry(),
+			NewModuleController: func(_ ModuleControllerOpts) ModuleController {
+				return NewModuleControllerMock()
+			},
+		},
+	})
+	require.NoError(t, err)
+	return l
+}
+
+// reproFileToBlock parses Alloy configuration text into a list of block
+// statements. It mirrors fileToBlock from the external test package, which is
+// not visible from the in-package tests.
+func reproFileToBlock(t *testing.T, bytes []byte) ([]*ast.BlockStmt, diag.Diagnostics) {
+	t.Helper()
+	var diags diag.Diagnostics
+	file, err := parser.ParseFile(t.Name(), bytes)
+
+	var parseDiags diag.Diagnostics
+	if errors.As(err, &parseDiags); parseDiags.HasErrors() {
+		return nil, parseDiags
+	}
+
+	var blocks []*ast.BlockStmt
+	for _, stmt := range file.Body {
+		switch stmt := stmt.(type) {
+		case *ast.BlockStmt:
+			blocks = append(blocks, stmt)
+		default:
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.SeverityLevelError,
+				Message:  "unexpected statement",
+				StartPos: ast.StartPos(stmt).Position(),
+				EndPos:   ast.EndPos(stmt).Position(),
+			})
+		}
+	}
+
+	return blocks, diags
+}
+
+// reproApply assembles Alloy configuration text into the Loader graph and
+// returns the diagnostics produced by Apply so callers can assert a successful
+// load. Note: import.* blocks are config-level blocks and must be passed via
+// the config parameter so that registerImport registers the namespace.
+func reproApply(t *testing.T, l *Loader, components, config, declares []byte) diag.Diagnostics {
+	t.Helper()
+	var diags diag.Diagnostics
+
+	componentBlocks, parseDiags := reproFileToBlock(t, components)
+	diags = append(diags, parseDiags...)
+	if parseDiags.HasErrors() {
+		return diags
+	}
+	configBlocks, parseDiags := reproFileToBlock(t, config)
+	diags = append(diags, parseDiags...)
+	if parseDiags.HasErrors() {
+		return diags
+	}
+	declareBlocks, parseDiags := reproFileToBlock(t, declares)
+	diags = append(diags, parseDiags...)
+	if parseDiags.HasErrors() {
+		return diags
+	}
+
+	l.Apply(ApplyOptions{
+		ComponentBlocks: componentBlocks,
+		ConfigBlocks:    configBlocks,
+		DeclareBlocks:   declareBlocks,
+	})
+	return diags
+}
+
+// moduleDataFlowFixture is the module body: an inner passthrough component
+// whose output is exposed through an export block. It is a minimized form of
+// the reporter's declare "filter" module from issue #4062.
+const moduleDataFlowFixture = `declare "filter" {
+	testcomponents.passthrough "inner" {
+		input = "from-module"
+	}
+
+	export "output" {
+		value = testcomponents.passthrough.inner.output
+	}
+}`
+
+// TestDataFlowEdgesCustomComponent verifies that a data flow edge is created
+// between a custom component instance and its upstream consumer (regression
+// test for grafana/alloy#4062).
+//
+// Instances of custom components defined with declare blocks or imported with
+// import.* blocks were missing the data flow edge towards their upstream
+// consumers, so the module instance only showed its downstream connections in
+// the graph view. The module instance is the exporting side, so the correct
+// edge direction is: instance -> consumer.
+func TestDataFlowEdgesCustomComponent(t *testing.T) {
+	tests := []struct {
+		name         string
+		namespaceRef string // reference path used in the consumer's input expression (also the graph node ID)
+	}{
+		{name: "imported module", namespaceRef: "arcm.filter.inst"},
+		{name: "local declare", namespaceRef: "filter.inst"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				cfg    []byte
+				config []byte
+			)
+			if tc.name == "imported module" {
+				config = []byte(`
+					import.string "arcm" {
+						content = ` + strconv.Quote(moduleDataFlowFixture) + `
+					}
+				`)
+				cfg = []byte(`
+					arcm.filter "inst" {}
+
+					testcomponents.passthrough "upstream" {
+						input = ` + tc.namespaceRef + `.output
+					}
+				`)
+			} else {
+				cfg = []byte(`
+					filter "inst" {}
+
+					testcomponents.passthrough "upstream" {
+						input = ` + tc.namespaceRef + `.output
+					}
+				`)
+			}
+
+			l := newReproLoader(t)
+			d := reproApply(t, l, cfg, config, []byte(moduleDataFlowFixture))
+			require.False(t, d.HasErrors(), "Apply should succeed, got diagnostics: %v", d.Error())
+
+			g := l.Graph()
+			inst, ok := g.GetByID(tc.namespaceRef).(ComponentNode)
+			require.True(t, ok, "node %q should exist and be a ComponentNode (got %v)", tc.namespaceRef, g.GetByID(tc.namespaceRef))
+			upstream, ok := g.GetByID("testcomponents.passthrough.upstream").(ComponentNode)
+			require.True(t, ok, "node testcomponents.passthrough.upstream should exist and be a ComponentNode")
+
+			require.Contains(t, inst.GetDataFlowEdgesTo(), upstream.NodeID(),
+				"module component instance should hold a data flow edge to its upstream consumer")
+		})
+	}
+}


### PR DESCRIPTION
#### PR Description

Module components (defined with `declare` blocks or imported with `import.*` blocks) were never connected to their upstream consumers with a data flow edge, so graph views only showed a module instance's downstream connections: an instance fed by an upstream component appeared to have no input.

The reason is a timing mismatch in `setDataFlowEdges`: module components only publish their exports once they are evaluated, which happens after the graph has been wired, and wiring runs only once. At wiring time the exports of a custom component are therefore either `nil` or a `map`, and both guards in `setDataFlowEdges` (`exports == nil` / `Kind() != reflect.Struct`) skipped the reference entirely, so the edge was never created. Builtin components were unaffected because their nodes are constructed with a non-nil exports struct.

The fix adds the data flow edge directly (module component -> consumer) when a reference points at an export field of a component whose exports cannot be matched against a struct field. References that do not point at an export field are still ignored, and the structured match with its direction special-cases (OTel consumer / appendable types) is untouched for builtin components.

#### Which issue(s) this PR fixes

Fixes #4062

#### Notes to the Reviewer

- The new test asserts graph state right after `Apply` (wiring time), before any evaluation publishes the module exports - exactly the state where the edge was previously lost.
- The test log may contain `field "output" does not exist` messages coming from the module controller mock during evaluation; they are unrelated to the assertion and also appear when the test fails on unfixed code.
- `TestDataFlowEdgesCustomComponent` fails on current `main` in both scenarios (imported module / local declare) with `[]string{} does not contain "testcomponents.passthrough.upstream"`, and passes with this change (controller package suite: ok, 0 failures; gofmt / go vet clean).

#### PR Checklist

- [ ] CHANGELOG.md updated _(left to release tooling, which derives changelog entries from the PR title)_
- [x] Tests updated
