### PR TITLE
docs: Ensure user facing FM documentation is up to date for the OTel Engine

### DIFF
--- a/docs/sources/introduction/otel_alloy.md
+++ b/docs/sources/introduction/otel_alloy.md
@@ -118,9 +118,11 @@ Push-based OTLP gateways and pull-based Prometheus scrapers have different load 
 
 ## Manage the {{% param "OTEL_ENGINE" %}} with Fleet Management
 
-The {{< param "OTEL_ENGINE" >}} works with the OpenTelemetry Collector support in Grafana Fleet Management.
-The {{< param "PRODUCT_NAME" >}} container provides an `otelcol`-compatible entry point, and the engine includes the components needed to run with the Open Agent Management Protocol (OpAMP) Supervisor.
-To monitor and remotely configure an {{< param "OTEL_ENGINE" >}} deployment, follow the [Fleet Management setup for the OpenTelemetry Collector](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/get-started/opentelemetry-collector/).
+The {{< param "OTEL_ENGINE" >}} works with the OpenTelemetry Collector support in Grafana Fleet Management, which lets you monitor and remotely configure your deployment over the Open Agent Management Protocol (OpAMP).
+There are two ways to get set up:
+
+- **Built-in supervisor**: Run the [`otel-supervisor`](../../reference/cli/otel-supervisor/) command to connect the {{< param "OTEL_ENGINE" >}} directly to Fleet Management over OpAMP, completely out of the box.
+- **Standard Collector setup**: The {{< param "OTEL_ENGINE" >}} exposes the same API surface area as the upstream OpenTelemetry collector, so you can follow the [Fleet Management setup for the OpenTelemetry Collector](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/get-started/opentelemetry-collector/) and run it like you would any other collector.
 
 ## How the engines evolve
 

--- a/docs/sources/introduction/otel_alloy.md
+++ b/docs/sources/introduction/otel_alloy.md
@@ -122,7 +122,7 @@ The {{< param "OTEL_ENGINE" >}} supports the OpenTelemetry Collector integration
 You can set this up in two ways:
 
 - **Built-in supervisor**: Run the [`otel-supervisor`](../../reference/cli/otel-supervisor/) command to connect the {{< param "OTEL_ENGINE" >}} directly to Fleet Management over OpAMP.
-- **Standard Collector setup**: The {{< param "OTEL_ENGINE" >}} exposes the same API surface as the standard OpenTelemetry Collector. Follow the [Fleet Management setup for the OpenTelemetry Collector](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/get-started/opentelemetry-collector/) and run the {< param "OTEL_ENGINE" >} like you would any other collector.
+- **Standard Collector setup**: The {{< param "OTEL_ENGINE" >}} exposes the same API surface as the standard OpenTelemetry Collector. Follow the [Fleet Management setup for the OpenTelemetry Collector](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/get-started/opentelemetry-collector/) and run the {{< param "OTEL_ENGINE" >}} like you would any other collector.
 
 ## How the engines evolve
 

--- a/docs/sources/introduction/otel_alloy.md
+++ b/docs/sources/introduction/otel_alloy.md
@@ -122,7 +122,7 @@ The {{< param "OTEL_ENGINE" >}} works with the OpenTelemetry Collector support i
 There are two ways to get set up:
 
 - **Built-in supervisor**: Run the [`otel-supervisor`](../../reference/cli/otel-supervisor/) command to connect the {{< param "OTEL_ENGINE" >}} directly to Fleet Management over OpAMP, completely out of the box.
-- **Standard Collector setup**: The {{< param "OTEL_ENGINE" >}} exposes the same API surface area as the upstream OpenTelemetry collector, so you can follow the [Fleet Management setup for the OpenTelemetry Collector](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/get-started/opentelemetry-collector/) and run it like you would any other collector.
+- **Standard Collector setup**: The {{< param "OTEL_ENGINE" >}} exposes the same API surface as the standard OpenTelemetry Collector. Follow the [Fleet Management setup for the OpenTelemetry Collector](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/get-started/opentelemetry-collector/) and run the {< param "OTEL_ENGINE" >} like you would any other collector.
 
 ## How the engines evolve
 

--- a/docs/sources/introduction/otel_alloy.md
+++ b/docs/sources/introduction/otel_alloy.md
@@ -121,7 +121,7 @@ Push-based OTLP gateways and pull-based Prometheus scrapers have different load 
 The {{< param "OTEL_ENGINE" >}} supports the OpenTelemetry Collector integration in Grafana Fleet Management so you can monitor and configure your deployment over the Open Agent Management Protocol (OpAMP).
 You can set this up in two ways:
 
-- **Built-in supervisor**: Run the [`otel-supervisor`](../../reference/cli/otel-supervisor/) command to connect the {{< param "OTEL_ENGINE" >}} directly to Fleet Management over OpAMP, completely out of the box.
+- **Built-in supervisor**: Run the [`otel-supervisor`](../../reference/cli/otel-supervisor/) command to connect the {{< param "OTEL_ENGINE" >}} directly to Fleet Management over OpAMP.
 - **Standard Collector setup**: The {{< param "OTEL_ENGINE" >}} exposes the same API surface as the standard OpenTelemetry Collector. Follow the [Fleet Management setup for the OpenTelemetry Collector](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/get-started/opentelemetry-collector/) and run the {< param "OTEL_ENGINE" >} like you would any other collector.
 
 ## How the engines evolve

--- a/docs/sources/introduction/otel_alloy.md
+++ b/docs/sources/introduction/otel_alloy.md
@@ -118,7 +118,7 @@ Push-based OTLP gateways and pull-based Prometheus scrapers have different load 
 
 ## Manage the {{% param "OTEL_ENGINE" %}} with Fleet Management
 
-The {{< param "OTEL_ENGINE" >}} works with the OpenTelemetry Collector support in Grafana Fleet Management, which lets you monitor and remotely configure your deployment over the Open Agent Management Protocol (OpAMP).
+The {{< param "OTEL_ENGINE" >}} supports the OpenTelemetry Collector integration in Grafana Fleet Management so you can monitor and configure your deployment over the Open Agent Management Protocol (OpAMP).
 You can set this up in two ways:
 
 - **Built-in supervisor**: Run the [`otel-supervisor`](../../reference/cli/otel-supervisor/) command to connect the {{< param "OTEL_ENGINE" >}} directly to Fleet Management over OpAMP, completely out of the box.

--- a/docs/sources/introduction/otel_alloy.md
+++ b/docs/sources/introduction/otel_alloy.md
@@ -119,7 +119,7 @@ Push-based OTLP gateways and pull-based Prometheus scrapers have different load 
 ## Manage the {{% param "OTEL_ENGINE" %}} with Fleet Management
 
 The {{< param "OTEL_ENGINE" >}} works with the OpenTelemetry Collector support in Grafana Fleet Management, which lets you monitor and remotely configure your deployment over the Open Agent Management Protocol (OpAMP).
-There are two ways to get set up:
+You can set this up in two ways:
 
 - **Built-in supervisor**: Run the [`otel-supervisor`](../../reference/cli/otel-supervisor/) command to connect the {{< param "OTEL_ENGINE" >}} directly to Fleet Management over OpAMP, completely out of the box.
 - **Standard Collector setup**: The {{< param "OTEL_ENGINE" >}} exposes the same API surface as the standard OpenTelemetry Collector. Follow the [Fleet Management setup for the OpenTelemetry Collector](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/get-started/opentelemetry-collector/) and run the {< param "OTEL_ENGINE" >} like you would any other collector.


### PR DESCRIPTION
This updates the wording in our [docs](https://grafana.com/docs/alloy/latest/introduction/otel_alloy/#manage-the-otel-engine-with-fleet-management) so that users are directed towards our bundled supervisor solution in the overview section, which currently only points to using the supervisor with alloy like any other upstream collector