### PR TITLE
feat: OTel service installation support for windows service

### DIFF
--- a/integration-tests/windows-service/util/registry.go
+++ b/integration-tests/windows-service/util/registry.go
@@ -15,3 +15,14 @@ func RegistryKeyExists(registryPath string) bool {
 	_ = k.Close()
 	return true
 }
+
+// RegistryStringValue reads a REG_SZ value under HKLM at registryPath.
+func RegistryStringValue(registryPath, name string) (string, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, registryPath, registry.READ)
+	if err != nil {
+		return "", err
+	}
+	defer k.Close()
+	v, _, err := k.GetStringValue(name)
+	return v, err
+}

--- a/integration-tests/windows-service/util/registry.go
+++ b/integration-tests/windows-service/util/registry.go
@@ -26,3 +26,14 @@ func RegistryStringValue(registryPath, name string) (string, error) {
 	v, _, err := k.GetStringValue(name)
 	return v, err
 }
+
+// RegistryStringsValue reads a REG_MULTI_SZ value under HKLM at registryPath.
+func RegistryStringsValue(registryPath, name string) ([]string, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, registryPath, registry.READ)
+	if err != nil {
+		return nil, err
+	}
+	defer k.Close()
+	v, _, err := k.GetStringsValue(name)
+	return v, err
+}

--- a/integration-tests/windows-service/windows_service_test.go
+++ b/integration-tests/windows-service/windows_service_test.go
@@ -99,6 +99,70 @@ func TestWindowsService(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		util.AssertEventLogLine(c, "msg=\"{^_^} Alloy is running\"")
 	}, waitTimeout*waitAttempts, waitTimeout)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		v, err := util.RegistryStringValue(registryPath, "ALLOY_OTEL_MODE")
+		assert.NoError(c, err)
+		assert.Equal(c, "", v)
+	}, waitTimeout*waitAttempts, waitTimeout)
+}
+
+func TestWindowsServiceOtelMode(t *testing.T) {
+	installerPath := os.Getenv(envVarInstallerPath)
+	if installerPath == "" {
+		t.Fatalf("%s not set; skipping Windows service integration test", envVarInstallerPath)
+	}
+	if _, err := os.Stat(installerPath); err != nil {
+		t.Fatalf("%s %q not found: %v", envVarInstallerPath, installerPath, err)
+	}
+
+	uninstallerPath := filepath.Join(installDir, "uninstall.exe")
+	cleanup := os.Getenv(envVarStateful) != "true"
+	if cleanup {
+		t.Logf("Stateful mode: skipping cleanup (service will remain installed) env=%s", envVarStateful)
+	} else {
+		defer uninstallAlloy(t, uninstallerPath)
+	}
+
+	if isAlloyInstalled(t, installDir) {
+		cleanIfExists := os.Getenv(envVarCleanIfExists) == "true"
+		if !cleanIfExists {
+			t.Fatalf("Alloy already present on the system. Uninstall manually or set %s=true to remove and continue", envVarCleanIfExists)
+		}
+		t.Logf("Alloy already present on the system. Uninstalling...")
+		uninstallAlloy(t, uninstallerPath)
+		if isAlloyInstalled(t, installDir) {
+			t.Fatalf("Uninstall failed. Alloy is still present on the system.")
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	installArgs := []string{"/S", "/D=" + installDir, "/OTELMODE=yes"}
+
+	t.Logf("Running installer path=%s args=%v", installerPath, installArgs)
+	cmd := exec.Command(installerPath, installArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run(), "installer failed")
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, isAlloyInstalled(t, installDir), "Alloy should be installed")
+		assert.FileExists(c, uninstallerPath, "uninstaller should exist after install")
+	}, waitTimeout*waitAttempts, waitTimeout)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		v, err := util.RegistryStringValue(registryPath, "ALLOY_OTEL_MODE")
+		assert.NoError(c, err)
+		assert.Equal(c, "yes", v)
+	}, waitTimeout*waitAttempts, waitTimeout)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		util.EnsureServiceRunning(c, t, serviceName)
+	}, waitTimeout*waitAttempts, waitTimeout)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		util.AssertMetricsEndpoint(c, "http://127.0.0.1:8888/metrics", "otelcol_")
+	}, waitTimeout*waitAttempts, waitTimeout)
 }
 
 func isAlloyInstalled(t *testing.T, installDir string) bool {

--- a/integration-tests/windows-service/windows_service_test.go
+++ b/integration-tests/windows-service/windows_service_test.go
@@ -104,6 +104,10 @@ func TestWindowsService(t *testing.T) {
 		v, err := util.RegistryStringValue(registryPath, "ALLOY_OTEL_MODE")
 		assert.NoError(c, err)
 		assert.Equal(c, "", v)
+
+		args, err := util.RegistryStringsValue(registryPath, "OTelArguments")
+		assert.NoError(c, err)
+		assert.Empty(c, args)
 	}, waitTimeout*waitAttempts, waitTimeout)
 }
 

--- a/internal/cmd/alloy-service/config_windows.go
+++ b/internal/cmd/alloy-service/config_windows.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -24,6 +25,17 @@ type config struct {
 	// WorkingDirectory points to the working directory to run the Alloy binary
 	// from.
 	WorkingDirectory string
+
+	// OtelMode is the raw ALLOY_OTEL_MODE registry value
+	OtelMode string
+}
+
+func getOptionalStringValue(k registry.Key, name string) (string, error) {
+	v, _, err := k.GetStringValue(name)
+	if errors.Is(err, registry.ErrNotExist) {
+		return "", nil
+	}
+	return v, err
 }
 
 // loadConfig loads the config from the Windows registry.
@@ -52,10 +64,16 @@ func loadConfig() (*config, error) {
 		return nil, fmt.Errorf("failed to retrieve key Environment: %w", err)
 	}
 
+	otelMode, err := getOptionalStringValue(alloyKey, "ALLOY_OTEL_MODE")
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve key ALLOY_OTEL_MODE: %w", err)
+	}
+
 	return &config{
 		ServicePath:      servicePath,
 		Args:             args,
 		Environment:      env,
 		WorkingDirectory: filepath.Dir(servicePath),
+		OtelMode:         otelMode,
 	}, nil
 }

--- a/internal/cmd/alloy-service/config_windows.go
+++ b/internal/cmd/alloy-service/config_windows.go
@@ -28,12 +28,24 @@ type config struct {
 
 	// OtelMode is the raw ALLOY_OTEL_MODE registry value
 	OtelMode string
+
+	// OtelArguments holds extra flags for the OTel engine only, read from
+	// the OTelArguments registry value
+	OtelArguments []string
 }
 
 func getOptionalStringValue(k registry.Key, name string) (string, error) {
 	v, _, err := k.GetStringValue(name)
 	if errors.Is(err, registry.ErrNotExist) {
 		return "", nil
+	}
+	return v, err
+}
+
+func getOptionalStringsValue(k registry.Key, name string) ([]string, error) {
+	v, _, err := k.GetStringsValue(name)
+	if errors.Is(err, registry.ErrNotExist) {
+		return nil, nil
 	}
 	return v, err
 }
@@ -69,11 +81,17 @@ func loadConfig() (*config, error) {
 		return nil, fmt.Errorf("failed to retrieve key ALLOY_OTEL_MODE: %w", err)
 	}
 
+	otelArguments, err := getOptionalStringsValue(alloyKey, "OTelArguments")
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve key OTelArguments: %w", err)
+	}
+
 	return &config{
 		ServicePath:      servicePath,
 		Args:             args,
 		Environment:      env,
 		WorkingDirectory: filepath.Dir(servicePath),
 		OtelMode:         otelMode,
+		OtelArguments:    otelArguments,
 	}, nil
 }

--- a/internal/cmd/alloy-service/engine.go
+++ b/internal/cmd/alloy-service/engine.go
@@ -27,13 +27,22 @@ func isOtelMode(value string) bool {
 //     install-time config path. The caller builds this path before
 //     calling in, since path joining is platform-specific and this
 //     function must stay OS-agnostic.
+//   - otelArguments is the raw OTelArguments registry value: extra flags
+//     for the OTel engine only, mirroring CUSTOM_OTEL_ARGS on systemd and
+//     otel-extra-args.txt on Homebrew. Placed before --config= so a
+//     repeated --config flag still resolves to the last one, matching
+//     upstream otelcol's own flag semantics.
 //   - defaultEngineArgs is Args exactly as read from the registry
 //     Arguments value (e.g. ["run", "<config>", "--storage.path=...", ...]).
 //     It is returned unmodified whenever otelMode is not truthy, so
 //     existing installs are byte-for-byte unaffected.
-func resolveEngineArgs(otelMode, otelConfigDefault string, defaultEngineArgs []string) []string {
+func resolveEngineArgs(otelMode, otelConfigDefault string, otelArguments, defaultEngineArgs []string) []string {
 	if !isOtelMode(otelMode) {
 		return defaultEngineArgs
 	}
-	return []string{"otel", "--config=" + otelConfigDefault}
+	args := make([]string, 0, len(otelArguments)+2)
+	args = append(args, "otel")
+	args = append(args, otelArguments...)
+	args = append(args, "--config="+otelConfigDefault)
+	return args
 }

--- a/internal/cmd/alloy-service/engine.go
+++ b/internal/cmd/alloy-service/engine.go
@@ -1,0 +1,39 @@
+package main
+
+// isOtelMode reports whether value (an ALLOY_OTEL_MODE-style toggle)
+// selects the OTel engine. Mirrors the truthy check in
+// packaging/systemd/alloy-wrapper and the Homebrew wrapper: "1", "true",
+// "yes", "on" (case-sensitive) select the OTel engine ("alloy otel");
+// anything else, including "" (unset or absent), keeps the default engine
+// ("alloy run").
+func isOtelMode(value string) bool {
+	switch value {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveEngineArgs computes the Alloy binary argv (excluding the binary
+// path itself) to launch, given the ALLOY_OTEL_MODE registry value and the
+// Arguments the installer wrote for the default engine.
+//
+//   - otelMode is the raw ALLOY_OTEL_MODE registry value.
+//   - otelConfigDefault is the OTel engine's config path. The OTel engine
+//     always reads its config from a fixed, installer-provisioned
+//     location (a sibling of the default engine's own installed config,
+//     inside the install directory) — it does not follow a custom
+//     install-time config path. The caller builds this path before
+//     calling in, since path joining is platform-specific and this
+//     function must stay OS-agnostic.
+//   - defaultEngineArgs is Args exactly as read from the registry
+//     Arguments value (e.g. ["run", "<config>", "--storage.path=...", ...]).
+//     It is returned unmodified whenever otelMode is not truthy, so
+//     existing installs are byte-for-byte unaffected.
+func resolveEngineArgs(otelMode, otelConfigDefault string, defaultEngineArgs []string) []string {
+	if !isOtelMode(otelMode) {
+		return defaultEngineArgs
+	}
+	return []string{"otel", "--config=" + otelConfigDefault}
+}

--- a/internal/cmd/alloy-service/engine_test.go
+++ b/internal/cmd/alloy-service/engine_test.go
@@ -1,0 +1,83 @@
+package main
+
+import "testing"
+
+func TestIsOtelMode(t *testing.T) {
+	truthy := []string{"1", "true", "yes", "on"}
+	for _, v := range truthy {
+		if !isOtelMode(v) {
+			t.Errorf("isOtelMode(%q) = false, want true", v)
+		}
+	}
+
+	notTruthy := []string{"", "0", "false", "no", "off", "maybe", "TRUE", "Yes", "ON"}
+	for _, v := range notTruthy {
+		if isOtelMode(v) {
+			t.Errorf("isOtelMode(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestResolveEngineArgs(t *testing.T) {
+	defaultArgs := []string{"run", `C:\ProgramData\GrafanaLabs\Alloy\config.alloy`, `--storage.path=C:\ProgramData\GrafanaLabs\Alloy\data`}
+
+	tt := []struct {
+		name              string
+		otelMode          string
+		otelConfigDefault string
+		defaultEngineArgs []string
+		want              []string
+	}{
+		{
+			name:              "unset toggle: unchanged",
+			defaultEngineArgs: defaultArgs,
+			want:              defaultArgs,
+		},
+		{
+			name:              "present-but-empty toggle: unchanged",
+			otelMode:          "",
+			defaultEngineArgs: defaultArgs,
+			want:              defaultArgs,
+		},
+		{
+			name:              "non-truthy toggle stays on default engine",
+			otelMode:          "maybe",
+			defaultEngineArgs: defaultArgs,
+			want:              defaultArgs,
+		},
+		{
+			name:              "truthy toggle is case-sensitive: wrong case stays default",
+			otelMode:          "TRUE",
+			defaultEngineArgs: defaultArgs,
+			want:              defaultArgs,
+		},
+		{
+			name:              "otel mode, config path",
+			otelMode:          "1",
+			otelConfigDefault: `C:\ProgramData\GrafanaLabs\Alloy\config.yaml`,
+			defaultEngineArgs: defaultArgs,
+			want:              []string{"otel", `--config=C:\ProgramData\GrafanaLabs\Alloy\config.yaml`},
+		},
+		{
+			name:              "otel mode via other truthy spellings",
+			otelMode:          "yes",
+			otelConfigDefault: `C:\ProgramData\GrafanaLabs\Alloy\config.yaml`,
+			defaultEngineArgs: defaultArgs,
+			want:              []string{"otel", `--config=C:\ProgramData\GrafanaLabs\Alloy\config.yaml`},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveEngineArgs(tc.otelMode, tc.otelConfigDefault, tc.defaultEngineArgs)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/cmd/alloy-service/engine_test.go
+++ b/internal/cmd/alloy-service/engine_test.go
@@ -25,6 +25,7 @@ func TestResolveEngineArgs(t *testing.T) {
 		name              string
 		otelMode          string
 		otelConfigDefault string
+		otelArguments     []string
 		defaultEngineArgs []string
 		want              []string
 	}{
@@ -52,6 +53,12 @@ func TestResolveEngineArgs(t *testing.T) {
 			want:              defaultArgs,
 		},
 		{
+			name:              "default engine ignores OTelArguments, the OTel engine's flags",
+			otelArguments:     []string{"--set=processors.batch.timeout=2s"},
+			defaultEngineArgs: defaultArgs,
+			want:              defaultArgs,
+		},
+		{
 			name:              "otel mode, config path",
 			otelMode:          "1",
 			otelConfigDefault: `C:\ProgramData\GrafanaLabs\Alloy\config.yaml`,
@@ -65,11 +72,19 @@ func TestResolveEngineArgs(t *testing.T) {
 			defaultEngineArgs: defaultArgs,
 			want:              []string{"otel", `--config=C:\ProgramData\GrafanaLabs\Alloy\config.yaml`},
 		},
+		{
+			name:              "otel mode, OTelArguments applies before --config",
+			otelMode:          "1",
+			otelConfigDefault: `C:\ProgramData\GrafanaLabs\Alloy\config.yaml`,
+			otelArguments:     []string{"--set=processors.batch.timeout=2s"},
+			defaultEngineArgs: defaultArgs,
+			want:              []string{"otel", "--set=processors.batch.timeout=2s", `--config=C:\ProgramData\GrafanaLabs\Alloy\config.yaml`},
+		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			got := resolveEngineArgs(tc.otelMode, tc.otelConfigDefault, tc.defaultEngineArgs)
+			got := resolveEngineArgs(tc.otelMode, tc.otelConfigDefault, tc.otelArguments, tc.defaultEngineArgs)
 			if len(got) != len(tc.want) {
 				t.Fatalf("got %v, want %v", got, tc.want)
 			}

--- a/internal/cmd/alloy-service/main_windows.go
+++ b/internal/cmd/alloy-service/main_windows.go
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	otelConfigDefault := filepath.Join(filepath.Dir(managerConfig.ServicePath), "config.yaml")
-	args := resolveEngineArgs(managerConfig.OtelMode, otelConfigDefault, managerConfig.Args)
+	args := resolveEngineArgs(managerConfig.OtelMode, otelConfigDefault, managerConfig.OtelArguments, managerConfig.Args)
 
 	cfg := serviceManagerConfig{
 		path:        managerConfig.ServicePath,

--- a/internal/cmd/alloy-service/main_windows.go
+++ b/internal/cmd/alloy-service/main_windows.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"golang.org/x/sys/windows"
@@ -49,9 +50,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	otelConfigDefault := filepath.Join(filepath.Dir(managerConfig.ServicePath), "config.yaml")
+	args := resolveEngineArgs(managerConfig.OtelMode, otelConfigDefault, managerConfig.Args)
+
 	cfg := serviceManagerConfig{
 		path:        managerConfig.ServicePath,
-		args:        managerConfig.Args,
+		args:        args,
 		environment: managerConfig.Environment,
 		dir:         managerConfig.WorkingDirectory,
 

--- a/packaging/windows/config.yaml
+++ b/packaging/windows/config.yaml
@@ -1,0 +1,24 @@
+# Sample config for Alloy's OTel engine.
+#
+# For a full configuration reference, see https://grafana.com/docs/alloy
+receivers:
+  otlp:
+    protocols:
+      grpc: {}
+      http: {}
+
+exporters:
+  # TODO: replace the debug exporter with a real backend.
+  debug:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      exporters: [debug]

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -283,6 +283,16 @@ Function InitializeRegistry
     Pop $0 # Ignore return result
   ${EndIf}
 
+  # Define the OTelArguments key, which holds extra flags for the OTel
+  # engine only, mirroring Arguments for the default engine. Empty by
+  # default; edited by hand after install, the same way Arguments is.
+  nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /v OTelArguments'
+  Pop $0
+  ${If} $0 == 1
+    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v OTelArguments /t REG_MULTI_SZ /d ""'
+    Pop $0 # Ignore return result
+  ${EndIf}
+
   Return
 FunctionEnd
 

--- a/packaging/windows/install_script.nsis
+++ b/packaging/windows/install_script.nsis
@@ -46,6 +46,7 @@ Var User
 Var Password
 Var AuthFlag
 Var ForceRegistry
+Var OtelMode
 
 # Pages during the installer.
 Page license
@@ -69,6 +70,7 @@ Section "install"
   ${GetOptions} $PassedInParameters "/USERNAME=" $User
   ${GetOptions} $PassedInParameters "/PASSWORD=" $Password
   ${GetOptions} $PassedInParameters "/FORCEREGISTRY=" $ForceRegistry
+  ${GetOptions} $PassedInParameters "/OTELMODE=" $OtelMode
 
   # Calls to functions like nsExec::ExecToLog below push the exit code to the
   # stack, and must be popped after calling.
@@ -118,6 +120,7 @@ Section "install"
   WriteRegDWORD HKLM "${UNINSTALLKEY}" "NoRepair" 1
 
   Call CreateConfig
+  Call CreateOtelConfig
   Call CreateDataDirectory
   Call InitializeRegistry
   Call RegisterEventSource
@@ -158,6 +161,27 @@ Function CreateConfig
     AccessControl::GrantOnFile  "$INSTDIR\config.alloy" "Everyone" "ReadAttributes"
     ${If} $User != ""
       AccessControl::SetOnFile    "$INSTDIR\config.alloy" "$User" "FullAccess"
+    ${EndIf}
+
+    Return
+FunctionEnd
+
+Function CreateOtelConfig
+  IfFileExists "$INSTDIR\config.yaml" Noop CreateNewOtelConfig
+  Noop:
+    Return
+  CreateNewOtelConfig:
+    File "config.yaml"
+
+    # Set permissions on the OTel engine config file, mirroring CreateConfig.
+    AccessControl::DisableFileInheritance "$INSTDIR\config.yaml"
+    AccessControl::SetFileOwner "$INSTDIR\config.yaml" "Administrators"
+    AccessControl::ClearOnFile  "$INSTDIR\config.yaml" "Administrators" "FullAccess"
+    AccessControl::SetOnFile    "$INSTDIR\config.yaml" "SYSTEM" "FullAccess"
+    AccessControl::GrantOnFile  "$INSTDIR\config.yaml" "Everyone" "ListDirectory"
+    AccessControl::GrantOnFile  "$INSTDIR\config.yaml" "Everyone" "ReadAttributes"
+    ${If} $User != ""
+      AccessControl::SetOnFile    "$INSTDIR\config.yaml" "$User" "FullAccess"
     ${EndIf}
 
     Return
@@ -244,6 +268,18 @@ Function InitializeRegistry
     # Define the environment key, which holds environment variables to pass to the
     # service.
     nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v Environment /t REG_MULTI_SZ /d "$Environment"'
+    Pop $0 # Ignore return result
+  ${EndIf}
+
+  # Define the ALLOY_OTEL_MODE key, which selects the run engine. Mirrors
+  # the ALLOY_OTEL_MODE environment variable used by the systemd packages
+  # and Homebrew: truthy values (1, true, yes, on) select the OTel engine
+  # (alloy otel); anything else, including absent/empty, keeps the default
+  # engine (alloy run).
+  nsExec::ExecToLog 'Reg.exe query "${REGKEY}" /reg:64 /v ALLOY_OTEL_MODE'
+  Pop $0
+  ${If} $0 == 1
+    nsExec::ExecToLog 'Reg.exe add "${REGKEY}" /reg:64 /v ALLOY_OTEL_MODE /t REG_SZ /d "$OtelMode"'
     Pop $0 # Ignore return result
   ${EndIf}
 


### PR DESCRIPTION
### Brief description of Pull Request
Implements the ability for users to toggle between the default engine and the otel engine in windows service installations

### Pull Request Details
Part of https://github.com/grafana/alloy/issues/4725

Mirroring the systemd and launchd implementations, this PR introduces the registry value `ALLOY_OTEL_MODE` which, when empty or set to falsy, will mean that the windows service launches `alloy run...`. If the user toggles this flag to a truthy value (true|1|yes, case insensitive) then the OTel engine will run with the config defined at `$INSTDIR\config.yaml`. The user can also specify the `OTelArguments` registry value in which they can pass through extra arguments to the `otel` command after the default `--config` argv. 

### Notes to the Reviewer
We already have some integration tests set up, so i extended those to smoke test toggling between the engines. Once we have a RC published I will also do some manual testing with the installer on our windows VM

Much like the systemd [PR](https://github.com/grafana/alloy/pull/7006), this PR does not include documentation. I will create a follow up PR which includes documentation for all our service installations that can be reviewed independently. 

### PR Checklist
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
