### PR TITLE
feat(database_observability): Add index_stats collectors to mysql and postgres

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -48,7 +48,8 @@ The following collectors are configurable:
 | `setup_actors`    | Check and update `performance_schema.setup_actors` settings. | yes                |
 | `locks`           | Collect queries that are waiting/blocking other queries.     | no                 |
 | `explain_plans`   | Collect explain plans information.                           | yes                |
-| `index_stats`     | Collect per-index fetch counts from `performance_schema.table_io_waits_summary_by_index_usage`, for missing-index and unused-index detection. | no |
+| `table_stats`     | Collect the no-index (`INDEX_NAME` is `NULL`) fetch count per table from `performance_schema.table_io_waits_summary_by_index_usage`, for missing-index detection. | no |
+| `index_stats`     | Collect the per-index fetch count from `performance_schema.table_io_waits_summary_by_index_usage`, for unused-index detection. | no |
 
 ## Blocks
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -48,7 +48,7 @@ The following collectors are configurable:
 | `setup_actors`    | Check and update `performance_schema.setup_actors` settings. | yes                |
 | `locks`           | Collect queries that are waiting/blocking other queries.     | no                 |
 | `explain_plans`   | Collect explain plans information.                           | yes                |
-| `index_io_waits`  | Collect per-index fetch counts from `performance_schema.table_io_waits_summary_by_index_usage`, for missing-index and unused-index detection. | no |
+| `index_stats`     | Collect per-index fetch counts from `performance_schema.table_io_waits_summary_by_index_usage`, for missing-index and unused-index detection. | no |
 
 ## Blocks
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -49,7 +49,7 @@ The following collectors are configurable:
 | `locks`           | Collect queries that are waiting/blocking other queries.     | no                 |
 | `explain_plans`   | Collect explain plans information.                           | yes                |
 | `table_stats`     | Collect the no-index (`INDEX_NAME` is `NULL`) fetch count per table from `performance_schema.table_io_waits_summary_by_index_usage`, for missing-index detection. | no |
-| `index_stats`     | Collect the per-index fetch count from `performance_schema.table_io_waits_summary_by_index_usage`, for unused-index detection. | no |
+| `index_stats`     | Collect the per-index fetch count from `performance_schema.table_io_waits_summary_by_index_usage`, and (MySQL 5.6.6+) per-index size from `mysql.innodb_index_stats`, for unused-index detection. | no |
 
 ## Blocks
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -48,6 +48,7 @@ The following collectors are configurable:
 | `setup_actors`    | Check and update `performance_schema.setup_actors` settings. | yes                |
 | `locks`           | Collect queries that are waiting/blocking other queries.     | no                 |
 | `explain_plans`   | Collect explain plans information.                           | yes                |
+| `index_io_waits`  | Collect per-index fetch counts from `performance_schema.table_io_waits_summary_by_index_usage`, for missing-index and unused-index detection. | no |
 
 ## Blocks
 

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -56,6 +56,7 @@ The following collectors are configurable:
 | Name             | Description                                                           | Enabled by default |
 |------------------|-----------------------------------------------------------------------|--------------------|
 | `explain_plans`  | Collect query explain plans.                                          | yes                |
+| `index_stats`    | Collect table scan and index usage statistics, across every database the connection can reach, for missing-index and unused-index detection. | no |
 | `logs`           | Process PostgreSQL logs and export error metrics.                     | yes                |
 | `query_details`  | Collect queries information.                                          | yes                |
 | `query_samples`  | Collect query samples and wait events information.                    | yes                |

--- a/docs/sources/reference/components/database_observability/database_observability.postgres.md
+++ b/docs/sources/reference/components/database_observability/database_observability.postgres.md
@@ -56,7 +56,8 @@ The following collectors are configurable:
 | Name             | Description                                                           | Enabled by default |
 |------------------|-----------------------------------------------------------------------|--------------------|
 | `explain_plans`  | Collect query explain plans.                                          | yes                |
-| `index_stats`    | Collect table scan and index usage statistics, across every database the connection can reach, for missing-index and unused-index detection. | no |
+| `table_stats`    | Collect table scan statistics from `pg_stat_user_tables`, across every database the connection can reach, for missing-index detection. | no |
+| `index_stats`    | Collect per-index usage statistics from `pg_stat_user_indexes`, across every database the connection can reach, for unused-index detection. | no |
 | `logs`           | Process PostgreSQL logs and export error metrics.                     | yes                |
 | `query_details`  | Collect queries information.                                          | yes                |
 | `query_samples`  | Collect query samples and wait events information.                    | yes                |

--- a/internal/component/database_observability/mysql/collector/exclude_schemas.go
+++ b/internal/component/database_observability/mysql/collector/exclude_schemas.go
@@ -1,6 +1,10 @@
 package collector
 
-import "github.com/grafana/alloy/internal/component/database_observability"
+import (
+	"strings"
+
+	"github.com/grafana/alloy/internal/component/database_observability"
+)
 
 var excludedSchemas = []string{"mysql", "performance_schema", "sys", "information_schema"}
 
@@ -15,4 +19,30 @@ func buildExcludedSchemasClause(schemas []string) string {
 	all = append(all, excludedSchemas...)
 	all = append(all, schemas...)
 	return database_observability.BuildExclusionClause(all)
+}
+
+// excludedSchemasArgs returns the combined default + custom excluded schemas
+// as query arguments, for callers that bind them as placeholders (`?`)
+// instead of formatting them into the SQL text.
+func excludedSchemasArgs(schemas []string) []any {
+	all := make([]string, 0, len(excludedSchemas)+len(schemas))
+	all = append(all, excludedSchemas...)
+	all = append(all, schemas...)
+
+	args := make([]any, len(all))
+	for i, s := range all {
+		args[i] = s
+	}
+	return args
+}
+
+// sqlPlaceholders returns a comma-separated list of n "?" placeholders, for
+// building a parameterized `IN (...)` / `NOT IN (...)` clause whose argument
+// count is dynamic.
+func sqlPlaceholders(n int) string {
+	placeholders := make([]string, n)
+	for i := range placeholders {
+		placeholders[i] = "?"
+	}
+	return strings.Join(placeholders, ", ")
 }

--- a/internal/component/database_observability/mysql/collector/index_io_waits.go
+++ b/internal/component/database_observability/mysql/collector/index_io_waits.go
@@ -1,0 +1,115 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+)
+
+// IndexIOWaitsCollector emits the minimal set of metrics needed for the
+// missing-index and unused-index KG insights: the fetch-operation count per
+// (schema, table, index) row of performance_schema.table_io_waits_summary_by_index_usage.
+// An index="NONE" row's fetch count is the "no index used" signal (missing-index);
+// each named row's fetch count is the per-index usage signal (unused-index).
+//
+// Named and labeled to match the metric mysqld_exporter's perf_schema.indexiowaits
+// scraper already emits (mysql_perf_schema_index_io_waits_total{schema,name,index,operation}),
+// but restricted to the fetch operation, which is all either insight reads.
+const IndexIOWaitsCollector = "index_io_waits"
+
+const selectIndexIOWaits = `
+	SELECT OBJECT_SCHEMA, OBJECT_NAME, ifnull(INDEX_NAME, 'NONE') as INDEX_NAME, COUNT_FETCH
+	FROM performance_schema.table_io_waits_summary_by_index_usage
+	WHERE OBJECT_SCHEMA NOT IN %s`
+
+var indexIOWaitsFetchDesc = prometheus.NewDesc(
+	"mysql_perf_schema_index_io_waits_total",
+	"The total number of index I/O wait events for each index and operation.",
+	[]string{"schema", "name", "index", "operation"}, nil,
+)
+
+type IndexIOWaitsArguments struct {
+	DB             *sql.DB
+	ExcludeSchemas []string
+	Registry       *prometheus.Registry
+
+	Logger *slog.Logger
+}
+
+type IndexIOWaits struct {
+	dbConnection   *sql.DB
+	excludeSchemas []string
+	registry       *prometheus.Registry
+
+	logger  *slog.Logger
+	running *atomic.Bool
+}
+
+func NewIndexIOWaits(args IndexIOWaitsArguments) (*IndexIOWaits, error) {
+	return &IndexIOWaits{
+		dbConnection:   args.DB,
+		excludeSchemas: args.ExcludeSchemas,
+		registry:       args.Registry,
+		logger:         args.Logger.With("collector", IndexIOWaitsCollector),
+		running:        &atomic.Bool{},
+	}, nil
+}
+
+func (c *IndexIOWaits) Name() string {
+	return IndexIOWaitsCollector
+}
+
+func (c *IndexIOWaits) Start(_ context.Context) error {
+	if err := c.registry.Register(c); err != nil {
+		return err
+	}
+	c.running.Store(true)
+	return nil
+}
+
+func (c *IndexIOWaits) Stopped() bool {
+	return !c.running.Load()
+}
+
+func (c *IndexIOWaits) Stop() {
+	c.registry.Unregister(c)
+	c.running.Store(false)
+}
+
+// Describe implements prometheus.Collector.
+func (c *IndexIOWaits) Describe(ch chan<- *prometheus.Desc) {
+	ch <- indexIOWaitsFetchDesc
+}
+
+// Collect implements prometheus.Collector. It runs synchronously at scrape time.
+func (c *IndexIOWaits) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	query := fmt.Sprintf(selectIndexIOWaits, buildExcludedSchemasClause(c.excludeSchemas))
+	rows, err := c.dbConnection.QueryContext(ctx, query)
+	if err != nil {
+		c.logger.Error("failed to query table_io_waits_summary_by_index_usage", "err", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var objectSchema, objectName, indexName string
+		var countFetch uint64
+
+		if err := rows.Scan(&objectSchema, &objectName, &indexName, &countFetch); err != nil {
+			c.logger.Error("failed to scan table_io_waits_summary_by_index_usage row", "err", err)
+			return
+		}
+
+		ch <- prometheus.MustNewConstMetric(indexIOWaitsFetchDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName, indexName, "fetch")
+	}
+
+	if err := rows.Err(); err != nil {
+		c.logger.Error("error iterating table_io_waits_summary_by_index_usage rows", "err", err)
+	}
+}

--- a/internal/component/database_observability/mysql/collector/index_io_waits_test.go
+++ b/internal/component/database_observability/mysql/collector/index_io_waits_test.go
@@ -1,0 +1,49 @@
+package collector
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
+)
+
+func TestIndexIOWaits(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	registry := prometheus.NewRegistry()
+
+	c, err := NewIndexIOWaits(IndexIOWaitsArguments{
+		DB:       db,
+		Registry: registry,
+		Logger:   util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Start(t.Context()))
+	defer c.Stop()
+
+	mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
+				AddRow("books_store", "books", "NONE", 39).
+				AddRow("books_store", "books", "idx_books_title", 0),
+		)
+
+	expected := `
+	# HELP mysql_perf_schema_index_io_waits_total The total number of index I/O wait events for each index and operation.
+	# TYPE mysql_perf_schema_index_io_waits_total counter
+	mysql_perf_schema_index_io_waits_total{index="NONE",name="books",operation="fetch",schema="books_store"} 39
+	mysql_perf_schema_index_io_waits_total{index="idx_books_title",name="books",operation="fetch",schema="books_store"} 0
+`
+
+	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -6,13 +6,16 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 )
 
-// IndexStatsCollector emits the minimal per-index metric needed for the
+// IndexStatsCollector emits the minimal per-index metrics needed for the
 // unused-index KG insight: the fetch count of each named-index row per
-// index, from performance_schema.table_io_waits_summary_by_index_usage.
+// index, from performance_schema.table_io_waits_summary_by_index_usage, and
+// (MySQL >= 5.6.6 only, see minIndexSizeEngineVersion) its size in bytes,
+// from mysql.innodb_index_stats.
 const IndexStatsCollector = "index_stats"
 
 const selectIndexIOWaits = `
@@ -20,15 +23,41 @@ const selectIndexIOWaits = `
 	FROM performance_schema.table_io_waits_summary_by_index_usage
 	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN (%s)`
 
-var indexStatsIdxScanDesc = prometheus.NewDesc(
-	prometheus.BuildFQName("mysql", "index_stats", "idx_scan_total"),
-	"Number of row fetches against this index",
-	[]string{labelSchema, "table", "index"}, nil,
+// mysql.innodb_index_stats holds InnoDB's persistent optimizer statistics,
+// refreshed by MySQL itself (never by us) -- introduced in MySQL 5.6.6, its
+// schema (and the "size" stat, in pages) hasn't changed since. Reading it
+// requires the monitoring role to be granted SELECT on this one table, which
+// is not part of today's default grant set (see deployment_tools).
+const selectIndexSizeBytes = `
+	SELECT database_name, table_name, index_name, stat_value * @@innodb_page_size
+	FROM mysql.innodb_index_stats
+	WHERE stat_name = 'size' AND database_name NOT IN (%s)`
+
+// minIndexSizeEngineVersion is the first MySQL version where
+// mysql.innodb_index_stats exists at all (persistent optimizer statistics,
+// introduced 5.6.6) -- versions older than this have no size source, so the
+// query is skipped entirely below it rather than attempted and failing.
+var minIndexSizeEngineVersion = semver.MustParse("5.6.6")
+
+var indexLabels = []string{labelSchema, labelTable, "index"}
+
+var (
+	indexStatsIdxScanDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("mysql", "index_stats", "idx_scan_total"),
+		"Number of row fetches against this index",
+		indexLabels, nil,
+	)
+	indexStatsSizeBytesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("mysql", "index_stats", "size_bytes"),
+		"Total disk space used by this index, in bytes",
+		indexLabels, nil,
+	)
 )
 
 type IndexStatsArguments struct {
 	DB             *sql.DB
 	ExcludeSchemas []string
+	EngineVersion  semver.Version
 	Registry       *prometheus.Registry
 
 	Logger *slog.Logger
@@ -37,6 +66,7 @@ type IndexStatsArguments struct {
 type IndexStats struct {
 	dbConnection   *sql.DB
 	excludeSchemas []string
+	engineVersion  semver.Version
 	registry       *prometheus.Registry
 
 	logger  *slog.Logger
@@ -47,6 +77,7 @@ func NewIndexStats(args IndexStatsArguments) (*IndexStats, error) {
 	return &IndexStats{
 		dbConnection:   args.DB,
 		excludeSchemas: args.ExcludeSchemas,
+		engineVersion:  args.EngineVersion,
 		registry:       args.Registry,
 		logger:         args.Logger.With("collector", IndexStatsCollector),
 		running:        &atomic.Bool{},
@@ -77,12 +108,21 @@ func (c *IndexStats) Stop() {
 // Describe implements prometheus.Collector.
 func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
 	ch <- indexStatsIdxScanDesc
+	ch <- indexStatsSizeBytesDesc
 }
 
 // Collect implements prometheus.Collector. It runs synchronously at scrape time.
 func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
+	c.collectIdxScan(ctx, ch)
+
+	if c.engineVersion.GE(minIndexSizeEngineVersion) {
+		c.collectIndexSize(ctx, ch)
+	}
+}
+
+func (c *IndexStats) collectIdxScan(ctx context.Context, ch chan<- prometheus.Metric) {
 	args := excludedSchemasArgs(c.excludeSchemas)
 	query := fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))
 	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
@@ -106,5 +146,32 @@ func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 
 	if err := rows.Err(); err != nil {
 		c.logger.Error("error iterating table_io_waits_summary_by_index_usage rows", "err", err)
+	}
+}
+
+func (c *IndexStats) collectIndexSize(ctx context.Context, ch chan<- prometheus.Metric) {
+	args := excludedSchemasArgs(c.excludeSchemas)
+	query := fmt.Sprintf(selectIndexSizeBytes, sqlPlaceholders(len(args)))
+	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
+	if err != nil {
+		c.logger.Error("failed to query mysql.innodb_index_stats", "err", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var databaseName, tableName, indexName string
+		var sizeBytes float64
+
+		if err := rows.Scan(&databaseName, &tableName, &indexName, &sizeBytes); err != nil {
+			c.logger.Error("failed to scan mysql.innodb_index_stats row", "err", err)
+			return
+		}
+
+		ch <- prometheus.MustNewConstMetric(indexStatsSizeBytesDesc, prometheus.GaugeValue, sizeBytes, databaseName, tableName, indexName)
+	}
+
+	if err := rows.Err(); err != nil {
+		c.logger.Error("error iterating mysql.innodb_index_stats rows", "err", err)
 	}
 }

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -22,7 +22,7 @@ const IndexStatsCollector = "index_stats"
 const selectIndexIOWaits = `
 	SELECT OBJECT_SCHEMA, OBJECT_NAME, INDEX_NAME, COUNT_FETCH
 	FROM performance_schema.table_io_waits_summary_by_index_usage
-	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN %s`
+	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN (%s)`
 
 type IndexStatsArguments struct {
 	DB             *sql.DB
@@ -81,8 +81,9 @@ func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
 func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
-	query := fmt.Sprintf(selectIndexIOWaits, buildExcludedSchemasClause(c.excludeSchemas))
-	rows, err := c.dbConnection.QueryContext(ctx, query)
+	args := excludedSchemasArgs(c.excludeSchemas)
+	query := fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))
+	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
 	if err != nil {
 		c.logger.Error("failed to query table_io_waits_summary_by_index_usage", "err", err)
 		return

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/atomic"
 )
 
-// IndexIOWaitsCollector emits the minimal set of metrics needed for the
+// IndexStatsCollector emits the minimal set of metrics needed for the
 // missing-index and unused-index KG insights: the fetch-operation count per
 // (schema, table, index) row of performance_schema.table_io_waits_summary_by_index_usage.
 // An index="NONE" row's fetch count is the "no index used" signal (missing-index);
@@ -19,7 +19,7 @@ import (
 // Named and labeled to match the metric mysqld_exporter's perf_schema.indexiowaits
 // scraper already emits (mysql_perf_schema_index_io_waits_total{schema,name,index,operation}),
 // but restricted to the fetch operation, which is all either insight reads.
-const IndexIOWaitsCollector = "index_io_waits"
+const IndexStatsCollector = "index_stats"
 
 const selectIndexIOWaits = `
 	SELECT OBJECT_SCHEMA, OBJECT_NAME, ifnull(INDEX_NAME, 'NONE') as INDEX_NAME, COUNT_FETCH
@@ -32,7 +32,7 @@ var indexIOWaitsFetchDesc = prometheus.NewDesc(
 	[]string{"schema", "name", "index", "operation"}, nil,
 )
 
-type IndexIOWaitsArguments struct {
+type IndexStatsArguments struct {
 	DB             *sql.DB
 	ExcludeSchemas []string
 	Registry       *prometheus.Registry
@@ -40,7 +40,7 @@ type IndexIOWaitsArguments struct {
 	Logger *slog.Logger
 }
 
-type IndexIOWaits struct {
+type IndexStats struct {
 	dbConnection   *sql.DB
 	excludeSchemas []string
 	registry       *prometheus.Registry
@@ -49,21 +49,21 @@ type IndexIOWaits struct {
 	running *atomic.Bool
 }
 
-func NewIndexIOWaits(args IndexIOWaitsArguments) (*IndexIOWaits, error) {
-	return &IndexIOWaits{
+func NewIndexStats(args IndexStatsArguments) (*IndexStats, error) {
+	return &IndexStats{
 		dbConnection:   args.DB,
 		excludeSchemas: args.ExcludeSchemas,
 		registry:       args.Registry,
-		logger:         args.Logger.With("collector", IndexIOWaitsCollector),
+		logger:         args.Logger.With("collector", IndexStatsCollector),
 		running:        &atomic.Bool{},
 	}, nil
 }
 
-func (c *IndexIOWaits) Name() string {
-	return IndexIOWaitsCollector
+func (c *IndexStats) Name() string {
+	return IndexStatsCollector
 }
 
-func (c *IndexIOWaits) Start(_ context.Context) error {
+func (c *IndexStats) Start(_ context.Context) error {
 	if err := c.registry.Register(c); err != nil {
 		return err
 	}
@@ -71,22 +71,22 @@ func (c *IndexIOWaits) Start(_ context.Context) error {
 	return nil
 }
 
-func (c *IndexIOWaits) Stopped() bool {
+func (c *IndexStats) Stopped() bool {
 	return !c.running.Load()
 }
 
-func (c *IndexIOWaits) Stop() {
+func (c *IndexStats) Stop() {
 	c.registry.Unregister(c)
 	c.running.Store(false)
 }
 
 // Describe implements prometheus.Collector.
-func (c *IndexIOWaits) Describe(ch chan<- *prometheus.Desc) {
+func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
 	ch <- indexIOWaitsFetchDesc
 }
 
 // Collect implements prometheus.Collector. It runs synchronously at scrape time.
-func (c *IndexIOWaits) Collect(ch chan<- prometheus.Metric) {
+func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
 	query := fmt.Sprintf(selectIndexIOWaits, buildExcludedSchemasClause(c.excludeSchemas))

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -10,19 +10,21 @@ import (
 	"go.uber.org/atomic"
 )
 
-// IndexStatsCollector emits the minimal set of per-index metrics needed for
-// the unused-index KG insight: the fetch-operation count of each named-index
-// row per index, from performance_schema.table_io_waits_summary_by_index_usage.
-//
-// Named and labeled to match the metric mysqld_exporter's perf_schema.indexiowaits
-// scraper already emits (mysql_perf_schema_index_io_waits_total{schema,name,index,operation}),
-// but restricted to the fetch operation on named-index rows.
+// IndexStatsCollector emits the minimal per-index metric needed for the
+// unused-index KG insight: the fetch count of each named-index row per
+// index, from performance_schema.table_io_waits_summary_by_index_usage.
 const IndexStatsCollector = "index_stats"
 
 const selectIndexIOWaits = `
 	SELECT OBJECT_SCHEMA, OBJECT_NAME, INDEX_NAME, COUNT_FETCH
 	FROM performance_schema.table_io_waits_summary_by_index_usage
 	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN (%s)`
+
+var indexStatsIdxScanDesc = prometheus.NewDesc(
+	prometheus.BuildFQName("mysql", "index_stats", "idx_scan_total"),
+	"Number of row fetches against this index",
+	[]string{labelSchema, "table", "index"}, nil,
+)
 
 type IndexStatsArguments struct {
 	DB             *sql.DB
@@ -74,7 +76,7 @@ func (c *IndexStats) Stop() {
 
 // Describe implements prometheus.Collector.
 func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
-	ch <- indexIOWaitsFetchDesc
+	ch <- indexStatsIdxScanDesc
 }
 
 // Collect implements prometheus.Collector. It runs synchronously at scrape time.
@@ -99,7 +101,7 @@ func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 			return
 		}
 
-		ch <- prometheus.MustNewConstMetric(indexIOWaitsFetchDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName, indexName, "fetch")
+		ch <- prometheus.MustNewConstMetric(indexStatsIdxScanDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName, indexName)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/component/database_observability/mysql/collector/index_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/index_stats_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -14,36 +15,84 @@ import (
 )
 
 func TestIndexStats(t *testing.T) {
-	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-	require.NoError(t, err)
-	defer db.Close()
+	t.Run("below minIndexSizeEngineVersion, size query is skipped", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
 
-	registry := prometheus.NewRegistry()
+		registry := prometheus.NewRegistry()
 
-	c, err := NewIndexStats(IndexStatsArguments{
-		DB:       db,
-		Registry: registry,
-		Logger:   util.TestAlloyLogger(t).Slog(),
-	})
-	require.NoError(t, err)
+		c, err := NewIndexStats(IndexStatsArguments{
+			DB:            db,
+			EngineVersion: semver.MustParse("5.5.62"),
+			Registry:      registry,
+			Logger:        util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
 
-	require.NoError(t, c.Start(t.Context()))
-	defer c.Stop()
+		require.NoError(t, c.Start(t.Context()))
+		defer c.Stop()
 
-	args := excludedSchemasArgs(nil)
-	mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
-		WithArgs(toDriverValues(args)...).RowsWillBeClosed().
-		WillReturnRows(
-			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
-				AddRow("books_store", "books", "idx_books_title", 0),
-		)
+		args := excludedSchemasArgs(nil)
+		mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
+			WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
+					AddRow("books_store", "books", "idx_books_title", 0),
+			)
 
-	expected := `
-	# HELP mysql_index_stats_idx_scan_total Number of row fetches against this index
-	# TYPE mysql_index_stats_idx_scan_total counter
-	mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
+		expected := `
+		# HELP mysql_index_stats_idx_scan_total Number of row fetches against this index
+		# TYPE mysql_index_stats_idx_scan_total counter
+		mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
 `
 
-	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
-	require.NoError(t, mock.ExpectationsWereMet())
+		require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("at or above minIndexSizeEngineVersion, size is collected from mysql.innodb_index_stats", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		registry := prometheus.NewRegistry()
+
+		c, err := NewIndexStats(IndexStatsArguments{
+			DB:            db,
+			EngineVersion: semver.MustParse("8.0.36"),
+			Registry:      registry,
+			Logger:        util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, c.Start(t.Context()))
+		defer c.Stop()
+
+		args := excludedSchemasArgs(nil)
+		mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
+			WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
+					AddRow("books_store", "books", "idx_books_title", 0),
+			)
+		mock.ExpectQuery(fmt.Sprintf(selectIndexSizeBytes, sqlPlaceholders(len(args)))).
+			WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"database_name", "table_name", "index_name", "size_bytes"}).
+					AddRow("books_store", "books", "idx_books_title", 14196736),
+			)
+
+		expected := `
+		# HELP mysql_index_stats_idx_scan_total Number of row fetches against this index
+		# TYPE mysql_index_stats_idx_scan_total counter
+		mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
+		# HELP mysql_index_stats_size_bytes Total disk space used by this index, in bytes
+		# TYPE mysql_index_stats_size_bytes gauge
+		mysql_index_stats_size_bytes{index="idx_books_title",schema="books_store",table="books"} 1.4196736e+07
+`
+
+		require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }

--- a/internal/component/database_observability/mysql/collector/index_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/index_stats_test.go
@@ -39,9 +39,9 @@ func TestIndexStats(t *testing.T) {
 		)
 
 	expected := `
-	# HELP mysql_perf_schema_index_io_waits_total The total number of index I/O wait events for each index and operation.
-	# TYPE mysql_perf_schema_index_io_waits_total counter
-	mysql_perf_schema_index_io_waits_total{index="idx_books_title",name="books",operation="fetch",schema="books_store"} 0
+	# HELP mysql_index_stats_idx_scan_total Number of row fetches against this index
+	# TYPE mysql_index_stats_idx_scan_total counter
+	mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
 `
 
 	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))

--- a/internal/component/database_observability/mysql/collector/index_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/index_stats_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/grafana/alloy/internal/util"
 )
 
-func TestIndexIOWaits(t *testing.T) {
+func TestIndexStats(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	require.NoError(t, err)
 	defer db.Close()
 
 	registry := prometheus.NewRegistry()
 
-	c, err := NewIndexIOWaits(IndexIOWaitsArguments{
+	c, err := NewIndexStats(IndexStatsArguments{
 		DB:       db,
 		Registry: registry,
 		Logger:   util.TestAlloyLogger(t).Slog(),

--- a/internal/component/database_observability/mysql/collector/index_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/index_stats_test.go
@@ -30,7 +30,9 @@ func TestIndexStats(t *testing.T) {
 	require.NoError(t, c.Start(t.Context()))
 	defer c.Stop()
 
-	mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+	args := excludedSchemasArgs(nil)
+	mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
+		WithArgs(toDriverValues(args)...).RowsWillBeClosed().
 		WillReturnRows(
 			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
 				AddRow("books_store", "books", "idx_books_title", 0),

--- a/internal/component/database_observability/mysql/collector/stats_registration_test.go
+++ b/internal/component/database_observability/mysql/collector/stats_registration_test.go
@@ -1,0 +1,36 @@
+package collector
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
+)
+
+// TestTableStatsAndIndexStatsShareRegistry guards against a regression where
+// TableStats and IndexStats fail to both register on the single registry the
+// component actually shares them on (e.g. if a future change makes them
+// declare an identical metric descriptor again). Per-collector tests each use
+// their own fresh registry and can't catch this; only registering both
+// together, as the component does, can.
+func TestTableStatsAndIndexStatsShareRegistry(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	registry := prometheus.NewRegistry()
+	logger := util.TestAlloyLogger(t).Slog()
+
+	tableStats, err := NewTableStats(TableStatsArguments{DB: db, Registry: registry, Logger: logger})
+	require.NoError(t, err)
+	require.NoError(t, tableStats.Start(t.Context()))
+	defer tableStats.Stop()
+
+	indexStats, err := NewIndexStats(IndexStatsArguments{DB: db, Registry: registry, Logger: logger})
+	require.NoError(t, err)
+	require.NoError(t, indexStats.Start(t.Context()))
+	defer indexStats.Stop()
+}

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -10,21 +10,28 @@ import (
 	"go.uber.org/atomic"
 )
 
-// IndexStatsCollector emits the minimal set of per-index metrics needed for
-// the unused-index KG insight: the fetch-operation count of each named-index
-// row per index, from performance_schema.table_io_waits_summary_by_index_usage.
+// TableStatsCollector emits the minimal set of table-level metrics needed for
+// the missing-index KG insight: the fetch-operation count of the index="NONE"
+// ("no index used") row per table, from
+// performance_schema.table_io_waits_summary_by_index_usage.
 //
 // Named and labeled to match the metric mysqld_exporter's perf_schema.indexiowaits
 // scraper already emits (mysql_perf_schema_index_io_waits_total{schema,name,index,operation}),
-// but restricted to the fetch operation on named-index rows.
-const IndexStatsCollector = "index_stats"
+// but restricted to the fetch operation on the table-level (no-index) row.
+const TableStatsCollector = "table_stats"
 
-const selectIndexIOWaits = `
-	SELECT OBJECT_SCHEMA, OBJECT_NAME, INDEX_NAME, COUNT_FETCH
+const selectTableIOWaitsNoIndex = `
+	SELECT OBJECT_SCHEMA, OBJECT_NAME, COUNT_FETCH
 	FROM performance_schema.table_io_waits_summary_by_index_usage
-	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN %s`
+	WHERE INDEX_NAME IS NULL AND OBJECT_SCHEMA NOT IN %s`
 
-type IndexStatsArguments struct {
+var indexIOWaitsFetchDesc = prometheus.NewDesc(
+	"mysql_perf_schema_index_io_waits_total",
+	"The total number of index I/O wait events for each index and operation.",
+	[]string{"schema", "name", "index", "operation"}, nil,
+)
+
+type TableStatsArguments struct {
 	DB             *sql.DB
 	ExcludeSchemas []string
 	Registry       *prometheus.Registry
@@ -32,7 +39,7 @@ type IndexStatsArguments struct {
 	Logger *slog.Logger
 }
 
-type IndexStats struct {
+type TableStats struct {
 	dbConnection   *sql.DB
 	excludeSchemas []string
 	registry       *prometheus.Registry
@@ -41,21 +48,21 @@ type IndexStats struct {
 	running *atomic.Bool
 }
 
-func NewIndexStats(args IndexStatsArguments) (*IndexStats, error) {
-	return &IndexStats{
+func NewTableStats(args TableStatsArguments) (*TableStats, error) {
+	return &TableStats{
 		dbConnection:   args.DB,
 		excludeSchemas: args.ExcludeSchemas,
 		registry:       args.Registry,
-		logger:         args.Logger.With("collector", IndexStatsCollector),
+		logger:         args.Logger.With("collector", TableStatsCollector),
 		running:        &atomic.Bool{},
 	}, nil
 }
 
-func (c *IndexStats) Name() string {
-	return IndexStatsCollector
+func (c *TableStats) Name() string {
+	return TableStatsCollector
 }
 
-func (c *IndexStats) Start(_ context.Context) error {
+func (c *TableStats) Start(_ context.Context) error {
 	if err := c.registry.Register(c); err != nil {
 		return err
 	}
@@ -63,25 +70,25 @@ func (c *IndexStats) Start(_ context.Context) error {
 	return nil
 }
 
-func (c *IndexStats) Stopped() bool {
+func (c *TableStats) Stopped() bool {
 	return !c.running.Load()
 }
 
-func (c *IndexStats) Stop() {
+func (c *TableStats) Stop() {
 	c.registry.Unregister(c)
 	c.running.Store(false)
 }
 
 // Describe implements prometheus.Collector.
-func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
+func (c *TableStats) Describe(ch chan<- *prometheus.Desc) {
 	ch <- indexIOWaitsFetchDesc
 }
 
 // Collect implements prometheus.Collector. It runs synchronously at scrape time.
-func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
+func (c *TableStats) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
-	query := fmt.Sprintf(selectIndexIOWaits, buildExcludedSchemasClause(c.excludeSchemas))
+	query := fmt.Sprintf(selectTableIOWaitsNoIndex, buildExcludedSchemasClause(c.excludeSchemas))
 	rows, err := c.dbConnection.QueryContext(ctx, query)
 	if err != nil {
 		c.logger.Error("failed to query table_io_waits_summary_by_index_usage", "err", err)
@@ -90,15 +97,15 @@ func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 	defer rows.Close()
 
 	for rows.Next() {
-		var objectSchema, objectName, indexName string
+		var objectSchema, objectName string
 		var countFetch uint64
 
-		if err := rows.Scan(&objectSchema, &objectName, &indexName, &countFetch); err != nil {
+		if err := rows.Scan(&objectSchema, &objectName, &countFetch); err != nil {
 			c.logger.Error("failed to scan table_io_waits_summary_by_index_usage row", "err", err)
 			return
 		}
 
-		ch <- prometheus.MustNewConstMetric(indexIOWaitsFetchDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName, indexName, "fetch")
+		ch <- prometheus.MustNewConstMetric(indexIOWaitsFetchDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName, "NONE", "fetch")
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -21,12 +21,15 @@ const selectTableIOWaitsNoIndex = `
 	FROM performance_schema.table_io_waits_summary_by_index_usage
 	WHERE INDEX_NAME IS NULL AND OBJECT_SCHEMA NOT IN (%s)`
 
-const labelSchema = "schema"
+const (
+	labelSchema = "schema"
+	labelTable  = "table"
+)
 
 var tableStatsSeqScanDesc = prometheus.NewDesc(
 	prometheus.BuildFQName("mysql", "table_stats", "seq_scan_total"),
 	"Number of row fetches against this table that did not use an index",
-	[]string{labelSchema, "table"}, nil,
+	[]string{labelSchema, labelTable}, nil,
 )
 
 type TableStatsArguments struct {

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -10,14 +10,10 @@ import (
 	"go.uber.org/atomic"
 )
 
-// TableStatsCollector emits the minimal set of table-level metrics needed for
-// the missing-index KG insight: the fetch-operation count of the index="NONE"
-// ("no index used") row per table, from
+// TableStatsCollector emits the minimal table-level metric needed for the
+// missing-index KG insight: the fetch count of the index="NONE" ("no index
+// used") row per table, from
 // performance_schema.table_io_waits_summary_by_index_usage.
-//
-// Named and labeled to match the metric mysqld_exporter's perf_schema.indexiowaits
-// scraper already emits (mysql_perf_schema_index_io_waits_total{schema,name,index,operation}),
-// but restricted to the fetch operation on the table-level (no-index) row.
 const TableStatsCollector = "table_stats"
 
 const selectTableIOWaitsNoIndex = `
@@ -25,10 +21,12 @@ const selectTableIOWaitsNoIndex = `
 	FROM performance_schema.table_io_waits_summary_by_index_usage
 	WHERE INDEX_NAME IS NULL AND OBJECT_SCHEMA NOT IN (%s)`
 
-var indexIOWaitsFetchDesc = prometheus.NewDesc(
-	"mysql_perf_schema_index_io_waits_total",
-	"The total number of index I/O wait events for each index and operation.",
-	[]string{"schema", "name", "index", "operation"}, nil,
+const labelSchema = "schema"
+
+var tableStatsSeqScanDesc = prometheus.NewDesc(
+	prometheus.BuildFQName("mysql", "table_stats", "seq_scan_total"),
+	"Number of row fetches against this table that did not use an index",
+	[]string{labelSchema, "table"}, nil,
 )
 
 type TableStatsArguments struct {
@@ -81,7 +79,7 @@ func (c *TableStats) Stop() {
 
 // Describe implements prometheus.Collector.
 func (c *TableStats) Describe(ch chan<- *prometheus.Desc) {
-	ch <- indexIOWaitsFetchDesc
+	ch <- tableStatsSeqScanDesc
 }
 
 // Collect implements prometheus.Collector. It runs synchronously at scrape time.
@@ -106,7 +104,7 @@ func (c *TableStats) Collect(ch chan<- prometheus.Metric) {
 			return
 		}
 
-		ch <- prometheus.MustNewConstMetric(indexIOWaitsFetchDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName, "NONE", "fetch")
+		ch <- prometheus.MustNewConstMetric(tableStatsSeqScanDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -23,7 +23,7 @@ const TableStatsCollector = "table_stats"
 const selectTableIOWaitsNoIndex = `
 	SELECT OBJECT_SCHEMA, OBJECT_NAME, COUNT_FETCH
 	FROM performance_schema.table_io_waits_summary_by_index_usage
-	WHERE INDEX_NAME IS NULL AND OBJECT_SCHEMA NOT IN %s`
+	WHERE INDEX_NAME IS NULL AND OBJECT_SCHEMA NOT IN (%s)`
 
 var indexIOWaitsFetchDesc = prometheus.NewDesc(
 	"mysql_perf_schema_index_io_waits_total",
@@ -88,8 +88,9 @@ func (c *TableStats) Describe(ch chan<- *prometheus.Desc) {
 func (c *TableStats) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
-	query := fmt.Sprintf(selectTableIOWaitsNoIndex, buildExcludedSchemasClause(c.excludeSchemas))
-	rows, err := c.dbConnection.QueryContext(ctx, query)
+	args := excludedSchemasArgs(c.excludeSchemas)
+	query := fmt.Sprintf(selectTableIOWaitsNoIndex, sqlPlaceholders(len(args)))
+	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
 	if err != nil {
 		c.logger.Error("failed to query table_io_waits_summary_by_index_usage", "err", err)
 		return

--- a/internal/component/database_observability/mysql/collector/table_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/table_stats_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/grafana/alloy/internal/util"
 )
 
-func TestIndexStats(t *testing.T) {
+func TestTableStats(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	require.NoError(t, err)
 	defer db.Close()
 
 	registry := prometheus.NewRegistry()
 
-	c, err := NewIndexStats(IndexStatsArguments{
+	c, err := NewTableStats(TableStatsArguments{
 		DB:       db,
 		Registry: registry,
 		Logger:   util.TestAlloyLogger(t).Slog(),
@@ -30,16 +30,16 @@ func TestIndexStats(t *testing.T) {
 	require.NoError(t, c.Start(t.Context()))
 	defer c.Stop()
 
-	mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+	mock.ExpectQuery(fmt.Sprintf(selectTableIOWaitsNoIndex, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 		WillReturnRows(
-			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
-				AddRow("books_store", "books", "idx_books_title", 0),
+			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "COUNT_FETCH"}).
+				AddRow("books_store", "books", 39),
 		)
 
 	expected := `
 	# HELP mysql_perf_schema_index_io_waits_total The total number of index I/O wait events for each index and operation.
 	# TYPE mysql_perf_schema_index_io_waits_total counter
-	mysql_perf_schema_index_io_waits_total{index="idx_books_title",name="books",operation="fetch",schema="books_store"} 0
+	mysql_perf_schema_index_io_waits_total{index="NONE",name="books",operation="fetch",schema="books_store"} 39
 `
 
 	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))

--- a/internal/component/database_observability/mysql/collector/table_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/table_stats_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,6 +13,16 @@ import (
 
 	"github.com/grafana/alloy/internal/util"
 )
+
+// toDriverValues converts args built for QueryContext (a mysql query's
+// natural argument type is any) into the []driver.Value sqlmock expects.
+func toDriverValues(args []any) []driver.Value {
+	values := make([]driver.Value, len(args))
+	for i, a := range args {
+		values[i] = a
+	}
+	return values
+}
 
 func TestTableStats(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -30,7 +41,9 @@ func TestTableStats(t *testing.T) {
 	require.NoError(t, c.Start(t.Context()))
 	defer c.Stop()
 
-	mock.ExpectQuery(fmt.Sprintf(selectTableIOWaitsNoIndex, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+	args := excludedSchemasArgs(nil)
+	mock.ExpectQuery(fmt.Sprintf(selectTableIOWaitsNoIndex, sqlPlaceholders(len(args)))).
+		WithArgs(toDriverValues(args)...).RowsWillBeClosed().
 		WillReturnRows(
 			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "COUNT_FETCH"}).
 				AddRow("books_store", "books", 39),

--- a/internal/component/database_observability/mysql/collector/table_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/table_stats_test.go
@@ -50,9 +50,9 @@ func TestTableStats(t *testing.T) {
 		)
 
 	expected := `
-	# HELP mysql_perf_schema_index_io_waits_total The total number of index I/O wait events for each index and operation.
-	# TYPE mysql_perf_schema_index_io_waits_total counter
-	mysql_perf_schema_index_io_waits_total{index="NONE",name="books",operation="fetch",schema="books_store"} 39
+	# HELP mysql_table_stats_seq_scan_total Number of row fetches against this table that did not use an index
+	# TYPE mysql_table_stats_seq_scan_total counter
+	mysql_table_stats_seq_scan_total{schema="books_store",table="books"} 39
 `
 
 	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -810,6 +810,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 		collector.QuerySamplesCollector:   true,
 		collector.ExplainPlansCollector:   true,
 		collector.LocksCollector:          false,
+		collector.TableStatsCollector:     false,
 		collector.IndexStatsCollector:     false,
 	}
 
@@ -995,6 +996,23 @@ func (c *Component) startCollectors(inst *dbInstance, serverID string, engineVer
 				logStartError(collector.ExplainPlansCollector, "start", err)
 			}
 			inst.collectors = append(inst.collectors, epCollector)
+		}
+	}
+
+	if collectors[collector.TableStatsCollector] {
+		tsCollector, err := collector.NewTableStats(collector.TableStatsArguments{
+			DB:             inst.dbConnection,
+			ExcludeSchemas: c.args.ExcludeSchemas,
+			Registry:       inst.registry,
+			Logger:         c.opts.Logger,
+		})
+		if err != nil {
+			logStartError(collector.TableStatsCollector, "create", err)
+		} else {
+			if err := tsCollector.Start(context.Background()); err != nil {
+				logStartError(collector.TableStatsCollector, "start", err)
+			}
+			inst.collectors = append(inst.collectors, tsCollector)
 		}
 	}
 

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -810,7 +810,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 		collector.QuerySamplesCollector:   true,
 		collector.ExplainPlansCollector:   true,
 		collector.LocksCollector:          false,
-		collector.IndexIOWaitsCollector:   false,
+		collector.IndexStatsCollector:     false,
 	}
 
 	for _, disabled := range a.DisableCollectors {
@@ -998,20 +998,20 @@ func (c *Component) startCollectors(inst *dbInstance, serverID string, engineVer
 		}
 	}
 
-	if collectors[collector.IndexIOWaitsCollector] {
-		iiwCollector, err := collector.NewIndexIOWaits(collector.IndexIOWaitsArguments{
+	if collectors[collector.IndexStatsCollector] {
+		isCollector, err := collector.NewIndexStats(collector.IndexStatsArguments{
 			DB:             inst.dbConnection,
 			ExcludeSchemas: c.args.ExcludeSchemas,
 			Registry:       inst.registry,
 			Logger:         c.opts.Logger,
 		})
 		if err != nil {
-			logStartError(collector.IndexIOWaitsCollector, "create", err)
+			logStartError(collector.IndexStatsCollector, "create", err)
 		} else {
-			if err := iiwCollector.Start(context.Background()); err != nil {
-				logStartError(collector.IndexIOWaitsCollector, "start", err)
+			if err := isCollector.Start(context.Background()); err != nil {
+				logStartError(collector.IndexStatsCollector, "start", err)
 			}
-			inst.collectors = append(inst.collectors, iiwCollector)
+			inst.collectors = append(inst.collectors, isCollector)
 		}
 	}
 

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -1020,6 +1020,7 @@ func (c *Component) startCollectors(inst *dbInstance, serverID string, engineVer
 		isCollector, err := collector.NewIndexStats(collector.IndexStatsArguments{
 			DB:             inst.dbConnection,
 			ExcludeSchemas: c.args.ExcludeSchemas,
+			EngineVersion:  parsedEngineVersion,
 			Registry:       inst.registry,
 			Logger:         c.opts.Logger,
 		})

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -810,6 +810,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 		collector.QuerySamplesCollector:   true,
 		collector.ExplainPlansCollector:   true,
 		collector.LocksCollector:          false,
+		collector.IndexIOWaitsCollector:   false,
 	}
 
 	for _, disabled := range a.DisableCollectors {
@@ -994,6 +995,23 @@ func (c *Component) startCollectors(inst *dbInstance, serverID string, engineVer
 				logStartError(collector.ExplainPlansCollector, "start", err)
 			}
 			inst.collectors = append(inst.collectors, epCollector)
+		}
+	}
+
+	if collectors[collector.IndexIOWaitsCollector] {
+		iiwCollector, err := collector.NewIndexIOWaits(collector.IndexIOWaitsArguments{
+			DB:             inst.dbConnection,
+			ExcludeSchemas: c.args.ExcludeSchemas,
+			Registry:       inst.registry,
+			Logger:         c.opts.Logger,
+		})
+		if err != nil {
+			logStartError(collector.IndexIOWaitsCollector, "create", err)
+		} else {
+			if err := iiwCollector.Start(context.Background()); err != nil {
+				logStartError(collector.IndexIOWaitsCollector, "start", err)
+			}
+			inst.collectors = append(inst.collectors, iiwCollector)
 		}
 	}
 

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -263,7 +263,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          false,
-			collector.IndexIOWaitsCollector:   false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -289,7 +289,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          true,
-			collector.IndexIOWaitsCollector:   false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -315,7 +315,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    false,
 			collector.ExplainPlansCollector:   false,
 			collector.LocksCollector:          false,
-			collector.IndexIOWaitsCollector:   false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -342,7 +342,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          true,
-			collector.IndexIOWaitsCollector:   false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -369,7 +369,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    false,
 			collector.ExplainPlansCollector:   false,
 			collector.LocksCollector:          false,
-			collector.IndexIOWaitsCollector:   false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -396,7 +396,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          false,
-			collector.IndexIOWaitsCollector:   false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 }

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -263,6 +263,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          false,
+			collector.IndexIOWaitsCollector:   false,
 		}, actualCollectors)
 	})
 
@@ -288,6 +289,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          true,
+			collector.IndexIOWaitsCollector:   false,
 		}, actualCollectors)
 	})
 
@@ -313,6 +315,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    false,
 			collector.ExplainPlansCollector:   false,
 			collector.LocksCollector:          false,
+			collector.IndexIOWaitsCollector:   false,
 		}, actualCollectors)
 	})
 
@@ -339,6 +342,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          true,
+			collector.IndexIOWaitsCollector:   false,
 		}, actualCollectors)
 	})
 
@@ -365,6 +369,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    false,
 			collector.ExplainPlansCollector:   false,
 			collector.LocksCollector:          false,
+			collector.IndexIOWaitsCollector:   false,
 		}, actualCollectors)
 	})
 
@@ -391,6 +396,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          false,
+			collector.IndexIOWaitsCollector:   false,
 		}, actualCollectors)
 	})
 }

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -263,6 +263,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          false,
+			collector.TableStatsCollector:     false,
 			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
@@ -289,6 +290,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          true,
+			collector.TableStatsCollector:     false,
 			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
@@ -315,6 +317,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    false,
 			collector.ExplainPlansCollector:   false,
 			collector.LocksCollector:          false,
+			collector.TableStatsCollector:     false,
 			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
@@ -342,6 +345,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          true,
+			collector.TableStatsCollector:     false,
 			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
@@ -369,6 +373,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    false,
 			collector.ExplainPlansCollector:   false,
 			collector.LocksCollector:          false,
+			collector.TableStatsCollector:     false,
 			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
@@ -396,6 +401,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          false,
+			collector.TableStatsCollector:     false,
 			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})

--- a/internal/component/database_observability/postgres/collector/dsn.go
+++ b/internal/component/database_observability/postgres/collector/dsn.go
@@ -30,3 +30,14 @@ func replaceDatabaseNameInDSN(dsn, newDatabaseName string) (string, error) {
 	newDSN := matches[1] + newDatabaseName + matches[3]
 	return newDSN, nil
 }
+
+// databaseNameFromDSN extracts the database name a DSN already points to, so
+// callers fanning out per-database can tell whether a target database is the
+// one an existing connection already uses.
+func databaseNameFromDSN(dsn string) (string, error) {
+	matches := dsnParseRegex.FindStringSubmatch(dsn)
+	if len(matches) < 4 {
+		return "", errors.New("failed to parse DSN for database name")
+	}
+	return matches[2], nil
+}

--- a/internal/component/database_observability/postgres/collector/index_stats.go
+++ b/internal/component/database_observability/postgres/collector/index_stats.go
@@ -1,0 +1,237 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+)
+
+// IndexStatsCollector emits the minimal set of metrics needed for the
+// missing-index and unused-index KG insights: table-level scan counts (from
+// pg_stat_user_tables) and per-index scan counts (from pg_stat_user_indexes),
+// scoped to every database the connection can reach rather than only the one
+// named in the DSN.
+const IndexStatsCollector = "index_stats"
+
+const (
+	selectTableScanStats = `
+		SELECT
+			schemaname,
+			relname,
+			seq_scan,
+			idx_scan,
+			n_live_tup
+		FROM pg_stat_user_tables`
+
+	selectIndexUsageStats = `
+		SELECT
+			s.schemaname,
+			s.relname,
+			s.indexrelname,
+			s.idx_scan,
+			i.indisprimary,
+			pg_relation_size(s.indexrelid) AS index_size_bytes
+		FROM pg_stat_user_indexes s
+		JOIN pg_index i ON i.indexrelid = s.indexrelid`
+)
+
+const labelDatname = "datname"
+
+var tableLabels = []string{labelDatname, "schemaname", "relname"}
+
+var indexLabels = []string{labelDatname, "schemaname", "relname", "indexrelname"}
+
+var (
+	tableScanStatsSeqScanDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("pg", "stat_user_tables", "seq_scan"),
+		"Number of sequential scans initiated on this table",
+		tableLabels, nil,
+	)
+	tableScanStatsIdxScanDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("pg", "stat_user_tables", "idx_scan"),
+		"Number of index scans initiated on this table",
+		tableLabels, nil,
+	)
+	tableScanStatsNLiveTupDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("pg", "stat_user_tables", "n_live_tup"),
+		"Estimated number of live rows",
+		tableLabels, nil,
+	)
+
+	// Named to match the metrics proposed by the (currently unmerged) upstream
+	// prometheus-community/postgres_exporter#1071, so that adopting the real
+	// upstream collector later, if/when it lands, needs no rule changes.
+	indexUsageIdxScanTotalDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("pg", "stat_user_indexes", "idx_scan_total"),
+		"Number of index scans initiated on this index",
+		indexLabels, nil,
+	)
+	indexPropertiesDesc = prometheus.NewDesc(
+		"pg_index_properties",
+		"Properties of an index; a constant 1 with is_primary set to whether the index backs a primary key",
+		append(append([]string{}, indexLabels...), "is_primary"), nil,
+	)
+	indexSizeBytesDesc = prometheus.NewDesc(
+		"pg_index_size_bytes",
+		"Total disk space used by this index, in bytes",
+		indexLabels, nil,
+	)
+)
+
+type IndexStatsArguments struct {
+	DB               *sql.DB
+	DSN              string
+	ExcludeDatabases []string
+	Registry         *prometheus.Registry
+
+	Logger *slog.Logger
+
+	dbConnectionFactory databaseConnectionFactory
+}
+
+type IndexStats struct {
+	initialConnection   *sql.DB
+	dbDSN               string
+	dbConnectionFactory databaseConnectionFactory
+	excludeDatabases    []string
+	registry            *prometheus.Registry
+
+	logger  *slog.Logger
+	running *atomic.Bool
+}
+
+func NewIndexStats(args IndexStatsArguments) (*IndexStats, error) {
+	factory := args.dbConnectionFactory
+	if factory == nil {
+		factory = defaultDbConnectionFactory
+	}
+
+	return &IndexStats{
+		initialConnection:   args.DB,
+		dbDSN:               args.DSN,
+		dbConnectionFactory: factory,
+		excludeDatabases:    args.ExcludeDatabases,
+		registry:            args.Registry,
+		logger:              args.Logger.With("collector", IndexStatsCollector),
+		running:             &atomic.Bool{},
+	}, nil
+}
+
+func (c *IndexStats) Name() string {
+	return IndexStatsCollector
+}
+
+func (c *IndexStats) Start(_ context.Context) error {
+	if err := c.registry.Register(c); err != nil {
+		return err
+	}
+	c.running.Store(true)
+	return nil
+}
+
+func (c *IndexStats) Stopped() bool {
+	return !c.running.Load()
+}
+
+func (c *IndexStats) Stop() {
+	c.registry.Unregister(c)
+	c.running.Store(false)
+}
+
+// Describe implements prometheus.Collector.
+func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
+	ch <- tableScanStatsSeqScanDesc
+	ch <- tableScanStatsIdxScanDesc
+	ch <- tableScanStatsNLiveTupDesc
+	ch <- indexUsageIdxScanTotalDesc
+	ch <- indexPropertiesDesc
+	ch <- indexSizeBytesDesc
+}
+
+// Collect implements prometheus.Collector. It runs synchronously at scrape
+// time, fanning out to every database the connection can reach.
+func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	databases, err := discoverDatabases(ctx, c.initialConnection, c.excludeDatabases)
+	if err != nil {
+		c.logger.Error("failed to discover databases", "err", err)
+		return
+	}
+
+	for _, dbName := range databases {
+		conn, closeConn, err := connectToDatabase(c.dbDSN, dbName, c.dbConnectionFactory, c.initialConnection)
+		if err != nil {
+			c.logger.Error("failed to connect to database", "datname", dbName, "err", err)
+			continue
+		}
+
+		c.collectTableScanStats(ctx, dbName, conn, ch)
+		c.collectIndexUsageStats(ctx, dbName, conn, ch)
+
+		closeConn()
+	}
+}
+
+func (c *IndexStats) collectTableScanStats(ctx context.Context, dbName string, conn *sql.DB, ch chan<- prometheus.Metric) {
+	rows, err := conn.QueryContext(ctx, selectTableScanStats)
+	if err != nil {
+		c.logger.Error("failed to query pg_stat_user_tables", "datname", dbName, "err", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var schemaname, relname string
+		var seqScan, idxScan, nLiveTup sql.NullInt64
+
+		if err := rows.Scan(&schemaname, &relname, &seqScan, &idxScan, &nLiveTup); err != nil {
+			c.logger.Error("failed to scan pg_stat_user_tables row", "datname", dbName, "err", err)
+			return
+		}
+
+		ch <- prometheus.MustNewConstMetric(tableScanStatsSeqScanDesc, prometheus.CounterValue, float64(seqScan.Int64), dbName, schemaname, relname)
+		ch <- prometheus.MustNewConstMetric(tableScanStatsIdxScanDesc, prometheus.CounterValue, float64(idxScan.Int64), dbName, schemaname, relname)
+		ch <- prometheus.MustNewConstMetric(tableScanStatsNLiveTupDesc, prometheus.GaugeValue, float64(nLiveTup.Int64), dbName, schemaname, relname)
+	}
+
+	if err := rows.Err(); err != nil {
+		c.logger.Error("error iterating pg_stat_user_tables rows", "datname", dbName, "err", err)
+	}
+}
+
+func (c *IndexStats) collectIndexUsageStats(ctx context.Context, dbName string, conn *sql.DB, ch chan<- prometheus.Metric) {
+	rows, err := conn.QueryContext(ctx, selectIndexUsageStats)
+	if err != nil {
+		c.logger.Error("failed to query pg_stat_user_indexes", "datname", dbName, "err", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var schemaname, relname, indexrelname string
+		var idxScan, indexSizeBytes sql.NullInt64
+		var isPrimary bool
+
+		if err := rows.Scan(&schemaname, &relname, &indexrelname, &idxScan, &isPrimary, &indexSizeBytes); err != nil {
+			c.logger.Error("failed to scan pg_stat_user_indexes row", "datname", dbName, "err", err)
+			return
+		}
+
+		isPrimaryLabel := "false"
+		if isPrimary {
+			isPrimaryLabel = "true"
+		}
+
+		ch <- prometheus.MustNewConstMetric(indexUsageIdxScanTotalDesc, prometheus.CounterValue, float64(idxScan.Int64), dbName, schemaname, relname, indexrelname)
+		ch <- prometheus.MustNewConstMetric(indexPropertiesDesc, prometheus.GaugeValue, 1, dbName, schemaname, relname, indexrelname, isPrimaryLabel)
+		ch <- prometheus.MustNewConstMetric(indexSizeBytesDesc, prometheus.GaugeValue, float64(indexSizeBytes.Int64), dbName, schemaname, relname, indexrelname)
+	}
+
+	if err := rows.Err(); err != nil {
+		c.logger.Error("error iterating pg_stat_user_indexes rows", "datname", dbName, "err", err)
+	}
+}

--- a/internal/component/database_observability/postgres/collector/index_stats.go
+++ b/internal/component/database_observability/postgres/collector/index_stats.go
@@ -9,58 +9,25 @@ import (
 	"go.uber.org/atomic"
 )
 
-// IndexStatsCollector emits the minimal set of metrics needed for the
-// missing-index and unused-index KG insights: table-level scan counts (from
-// pg_stat_user_tables) and per-index scan counts (from pg_stat_user_indexes),
-// scoped to every database the connection can reach rather than only the one
-// named in the DSN.
+// IndexStatsCollector emits the minimal set of per-index metrics needed for
+// the unused-index KG insight, from pg_stat_user_indexes, scoped to every
+// database the connection can reach rather than only the one named in the DSN.
 const IndexStatsCollector = "index_stats"
 
-const (
-	selectTableScanStats = `
-		SELECT
-			schemaname,
-			relname,
-			seq_scan,
-			idx_scan,
-			n_live_tup
-		FROM pg_stat_user_tables`
-
-	selectIndexUsageStats = `
-		SELECT
-			s.schemaname,
-			s.relname,
-			s.indexrelname,
-			s.idx_scan,
-			i.indisprimary,
-			pg_relation_size(s.indexrelid) AS index_size_bytes
-		FROM pg_stat_user_indexes s
-		JOIN pg_index i ON i.indexrelid = s.indexrelid`
-)
-
-const labelDatname = "datname"
-
-var tableLabels = []string{labelDatname, "schemaname", "relname"}
+const selectIndexUsageStats = `
+	SELECT
+		s.schemaname,
+		s.relname,
+		s.indexrelname,
+		s.idx_scan,
+		i.indisprimary,
+		pg_relation_size(s.indexrelid) AS index_size_bytes
+	FROM pg_stat_user_indexes s
+	JOIN pg_index i ON i.indexrelid = s.indexrelid`
 
 var indexLabels = []string{labelDatname, "schemaname", "relname", "indexrelname"}
 
 var (
-	tableScanStatsSeqScanDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("pg", "stat_user_tables", "seq_scan"),
-		"Number of sequential scans initiated on this table",
-		tableLabels, nil,
-	)
-	tableScanStatsIdxScanDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("pg", "stat_user_tables", "idx_scan"),
-		"Number of index scans initiated on this table",
-		tableLabels, nil,
-	)
-	tableScanStatsNLiveTupDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("pg", "stat_user_tables", "n_live_tup"),
-		"Estimated number of live rows",
-		tableLabels, nil,
-	)
-
 	// Named to match the metrics proposed by the (currently unmerged) upstream
 	// prometheus-community/postgres_exporter#1071, so that adopting the real
 	// upstream collector later, if/when it lands, needs no rule changes.
@@ -143,9 +110,6 @@ func (c *IndexStats) Stop() {
 
 // Describe implements prometheus.Collector.
 func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
-	ch <- tableScanStatsSeqScanDesc
-	ch <- tableScanStatsIdxScanDesc
-	ch <- tableScanStatsNLiveTupDesc
 	ch <- indexUsageIdxScanTotalDesc
 	ch <- indexPropertiesDesc
 	ch <- indexSizeBytesDesc
@@ -169,37 +133,9 @@ func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 			continue
 		}
 
-		c.collectTableScanStats(ctx, dbName, conn, ch)
 		c.collectIndexUsageStats(ctx, dbName, conn, ch)
 
 		closeConn()
-	}
-}
-
-func (c *IndexStats) collectTableScanStats(ctx context.Context, dbName string, conn *sql.DB, ch chan<- prometheus.Metric) {
-	rows, err := conn.QueryContext(ctx, selectTableScanStats)
-	if err != nil {
-		c.logger.Error("failed to query pg_stat_user_tables", "datname", dbName, "err", err)
-		return
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var schemaname, relname string
-		var seqScan, idxScan, nLiveTup sql.NullInt64
-
-		if err := rows.Scan(&schemaname, &relname, &seqScan, &idxScan, &nLiveTup); err != nil {
-			c.logger.Error("failed to scan pg_stat_user_tables row", "datname", dbName, "err", err)
-			return
-		}
-
-		ch <- prometheus.MustNewConstMetric(tableScanStatsSeqScanDesc, prometheus.CounterValue, float64(seqScan.Int64), dbName, schemaname, relname)
-		ch <- prometheus.MustNewConstMetric(tableScanStatsIdxScanDesc, prometheus.CounterValue, float64(idxScan.Int64), dbName, schemaname, relname)
-		ch <- prometheus.MustNewConstMetric(tableScanStatsNLiveTupDesc, prometheus.GaugeValue, float64(nLiveTup.Int64), dbName, schemaname, relname)
-	}
-
-	if err := rows.Err(); err != nil {
-		c.logger.Error("error iterating pg_stat_user_tables rows", "datname", dbName, "err", err)
 	}
 }
 

--- a/internal/component/database_observability/postgres/collector/index_stats_test.go
+++ b/internal/component/database_observability/postgres/collector/index_stats_test.go
@@ -1,0 +1,81 @@
+package collector
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
+)
+
+func TestIndexStats(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	registry := prometheus.NewRegistry()
+
+	c, err := NewIndexStats(IndexStatsArguments{
+		DB:               db,
+		DSN:              "postgres://user:pass@localhost:5432/books_store",
+		ExcludeDatabases: nil,
+		Registry:         registry,
+		Logger:           util.TestAlloyLogger(t).Slog(),
+		dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+			return db, nil
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Start(t.Context()))
+	defer c.Stop()
+
+	mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("books_store"))
+
+	mock.ExpectQuery(selectTableScanStats).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{"schemaname", "relname", "seq_scan", "idx_scan", "n_live_tup"}).
+				AddRow("public", "gen_adjectives", 37154, 0, 500),
+		)
+
+	mock.ExpectQuery(selectIndexUsageStats).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{"schemaname", "relname", "indexrelname", "idx_scan", "indisprimary", "index_size_bytes"}).
+				AddRow("public", "books", "books_pkey", 184000000, true, 65536).
+				AddRow("public", "books", "idx_books_title", 0, false, 32768),
+		)
+
+	expected := `
+	# HELP pg_stat_user_indexes_idx_scan_total Number of index scans initiated on this index
+	# TYPE pg_stat_user_indexes_idx_scan_total counter
+	pg_stat_user_indexes_idx_scan_total{datname="books_store",indexrelname="books_pkey",relname="books",schemaname="public"} 1.84e+08
+	pg_stat_user_indexes_idx_scan_total{datname="books_store",indexrelname="idx_books_title",relname="books",schemaname="public"} 0
+	# HELP pg_stat_user_tables_idx_scan Number of index scans initiated on this table
+	# TYPE pg_stat_user_tables_idx_scan counter
+	pg_stat_user_tables_idx_scan{datname="books_store",relname="gen_adjectives",schemaname="public"} 0
+	# HELP pg_stat_user_tables_n_live_tup Estimated number of live rows
+	# TYPE pg_stat_user_tables_n_live_tup gauge
+	pg_stat_user_tables_n_live_tup{datname="books_store",relname="gen_adjectives",schemaname="public"} 500
+	# HELP pg_stat_user_tables_seq_scan Number of sequential scans initiated on this table
+	# TYPE pg_stat_user_tables_seq_scan counter
+	pg_stat_user_tables_seq_scan{datname="books_store",relname="gen_adjectives",schemaname="public"} 37154
+	# HELP pg_index_properties Properties of an index; a constant 1 with is_primary set to whether the index backs a primary key
+	# TYPE pg_index_properties gauge
+	pg_index_properties{datname="books_store",indexrelname="books_pkey",is_primary="true",relname="books",schemaname="public"} 1
+	pg_index_properties{datname="books_store",indexrelname="idx_books_title",is_primary="false",relname="books",schemaname="public"} 1
+	# HELP pg_index_size_bytes Total disk space used by this index, in bytes
+	# TYPE pg_index_size_bytes gauge
+	pg_index_size_bytes{datname="books_store",indexrelname="books_pkey",relname="books",schemaname="public"} 65536
+	pg_index_size_bytes{datname="books_store",indexrelname="idx_books_title",relname="books",schemaname="public"} 32768
+`
+
+	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/component/database_observability/postgres/collector/index_stats_test.go
+++ b/internal/component/database_observability/postgres/collector/index_stats_test.go
@@ -39,12 +39,6 @@ func TestIndexStats(t *testing.T) {
 	mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 		WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("books_store"))
 
-	mock.ExpectQuery(selectTableScanStats).WithoutArgs().RowsWillBeClosed().
-		WillReturnRows(
-			sqlmock.NewRows([]string{"schemaname", "relname", "seq_scan", "idx_scan", "n_live_tup"}).
-				AddRow("public", "gen_adjectives", 37154, 0, 500),
-		)
-
 	mock.ExpectQuery(selectIndexUsageStats).WithoutArgs().RowsWillBeClosed().
 		WillReturnRows(
 			sqlmock.NewRows([]string{"schemaname", "relname", "indexrelname", "idx_scan", "indisprimary", "index_size_bytes"}).
@@ -57,15 +51,6 @@ func TestIndexStats(t *testing.T) {
 	# TYPE pg_stat_user_indexes_idx_scan_total counter
 	pg_stat_user_indexes_idx_scan_total{datname="books_store",indexrelname="books_pkey",relname="books",schemaname="public"} 1.84e+08
 	pg_stat_user_indexes_idx_scan_total{datname="books_store",indexrelname="idx_books_title",relname="books",schemaname="public"} 0
-	# HELP pg_stat_user_tables_idx_scan Number of index scans initiated on this table
-	# TYPE pg_stat_user_tables_idx_scan counter
-	pg_stat_user_tables_idx_scan{datname="books_store",relname="gen_adjectives",schemaname="public"} 0
-	# HELP pg_stat_user_tables_n_live_tup Estimated number of live rows
-	# TYPE pg_stat_user_tables_n_live_tup gauge
-	pg_stat_user_tables_n_live_tup{datname="books_store",relname="gen_adjectives",schemaname="public"} 500
-	# HELP pg_stat_user_tables_seq_scan Number of sequential scans initiated on this table
-	# TYPE pg_stat_user_tables_seq_scan counter
-	pg_stat_user_tables_seq_scan{datname="books_store",relname="gen_adjectives",schemaname="public"} 37154
 	# HELP pg_index_properties Properties of an index; a constant 1 with is_primary set to whether the index backs a primary key
 	# TYPE pg_index_properties gauge
 	pg_index_properties{datname="books_store",indexrelname="books_pkey",is_primary="true",relname="books",schemaname="public"} 1

--- a/internal/component/database_observability/postgres/collector/logs.go
+++ b/internal/component/database_observability/postgres/collector/logs.go
@@ -180,7 +180,7 @@ func (l *Logs) initMetrics() {
 			Name:      "pg_errors_total",
 			Help:      "Number of log lines with errors by severity and sql state code",
 		},
-		[]string{"severity", "sqlstate", "sqlstate_class", "datname", "user"},
+		[]string{"severity", "sqlstate", "sqlstate_class", labelDatname, "user"},
 	)
 
 	l.parseErrors = prometheus.NewCounter(

--- a/internal/component/database_observability/postgres/collector/multi_database.go
+++ b/internal/component/database_observability/postgres/collector/multi_database.go
@@ -1,0 +1,61 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// discoverDatabases lists the databases on the Postgres instance that the
+// current connection is allowed to CONNECT to, via the pg_database catalog
+// view (readable from any single connection). Callers use this to fan out
+// per-database connections, since most stat views (e.g. pg_stat_user_tables,
+// pg_stat_user_indexes) only ever report on the database a connection is
+// actually established to.
+func discoverDatabases(ctx context.Context, conn *sql.DB, excludeDatabases []string) ([]string, error) {
+	query := fmt.Sprintf(selectAllDatabases, buildExcludedDatabasesClause(excludeDatabases))
+	rows, err := conn.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover databases: %w", err)
+	}
+	defer rows.Close()
+
+	var databases []string
+	for rows.Next() {
+		var datname string
+		if err := rows.Scan(&datname); err != nil {
+			return nil, fmt.Errorf("failed to scan database name: %w", err)
+		}
+		databases = append(databases, datname)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating database rows: %w", err)
+	}
+
+	return databases, nil
+}
+
+// connectToDatabase opens a connection to dbName by rewriting the database
+// name in dsn, using factory. The returned closeFn closes the connection
+// unless it is the same connection as initial (in which case closing it is
+// the caller's responsibility elsewhere).
+func connectToDatabase(dsn, dbName string, factory databaseConnectionFactory, initial *sql.DB) (conn *sql.DB, closeFn func(), err error) {
+	databaseDSN, err := replaceDatabaseNameInDSN(dsn, dbName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create DSN for database %s: %w", dbName, err)
+	}
+
+	conn, err = factory(databaseDSN)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create connection to database %s: %w", dbName, err)
+	}
+
+	closeFn = func() {
+		if conn != initial {
+			conn.Close()
+		}
+	}
+
+	return conn, closeFn, nil
+}

--- a/internal/component/database_observability/postgres/collector/multi_database.go
+++ b/internal/component/database_observability/postgres/collector/multi_database.go
@@ -37,10 +37,20 @@ func discoverDatabases(ctx context.Context, conn *sql.DB, excludeDatabases []str
 }
 
 // connectToDatabase opens a connection to dbName by rewriting the database
-// name in dsn, using factory. The returned closeFn closes the connection
-// unless it is the same connection as initial (in which case closing it is
-// the caller's responsibility elsewhere).
+// name in dsn, using factory. If dbName is the database dsn (and so initial)
+// already points to, initial is reused directly instead of opening a
+// redundant connection: with the real sql.Open-based factory, a freshly
+// opened *sql.DB is never pointer-equal to initial even for an identical
+// DSN, so skipping the redundant open/close has to happen here, up front.
+// The returned closeFn closes the connection unless it is initial (in which
+// case closing it is the caller's responsibility elsewhere).
 func connectToDatabase(dsn, dbName string, factory databaseConnectionFactory, initial *sql.DB) (conn *sql.DB, closeFn func(), err error) {
+	noopClose := func() {}
+
+	if currentDBName, err := databaseNameFromDSN(dsn); err == nil && currentDBName == dbName {
+		return initial, noopClose, nil
+	}
+
 	databaseDSN, err := replaceDatabaseNameInDSN(dsn, dbName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create DSN for database %s: %w", dbName, err)

--- a/internal/component/database_observability/postgres/collector/multi_database_test.go
+++ b/internal/component/database_observability/postgres/collector/multi_database_test.go
@@ -1,0 +1,57 @@
+package collector
+
+import (
+	"database/sql"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConnectToDatabaseReusesInitialConnection guards against a regression
+// where connectToDatabase opens (and immediately closes) a redundant
+// connection for the one database in a fan-out that's already the database
+// initial points to. With the real sql.Open-based factory, a freshly opened
+// *sql.DB is never pointer-equal to initial even for an identical DSN, so
+// the "same database" case has to be detected up front, before the factory
+// is ever called -- a bare `conn != initial` check after the fact can't
+// catch it.
+func TestConnectToDatabaseReusesInitialConnection(t *testing.T) {
+	initial, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer initial.Close()
+
+	newDB, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer newDB.Close()
+
+	t.Run("same database as the DSN: reuses initial, never calls factory", func(t *testing.T) {
+		factoryCalls := 0
+		factory := func(dsn string) (*sql.DB, error) {
+			factoryCalls++
+			return newDB, nil
+		}
+
+		conn, closeFn, err := connectToDatabase("postgres://user:pass@localhost:5432/books_store", "books_store", factory, initial)
+		require.NoError(t, err)
+		require.Same(t, initial, conn)
+		require.Equal(t, 0, factoryCalls)
+		closeFn() // must not close initial
+
+		require.NoError(t, initial.PingContext(t.Context())) // still usable
+	})
+
+	t.Run("different database: opens a new connection via factory", func(t *testing.T) {
+		factoryCalls := 0
+		factory := func(dsn string) (*sql.DB, error) {
+			factoryCalls++
+			return newDB, nil
+		}
+
+		conn, closeFn, err := connectToDatabase("postgres://user:pass@localhost:5432/postgres", "books_store", factory, initial)
+		require.NoError(t, err)
+		require.Same(t, newDB, conn)
+		require.Equal(t, 1, factoryCalls)
+		closeFn()
+	})
+}

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -415,29 +415,11 @@ func (c *SchemaDetails) Stop() {
 }
 
 func (c *SchemaDetails) getAllDatabases(ctx context.Context) ([]string, error) {
-	query := fmt.Sprintf(selectAllDatabases, buildExcludedDatabasesClause(c.excludeDatabases))
-	rows, err := c.initialConnection.QueryContext(ctx, query)
+	databases, err := discoverDatabases(ctx, c.initialConnection, c.excludeDatabases)
 	if err != nil {
 		c.logger.Error("failed to discover databases", "err", err)
-		return nil, fmt.Errorf("failed to discover databases: %w", err)
+		return nil, err
 	}
-	defer rows.Close()
-
-	var databases []string
-	for rows.Next() {
-		var datname string
-		if err := rows.Scan(&datname); err != nil {
-			c.logger.Error("failed to scan database name", "err", err)
-			continue
-		}
-		databases = append(databases, datname)
-	}
-
-	if err := rows.Err(); err != nil {
-		c.logger.Error("error iterating database rows", "err", err)
-		return nil, fmt.Errorf("error iterating database rows: %w", err)
-	}
-
 	return databases, nil
 }
 
@@ -597,31 +579,19 @@ func (c *SchemaDetails) extractNames(ctx context.Context) error {
 	}
 
 	for _, dbName := range databases {
-		databaseDSN, err := replaceDatabaseNameInDSN(c.dbDSN, dbName)
+		conn, closeConn, err := connectToDatabase(c.dbDSN, dbName, c.dbConnectionFactory, c.initialConnection)
 		if err != nil {
-			c.logger.Error("failed to create DSN for database", "datname", dbName, "err", err)
-			continue
-		}
-
-		conn, err := c.dbConnectionFactory(databaseDSN)
-		if err != nil {
-			c.logger.Error("failed to create connection to database", "datname", dbName, "err", err)
+			c.logger.Error("failed to connect to database", "datname", dbName, "err", err)
 			continue
 		}
 
 		if err := c.extractSchemas(ctx, dbName, conn); err != nil {
 			c.logger.Error("failed to collect schema from database", "datname", dbName, "err", err)
-			if conn != c.initialConnection {
-				conn.Close()
-			}
+			closeConn()
 			continue
 		}
 
-		if conn != c.initialConnection {
-			if err := conn.Close(); err != nil {
-				c.logger.Warn("failed to close database connection", "datname", dbName, "err", err)
-			}
-		}
+		closeConn()
 	}
 
 	// Drop throttle entries for databases that getAllDatabases no longer

--- a/internal/component/database_observability/postgres/collector/table_stats.go
+++ b/internal/component/database_observability/postgres/collector/table_stats.go
@@ -1,0 +1,164 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+)
+
+// TableStatsCollector emits the minimal set of table-level metrics needed for
+// the missing-index KG insight, from pg_stat_user_tables, scoped to every
+// database the connection can reach rather than only the one named in the DSN.
+const TableStatsCollector = "table_stats"
+
+const selectTableScanStats = `
+	SELECT
+		schemaname,
+		relname,
+		seq_scan,
+		idx_scan,
+		n_live_tup
+	FROM pg_stat_user_tables`
+
+const labelDatname = "datname"
+
+var tableLabels = []string{labelDatname, "schemaname", "relname"}
+
+var (
+	tableScanStatsSeqScanDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("pg", "stat_user_tables", "seq_scan"),
+		"Number of sequential scans initiated on this table",
+		tableLabels, nil,
+	)
+	tableScanStatsIdxScanDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("pg", "stat_user_tables", "idx_scan"),
+		"Number of index scans initiated on this table",
+		tableLabels, nil,
+	)
+	tableScanStatsNLiveTupDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("pg", "stat_user_tables", "n_live_tup"),
+		"Estimated number of live rows",
+		tableLabels, nil,
+	)
+)
+
+type TableStatsArguments struct {
+	DB               *sql.DB
+	DSN              string
+	ExcludeDatabases []string
+	Registry         *prometheus.Registry
+
+	Logger *slog.Logger
+
+	dbConnectionFactory databaseConnectionFactory
+}
+
+type TableStats struct {
+	initialConnection   *sql.DB
+	dbDSN               string
+	dbConnectionFactory databaseConnectionFactory
+	excludeDatabases    []string
+	registry            *prometheus.Registry
+
+	logger  *slog.Logger
+	running *atomic.Bool
+}
+
+func NewTableStats(args TableStatsArguments) (*TableStats, error) {
+	factory := args.dbConnectionFactory
+	if factory == nil {
+		factory = defaultDbConnectionFactory
+	}
+
+	return &TableStats{
+		initialConnection:   args.DB,
+		dbDSN:               args.DSN,
+		dbConnectionFactory: factory,
+		excludeDatabases:    args.ExcludeDatabases,
+		registry:            args.Registry,
+		logger:              args.Logger.With("collector", TableStatsCollector),
+		running:             &atomic.Bool{},
+	}, nil
+}
+
+func (c *TableStats) Name() string {
+	return TableStatsCollector
+}
+
+func (c *TableStats) Start(_ context.Context) error {
+	if err := c.registry.Register(c); err != nil {
+		return err
+	}
+	c.running.Store(true)
+	return nil
+}
+
+func (c *TableStats) Stopped() bool {
+	return !c.running.Load()
+}
+
+func (c *TableStats) Stop() {
+	c.registry.Unregister(c)
+	c.running.Store(false)
+}
+
+// Describe implements prometheus.Collector.
+func (c *TableStats) Describe(ch chan<- *prometheus.Desc) {
+	ch <- tableScanStatsSeqScanDesc
+	ch <- tableScanStatsIdxScanDesc
+	ch <- tableScanStatsNLiveTupDesc
+}
+
+// Collect implements prometheus.Collector. It runs synchronously at scrape
+// time, fanning out to every database the connection can reach.
+func (c *TableStats) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	databases, err := discoverDatabases(ctx, c.initialConnection, c.excludeDatabases)
+	if err != nil {
+		c.logger.Error("failed to discover databases", "err", err)
+		return
+	}
+
+	for _, dbName := range databases {
+		conn, closeConn, err := connectToDatabase(c.dbDSN, dbName, c.dbConnectionFactory, c.initialConnection)
+		if err != nil {
+			c.logger.Error("failed to connect to database", "datname", dbName, "err", err)
+			continue
+		}
+
+		c.collectTableScanStats(ctx, dbName, conn, ch)
+
+		closeConn()
+	}
+}
+
+func (c *TableStats) collectTableScanStats(ctx context.Context, dbName string, conn *sql.DB, ch chan<- prometheus.Metric) {
+	rows, err := conn.QueryContext(ctx, selectTableScanStats)
+	if err != nil {
+		c.logger.Error("failed to query pg_stat_user_tables", "datname", dbName, "err", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var schemaname, relname string
+		var seqScan, idxScan, nLiveTup sql.NullInt64
+
+		if err := rows.Scan(&schemaname, &relname, &seqScan, &idxScan, &nLiveTup); err != nil {
+			c.logger.Error("failed to scan pg_stat_user_tables row", "datname", dbName, "err", err)
+			return
+		}
+
+		ch <- prometheus.MustNewConstMetric(tableScanStatsSeqScanDesc, prometheus.CounterValue, float64(seqScan.Int64), dbName, schemaname, relname)
+		ch <- prometheus.MustNewConstMetric(tableScanStatsIdxScanDesc, prometheus.CounterValue, float64(idxScan.Int64), dbName, schemaname, relname)
+		ch <- prometheus.MustNewConstMetric(tableScanStatsNLiveTupDesc, prometheus.GaugeValue, float64(nLiveTup.Int64), dbName, schemaname, relname)
+	}
+
+	if err := rows.Err(); err != nil {
+		c.logger.Error("error iterating pg_stat_user_tables rows", "datname", dbName, "err", err)
+	}
+}

--- a/internal/component/database_observability/postgres/collector/table_stats_test.go
+++ b/internal/component/database_observability/postgres/collector/table_stats_test.go
@@ -1,0 +1,62 @@
+package collector
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
+)
+
+func TestTableStats(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	registry := prometheus.NewRegistry()
+
+	c, err := NewTableStats(TableStatsArguments{
+		DB:               db,
+		DSN:              "postgres://user:pass@localhost:5432/books_store",
+		ExcludeDatabases: nil,
+		Registry:         registry,
+		Logger:           util.TestAlloyLogger(t).Slog(),
+		dbConnectionFactory: func(dsn string) (*sql.DB, error) {
+			return db, nil
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Start(t.Context()))
+	defer c.Stop()
+
+	mock.ExpectQuery(fmt.Sprintf(selectAllDatabases, exclusionClause)).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(sqlmock.NewRows([]string{"datname"}).AddRow("books_store"))
+
+	mock.ExpectQuery(selectTableScanStats).WithoutArgs().RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{"schemaname", "relname", "seq_scan", "idx_scan", "n_live_tup"}).
+				AddRow("public", "gen_adjectives", 37154, 0, 500),
+		)
+
+	expected := `
+	# HELP pg_stat_user_tables_idx_scan Number of index scans initiated on this table
+	# TYPE pg_stat_user_tables_idx_scan counter
+	pg_stat_user_tables_idx_scan{datname="books_store",relname="gen_adjectives",schemaname="public"} 0
+	# HELP pg_stat_user_tables_n_live_tup Estimated number of live rows
+	# TYPE pg_stat_user_tables_n_live_tup gauge
+	pg_stat_user_tables_n_live_tup{datname="books_store",relname="gen_adjectives",schemaname="public"} 500
+	# HELP pg_stat_user_tables_seq_scan Number of sequential scans initiated on this table
+	# TYPE pg_stat_user_tables_seq_scan counter
+	pg_stat_user_tables_seq_scan{datname="books_store",relname="gen_adjectives",schemaname="public"} 37154
+`
+
+	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -520,6 +520,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 		collector.QuerySamplesCollector:  true,
 		collector.SchemaDetailsCollector: true,
 		collector.ExplainPlanCollector:   true,
+		collector.TableStatsCollector:    false,
 		collector.IndexStatsCollector:    false,
 	}
 
@@ -670,6 +671,24 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			logStartError(collector.ExplainPlanCollector, "start", err)
 		}
 		c.instance.collectors = append(c.instance.collectors, epCollector)
+	}
+
+	if collectors[collector.TableStatsCollector] {
+		tsCollector, err := collector.NewTableStats(collector.TableStatsArguments{
+			DB:               c.instance.dbConnection,
+			DSN:              string(c.args.DataSourceName),
+			ExcludeDatabases: c.args.ExcludeDatabases,
+			Registry:         c.instance.registry,
+			Logger:           c.opts.Logger,
+		})
+		if err != nil {
+			logStartError(collector.TableStatsCollector, "create", err)
+		} else {
+			if err := tsCollector.Start(context.Background()); err != nil {
+				logStartError(collector.TableStatsCollector, "start", err)
+			}
+			c.instance.collectors = append(c.instance.collectors, tsCollector)
+		}
 	}
 
 	if collectors[collector.IndexStatsCollector] {

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -520,6 +520,7 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 		collector.QuerySamplesCollector:  true,
 		collector.SchemaDetailsCollector: true,
 		collector.ExplainPlanCollector:   true,
+		collector.IndexStatsCollector:    false,
 	}
 
 	for _, disabled := range a.DisableCollectors {
@@ -669,6 +670,24 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			logStartError(collector.ExplainPlanCollector, "start", err)
 		}
 		c.instance.collectors = append(c.instance.collectors, epCollector)
+	}
+
+	if collectors[collector.IndexStatsCollector] {
+		isCollector, err := collector.NewIndexStats(collector.IndexStatsArguments{
+			DB:               c.instance.dbConnection,
+			DSN:              string(c.args.DataSourceName),
+			ExcludeDatabases: c.args.ExcludeDatabases,
+			Registry:         c.instance.registry,
+			Logger:           c.opts.Logger,
+		})
+		if err != nil {
+			logStartError(collector.IndexStatsCollector, "create", err)
+		} else {
+			if err := isCollector.Start(context.Background()); err != nil {
+				logStartError(collector.IndexStatsCollector, "start", err)
+			}
+			c.instance.collectors = append(c.instance.collectors, isCollector)
+		}
 	}
 
 	// HealthCheck collector is always enabled

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -117,6 +117,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.TableStatsCollector:    false,
 			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
@@ -140,6 +141,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.TableStatsCollector:    false,
 			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
@@ -163,6 +165,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.TableStatsCollector:    false,
 			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
@@ -187,6 +190,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.TableStatsCollector:    false,
 			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
@@ -211,6 +215,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.TableStatsCollector:    false,
 			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
@@ -234,6 +239,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.TableStatsCollector:    false,
 			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
@@ -257,6 +263,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.TableStatsCollector:    false,
 			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
@@ -280,6 +287,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.TableStatsCollector:    false,
 			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
@@ -303,6 +311,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  false,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.TableStatsCollector:    false,
 			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})

--- a/internal/component/database_observability/postgres/component_test.go
+++ b/internal/component/database_observability/postgres/component_test.go
@@ -117,6 +117,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
 
@@ -139,6 +140,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
 
@@ -161,6 +163,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
 
@@ -184,6 +187,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
 
@@ -207,6 +211,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
 
@@ -229,6 +234,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
 
@@ -251,6 +257,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
 
@@ -273,6 +280,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  true,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
 
@@ -295,6 +303,7 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.QuerySamplesCollector:  false,
 			collector.SchemaDetailsCollector: true,
 			collector.ExplainPlanCollector:   true,
+			collector.IndexStatsCollector:    false,
 		}, actualCollectors)
 	})
 }


### PR DESCRIPTION
### Brief description of Pull Request

Adds four new opt-in collectors to `database_observability`, emitting only the metrics needed for missing-index and unused-index detection, named consistently across both engines so future metrics stay easy to place:

- **postgres**: `table_stats` — table scan counts from `pg_stat_user_tables` (`seq_scan`, `idx_scan`, `n_live_tup`). `index_stats` — per-index scan counts from `pg_stat_user_indexes` (`idx_scan_total`, `pg_index_properties{is_primary}`, `pg_index_size_bytes`). Both fan out across every database the connection can reach, reusing the discovery/connection-fanout mechanism already used by the `schema_details` collector (extracted into a shared `multi_database.go`).
- **mysql**: `table_stats` — `mysql_table_stats_seq_scan_total{schema,table}`, the fetch count of the `index="NONE"` ("no index used") row per table. `index_stats` — `mysql_index_stats_idx_scan_total{schema,table,index}`, the same counter for each named-index row, plus (MySQL >= 5.6.6) `mysql_index_stats_size_bytes{schema,table,index}` from `mysql.innodb_index_stats` (InnoDB's persistent optimizer statistics, refreshed by MySQL itself, never triggered by us). Both read `performance_schema.table_io_waits_summary_by_index_usage` and bind the excluded-schema list as query parameters rather than formatting it into the SQL text. Each collector owns its own metric name rather than sharing one upstream-style name across two independently-toggleable collectors (which would have meant one collector's data being silently incomplete under a shared name whenever only one is enabled).

All four collectors are disabled by default and enabled via `enable_collectors`. The postgres metric names/labels match the existing `pg_stat_user_tables_*` fields (and, for the new index metrics, the shape proposed by the unmerged upstream `prometheus-community/postgres_exporter#1071`); the mysql metric names are purpose-built rather than mirroring `mysqld_exporter`'s naming, since that upstream metric isn't cleanly splittable across two independent collectors.

Also fixes a redundant-connection issue in the postgres multi-database fan-out (`connectToDatabase`): it always opened a fresh connection via `factory()`, even for the one database in the fan-out that's already the database the initial connection points to, since a freshly-`sql.Open`'d `*sql.DB` is never pointer-equal to the initial one. It now detects that case up front and reuses the initial connection directly instead of opening (and immediately closing) a redundant one on every scrape.

**Known dependency**: `mysql_index_stats_size_bytes` requires `GRANT SELECT ON mysql.innodb_index_stats` on the monitoring role, which is not part of today's default grant set (verified against the actual `db-o11y` MySQL role's live grants) — a `deployment_tools`-side change, not something this PR can satisfy alone. Missing the grant degrades gracefully (logged error, the metric just doesn't appear).

Validated against live `db-o11y` test RDS instances (Postgres 16, MySQL 8.0) hosting real `books_store` data: every emitted series across all four collectors, including the new size metric, was cross-checked against the database source directly and matched exactly. Scraped a locally-run build with no remote_write configured.

### Pull Request Details



### Issue(s) fixed by this Pull Request



### Notes to the Reviewer



### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))