### PR TITLE
ci(helm): Automate helm releases

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,12 +1,16 @@
 name: Release Helm chart
 on:
-  push:
-    branches: [main]
-  workflow_dispatch: {}
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing stable Alloy release tag for which to publish a Helm chart
+        required: true
+        type: string
 env:
   ALLOYBOT_APP_NAME: grafana-alloybot
   CR_CONFIGFILE: "${{ github.workspace }}/source/operations/helm/cr.yaml"
-  CT_CONFIGFILE: "${{ github.workspace }}/source/operations/helm/ct.yaml"
   CR_INDEX_PATH: "${{ github.workspace }}/.cr-index"
   CR_PACKAGE_PATH: "${{ github.workspace }}/.cr-release-packages"
   CR_TOOL_PATH: "${{ github.workspace }}/.cr-tool"
@@ -14,57 +18,49 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: helm-release
+  cancel-in-progress: false
+
 jobs:
   setup:
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'v') && github.event.release.prerelease == false)
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.list-changed.outputs.changed }}
-      chartpath: ${{ steps.list-changed.outputs.chartpath }}
+      changed: ${{ steps.prepare.outputs.changed }}
+      chartpath: ${{ steps.prepare.outputs.chartpath }}
+      desc: ${{ steps.prepare.outputs.desc }}
+      tagname: ${{ steps.prepare.outputs.tagname }}
+      packagename: ${{ steps.prepare.outputs.packagename }}
+      source_sha: ${{ steps.prepare.outputs.source_sha }}
     steps:
-      - name: Checkout
+      - name: Checkout tools
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.repository.default_branch || github.ref }}
+          persist-credentials: false
+
+      - name: Checkout Alloy tag
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           path: source
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
           persist-credentials: false
 
-      - name: Install chart-testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: tools/go.mod
+          cache-dependency-path: tools/go.sum
+          cache: false
 
-      - name: List changed charts
-        id: list-changed
-        run: |
-          cd source
-
-          latest_tag=$( if ! git describe --tags --abbrev=0 --match='helm-chart/*' 2> /dev/null ; then git rev-list --max-parents=0 --first-parent HEAD; fi )
-
-          echo "Running: ct list-changed --config ${CT_CONFIGFILE} --since ${latest_tag} --target-branch ${GH_REF_NAME}"
-          changed=$(ct list-changed --config "${CT_CONFIGFILE}" --since "${latest_tag}" --target-branch "${GH_REF_NAME}")
-          echo "${changed}"
-
-          num_changed=$(wc -l <<< ${changed})
-          if [[ "${num_changed}" -gt "1" ]] ; then
-            echo "More than one chart changed, exiting"
-            exit 1
-          fi
-          if [[ -n "${changed}" ]]; then
-            name=$(yq ".name" < ${changed}/Chart.yaml)
-            version=$(yq ".version" < ${changed}/Chart.yaml)
-
-            if [ $(git tag -l "helm-chart/${version}") ]; then
-              echo "Tag helm-chart/${tagname} already exists, skipping release"
-              echo "changed=false" >> $GITHUB_OUTPUT
-            else
-              echo "Releasing ${changed}"
-              echo "changed=true" >> $GITHUB_OUTPUT
-              echo "chartpath=${changed}" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "No charts have changed, skipping release"
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
+      - name: Prepare Helm release
+        id: prepare
         env:
-          GH_REF_NAME: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: go run -C tools ./cmd release prepare-helm --tag "${RELEASE_TAG}" --repo-root "${GITHUB_WORKSPACE}/source"
 
   release:
     needs: [setup]
@@ -92,35 +88,15 @@ jobs:
         with:
           fetch-depth: 0
           path: source
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: true # Needed for `git push origin tag_name`
-
-      - name: Configure Git
-        run: |
-          cd source
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           # renovate: datasource=github-releases packageName=helm/helm
           version: v3.21.1
-
-      - name: Parse Chart.yaml
-        id: parse-chart
-        run: |
-          cd source
-          changed="${CHART_PATH}"
-          description=$(yq ".description" < ${changed}/Chart.yaml)
-          name=$(yq ".name" < ${changed}/Chart.yaml)
-          version=$(yq ".version" < ${changed}/Chart.yaml)
-          echo "chartpath=${changed}" >> $GITHUB_OUTPUT
-          echo "desc=${description}" >> $GITHUB_OUTPUT
-          echo "tagname=helm-chart/${version}" >> $GITHUB_OUTPUT
-          echo "packagename=${name}-${version}" >> $GITHUB_OUTPUT
-        env:
-          CHART_PATH: ${{ needs.setup.outputs.chartpath }}
 
       - name: Install CR tool
         run: |
@@ -138,42 +114,26 @@ jobs:
           echo "Result of chart package:"
           ls -l "${CR_PACKAGE_PATH}"
         env:
-          CHART_PATH: ${{ steps.parse-chart.outputs.chartpath }}
-
-      - name: Create tag and check if exists on origin
-        run: |
-          cd source
-          echo "Making tag ${TAG_NAME}"
-          git tag "${TAG_NAME}"
-        env:
-          TAG_NAME: ${{ steps.parse-chart.outputs.tagname }}
+          CHART_PATH: ${{ needs.setup.outputs.chartpath }}
 
       # Note that this creates a release in grafana/helm-charts with a new tag.
       # The tag name in grafana/helm-charts is <package>-<version>, while the
-      # tag name for grafana/alloy is helm-chart/<version>.
+      # helm-chart/<version> source tag is created by Release-Please.
       - name: Make github release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          name: ${{ steps.parse-chart.outputs.packagename }}
+          name: ${{ needs.setup.outputs.packagename }}
           repository: grafana/helm-charts
-          tag_name: ${{ steps.parse-chart.outputs.packagename }}
+          tag_name: ${{ needs.setup.outputs.packagename }}
           token: ${{ steps.app-token.outputs.token }}
           body: |
-            ${{ steps.parse-chart.outputs.desc }}
+            ${{ needs.setup.outputs.desc }}
 
-            Source commit: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+            Source commit: https://github.com/${{ github.repository }}/commit/${{ needs.setup.outputs.source_sha }}
 
-            Tag on source: https://github.com/${{ github.repository }}/releases/tag/${{ steps.parse-chart.outputs.tagname }}
+            Tag on source: https://github.com/${{ github.repository }}/releases/tag/${{ needs.setup.outputs.tagname }}
           files: |
-            ${{ env.CR_PACKAGE_PATH }}/${{ steps.parse-chart.outputs.packagename }}.tgz
-
-      - name: Push release tag on origin
-        run: |
-          cd source
-          echo "Pushing tag ${TAG_NAME}"
-          git push origin "${TAG_NAME}"
-        env:
-          TAG_NAME: ${{ steps.parse-chart.outputs.tagname }}
+            ${{ env.CR_PACKAGE_PATH }}/${{ needs.setup.outputs.packagename }}.tgz
 
       - name: Update helm-charts index.yaml
         run: |
@@ -185,7 +145,7 @@ jobs:
       - name: Publish index.yaml to gh-pages
         uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
         with:
-          commit_message: "Update index.yaml for ${{ steps.parse-chart.outputs.tagname }}"
+          commit_message: "Update index.yaml for ${{ needs.setup.outputs.tagname }}"
           repo: grafana/helm-charts
           branch: gh-pages
           file_pattern: index.yaml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -60,11 +60,13 @@ jobs:
           TARGET_BRANCH: ${{ github.ref_name }}
           CONFIG_FILE: release-please-config.json
           MANIFEST_FILE: .release-please-manifest.json
-        # Release branches only manage the root Alloy module. Component modules
-        # (e.g. syntax) release from main and should not open PRs on release/v*.
+        # Release branches manage Alloy and its Helm chart. Other component
+        # modules (e.g. syntax) release from main.
         run: |
           if [[ "${TARGET_BRANCH}" == release/v* ]]; then
-            node index.js --root-only
+            node index.js \
+              --include . \
+              --include operations/helm/charts/alloy
           else
             node index.js
           fi
@@ -99,7 +101,7 @@ jobs:
         with:
           version: v2026.5.18
           sha256: cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84
-          install_args: go
+          install_args: go helm helm-docs
 
       - name: Find release-please branch 🔎
         id: release-branch
@@ -135,6 +137,10 @@ jobs:
       - name: Regenerate collector distro 🏗️
         if: steps.release-branch.outputs.exists == 'true'
         run: make generate-otel-collector-distro
+
+      - name: Regenerate Helm documentation and tests 🏗️
+        if: steps.release-branch.outputs.exists == 'true'
+        run: make generate-helm-docs generate-helm-tests
 
       - name: Write release-please pull request body 📝
         if: steps.release-branch.outputs.exists == 'true'

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   ".": "1.19.0",
-  "syntax": "0.1.2"
+  "syntax": "0.1.2",
+  "operations/helm/charts/alloy": "1.12.1"
 }

--- a/build-tools/release-please-runner/index.js
+++ b/build-tools/release-please-runner/index.js
@@ -8,12 +8,14 @@
 import { GitHub, Manifest, VERSION } from 'release-please';
 import { registerVersioningStrategy } from 'release-please/build/src/factories/versioning-strategy-factory.js';
 import { MinorBreakingVersioningStrategy } from './minor-breaking-versioning.js';
+import { HelmAlloyCommitInjector } from './plugins/helm-alloy-commit-injector.js';
 import { outputReleasePullRequests } from './release-pr-output.js';
 import {
   installTagOnlyReleaseHandler,
   prepareTagOnlyPackages,
   getTagOnlyPathsFromConfig,
 } from './tag-only-releases.js';
+import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 
 // Register the custom versioning strategy
@@ -21,31 +23,51 @@ registerVersioningStrategy('minor-breaking', (options) => new MinorBreakingVersi
 
 const DEFAULT_CONFIG_FILE = 'release-please-config.json';
 const DEFAULT_MANIFEST_FILE = '.release-please-manifest.json';
-const ROOT_PACKAGE_PATH = '.';
+
+export const usage = `Usage: node index.js [options]
+
+Options:
+  --include <path>  Keep only this package path in the manifest. Repeatable.
+                    Packages that are not listed are dropped. If omitted, all
+                    packages are kept.
+  -h, --help        Show this help.
+`;
 
 /**
- * Parse CLI flags from argv (process.argv.slice(2) by default).
- * Unknown flags are rejected.
+ * Returns a parser for the runner CLI. Unknown flags are rejected.
+ *
+ * Options:
+ *   --include <path>  Keep only this package path. Repeatable.
+ *   -h, --help        Show usage.
  */
-export function parseArgs(argv = process.argv.slice(2)) {
-  const args = {
-    rootOnly: false,
+export function createArgParser() {
+  return (argv = process.argv.slice(2)) => {
+    const { values } = parseArgs({
+      args: argv,
+      options: {
+        include: {
+          type: 'string',
+          multiple: true,
+          default: [],
+        },
+        help: {
+          type: 'boolean',
+          short: 'h',
+          default: false,
+        },
+      },
+    });
+    return { include: values.include, help: values.help };
   };
-
-  for (const arg of argv) {
-    switch (arg) {
-      case '--root-only':
-        args.rootOnly = true;
-        break;
-      default:
-        throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  return args;
 }
 
 function parseInputs(argv = process.argv.slice(2)) {
+  const parse = createArgParser();
+  const cliArgs = parse(argv);
+  if (cliArgs.help) {
+    return { help: true, include: cliArgs.include };
+  }
+
   const token = process.env.GITHUB_TOKEN;
   if (!token) {
     throw new Error('GITHUB_TOKEN environment variable is required');
@@ -56,8 +78,6 @@ function parseInputs(argv = process.argv.slice(2)) {
     throw new Error('REPO_URL or GITHUB_REPOSITORY environment variable is required');
   }
 
-  const cliArgs = parseArgs(argv);
-
   return {
     token,
     repoUrl,
@@ -66,30 +86,47 @@ function parseInputs(argv = process.argv.slice(2)) {
     manifestFile: process.env.MANIFEST_FILE || DEFAULT_MANIFEST_FILE,
     skipGitHubRelease: process.env.SKIP_GITHUB_RELEASE === 'true',
     skipGitHubPullRequest: process.env.SKIP_GITHUB_PULL_REQUEST === 'true',
-    rootOnly: cliArgs.rootOnly,
+    include: cliArgs.include,
   };
 }
 
-function loadManifest(github, inputs) {
-  const onlyPath = inputs.rootOnly ? ROOT_PACKAGE_PATH : undefined;
-  if (onlyPath) {
-    console.log(`Loading manifest from config file (root-only: path=${onlyPath})`);
-  } else {
-    console.log('Loading manifest from config file');
-  }
-  return Manifest.fromManifest(
+function keepPaths(entries, paths) {
+  return Object.fromEntries(Object.entries(entries).filter(([path]) => paths.has(path)));
+}
+
+export function keepIncludedPackages(manifest, paths) {
+  const included = new Set(paths);
+  manifest.repositoryConfig = keepPaths(manifest.repositoryConfig, included);
+  manifest.releasedVersions = keepPaths(manifest.releasedVersions, included);
+}
+
+async function loadManifest(github, inputs) {
+  console.log('Loading manifest from config file');
+  const manifest = await Manifest.fromManifest(
     github,
     inputs.targetBranch || github.repository.defaultBranch,
     inputs.configFile,
     inputs.manifestFile,
-    {},
-    onlyPath
   );
+
+  if (inputs.include.length > 0) {
+    console.log(`Keeping packages: ${inputs.include.join(', ')}`);
+    keepIncludedPackages(manifest, inputs.include);
+  }
+
+  manifest.plugins.unshift(new HelmAlloyCommitInjector());
+
+  return manifest;
 }
 
 async function main() {
-  console.log(`Running release-please version: ${VERSION}`);
   const inputs = parseInputs();
+  if (inputs.help) {
+    console.log(usage);
+    return;
+  }
+
+  console.log(`Running release-please version: ${VERSION}`);
   const github = await getGitHubInstance(inputs);
 
   if (!inputs.skipGitHubRelease) {

--- a/build-tools/release-please-runner/index.test.js
+++ b/build-tools/release-please-runner/index.test.js
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createArgParser, keepIncludedPackages, usage } from './index.js';
+
+const parseArgs = createArgParser();
+
+test('parseArgs collects repeated --include paths', () => {
+  assert.deepEqual(parseArgs(['--include', '.', '--include', 'syntax']), {
+    include: ['.', 'syntax'],
+    help: false,
+  });
+});
+
+test('parseArgs collects --include= paths', () => {
+  assert.deepEqual(parseArgs(['--include=.', '--include=syntax']), {
+    include: ['.', 'syntax'],
+    help: false,
+  });
+});
+
+test('parseArgs defaults include to an empty list', () => {
+  assert.deepEqual(parseArgs([]), { include: [], help: false });
+});
+
+test('parseArgs accepts --help', () => {
+  assert.equal(parseArgs(['--help']).help, true);
+  assert.equal(parseArgs(['-h']).help, true);
+});
+
+test('usage documents --include as an allowlist', () => {
+  assert.match(usage, /--include <path>/);
+  assert.match(usage, /Keep only this package path in the manifest/);
+  assert.match(usage, /Packages that are not listed are dropped/);
+});
+
+test('parseArgs rejects --include without a path', () => {
+  assert.throws(() => parseArgs(['--include']), /Option '--include <value>' argument missing/);
+  assert.throws(() => parseArgs(['--include', '--include', '.']), /Option '--include' argument is ambiguous/);
+});
+
+test('parseArgs rejects unknown arguments', () => {
+  assert.throws(() => parseArgs(['--root-only']), /Unknown option '--root-only'/);
+});
+
+test('keepIncludedPackages keeps only the requested paths', () => {
+  const manifest = {
+    repositoryConfig: {
+      '.': {},
+      syntax: {},
+      'operations/helm/charts/alloy': {},
+    },
+    releasedVersions: {
+      '.': '1.20.0',
+      syntax: '0.2.0',
+      'operations/helm/charts/alloy': '1.13.0',
+    },
+  };
+
+  keepIncludedPackages(manifest, ['.', 'operations/helm/charts/alloy']);
+
+  assert.deepEqual(Object.keys(manifest.repositoryConfig), [
+    '.',
+    'operations/helm/charts/alloy',
+  ]);
+  assert.deepEqual(Object.keys(manifest.releasedVersions), [
+    '.',
+    'operations/helm/charts/alloy',
+  ]);
+});

--- a/build-tools/release-please-runner/package.json
+++ b/build-tools/release-please-runner/package.json
@@ -9,7 +9,8 @@
     "npm": ">=11.13.0"
   },
   "scripts": {
-    "release-please": "node index.js"
+    "release-please": "node index.js",
+    "test": "node --test '**/*.test.js'"
   },
   "dependencies": {
     "release-please": "^17.11.1"

--- a/build-tools/release-please-runner/plugins/helm-alloy-commit-injector.js
+++ b/build-tools/release-please-runner/plugins/helm-alloy-commit-injector.js
@@ -1,0 +1,47 @@
+import { parseConventionalCommits } from 'release-please/build/src/commit.js';
+
+const ROOT_PATH = '.';
+const HELM_PATH = 'operations/helm/charts/alloy';
+
+/**
+ * Injects a synthetic conventional commit into the Helm package when Alloy
+ * would get a new version, so the chart bumps with it: `fix` for a patch,
+ * `feat` otherwise. No-ops if either strategy is missing.
+ */
+export class HelmAlloyCommitInjector {
+  async preconfigure(strategies, commitsByPath, releasesByPath) {
+    if (!strategies[ROOT_PATH] || !strategies[HELM_PATH]) {
+      // Do nothing unless both Alloy and Helm release strategies are present
+      return strategies;
+    }
+
+    const alloyRelease = await strategies[ROOT_PATH].buildReleasePullRequest(
+      parseConventionalCommits(commitsByPath[ROOT_PATH]),
+      releasesByPath[ROOT_PATH],
+    );
+    if (!alloyRelease?.version) {
+      return strategies;
+    }
+
+    const previousVersion = releasesByPath[ROOT_PATH]?.tag.version;
+    const commitType =
+      previousVersion?.major === alloyRelease.version.major &&
+      previousVersion?.minor === alloyRelease.version.minor
+        ? 'fix'
+        : 'feat';
+
+    commitsByPath[HELM_PATH].push({
+      sha: '',
+      message: `${commitType}(helm): Update to Grafana Alloy v${alloyRelease.version}`,
+    });
+    return strategies;
+  }
+
+  processCommits(commits) {
+    return commits;
+  }
+
+  async run(candidates) {
+    return candidates;
+  }
+}

--- a/build-tools/release-please-runner/plugins/helm-alloy-commit-injector.test.js
+++ b/build-tools/release-please-runner/plugins/helm-alloy-commit-injector.test.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { Version } from 'release-please/build/src/version.js';
+import { HelmAlloyCommitInjector } from './helm-alloy-commit-injector.js';
+
+const HELM_PATH = 'operations/helm/charts/alloy';
+
+test('adds a Helm fix commit for an Alloy patch candidate', async () => {
+  const plugin = new HelmAlloyCommitInjector();
+  const strategies = {
+    '.': {
+      buildReleasePullRequest: async () => ({
+        version: Version.parse('1.19.3'),
+      }),
+    },
+    [HELM_PATH]: {},
+  };
+  const commitsByPath = {
+    '.': [{ sha: 'abc123', message: 'feat: Add an Alloy feature' }],
+    [HELM_PATH]: [],
+  };
+
+  const releasesByPath = {
+    '.': { tag: { version: Version.parse('1.19.2') } },
+  };
+
+  const result = await plugin.preconfigure(strategies, commitsByPath, releasesByPath);
+
+  assert.equal(result, strategies);
+  assert.deepEqual(commitsByPath[HELM_PATH], [
+    {
+      sha: '',
+      message: 'fix(helm): Update to Grafana Alloy v1.19.3',
+    },
+  ]);
+});
+
+test('adds a Helm feature commit for an Alloy minor candidate', async () => {
+  const plugin = new HelmAlloyCommitInjector();
+  const strategies = {
+    '.': {
+      buildReleasePullRequest: async () => ({
+        version: Version.parse('1.20.0'),
+      }),
+    },
+    [HELM_PATH]: {},
+  };
+  const commitsByPath = {
+    '.': [{ sha: 'abc123', message: 'feat: Add an Alloy feature' }],
+    [HELM_PATH]: [],
+  };
+  const releasesByPath = {
+    '.': { tag: { version: Version.parse('1.19.2') } },
+  };
+
+  await plugin.preconfigure(strategies, commitsByPath, releasesByPath);
+
+  assert.deepEqual(commitsByPath[HELM_PATH], [
+    {
+      sha: '',
+      message: 'feat(helm): Update to Grafana Alloy v1.20.0',
+    },
+  ]);
+});
+
+test('does not add a Helm commit when Alloy would not version', async () => {
+  const plugin = new HelmAlloyCommitInjector();
+  const strategies = {
+    '.': {
+      buildReleasePullRequest: async () => undefined,
+    },
+    [HELM_PATH]: {},
+  };
+  const commitsByPath = {
+    '.': [],
+    [HELM_PATH]: [],
+  };
+
+  await plugin.preconfigure(strategies, commitsByPath, {});
+
+  assert.deepEqual(commitsByPath[HELM_PATH], []);
+});

--- a/docs/developer/shepherding-releases.md
+++ b/docs/developer/shepherding-releases.md
@@ -97,12 +97,14 @@ cut a new RC and repeat step 3.
 4. This will automatically create the corresponding `release/vX.Y` branch (and `backport/vX.Y` label
    if it wasn't already created during the RC phase).
 
-### 6. Update Helm Chart
+### 6. Verify the Helm chart release
 
-1. Create a PR against `main` to update the helm chart code.
-2. Update `Chart.yaml` with the new helm version and app version.
-3. Update `CHANGELOG.md` with a new section for the helm version.
-4. Run `make docs rebuild-tests` from the `operations/helm` directory.
+The release-please PR automatically updates the Helm chart version, sets `appVersion` to the Alloy
+version, updates the Helm changelog, and regenerates Helm documentation and tests. Publishing the
+stable Alloy release then publishes the chart from the same tag.
+
+Confirm that the `Release Helm chart` workflow completes successfully. If it needs to be recovered,
+run that workflow manually with the existing stable Alloy release tag.
 
 ### 7. Update Homebrew
 
@@ -150,6 +152,8 @@ The process for this is exactly the same as a minor release with a few notable e
    truly goofed and backported a feature instead of a fix, revert it and update changelog entries as
    necessary.
 4. Patch releases typically do not have RCs.
+5. Helm automation applies only to release branches created after this process was introduced.
+   Older release branches retain their existing chart state.
 
 ## Publishing fails with a tag rule violation
 

--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -1,17 +1,6 @@
 # Changelog
 
-> _Contributors should read our [contributors guide][] for instructions on how
-> to update the changelog._
-
-This document contains a historical list of changes between releases. Only
-changes that impact end-user behavior are listed; changes to documentation or
-internal API changes are not present.
-
-Unreleased
-----------
-
-1.12.1 (2026-08-26)
-----------
+## [1.12.1](https://github.com/grafana/alloy/compare/helm-chart/1.12.0...helm-chart/1.12.1) (2026-08-26)
 
 ### Enhancements
 

--- a/operations/helm/charts/alloy/Chart.yaml
+++ b/operations/helm/charts/alloy/Chart.yaml
@@ -3,7 +3,9 @@ name: alloy
 description: "Grafana Alloy"
 type: application
 version: 1.12.1
-appVersion: "v1.19.2"  # x-release-please-version
+# x-release-please-start-version
+appVersion: "v1.19.2"
+# x-release-please-end
 icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
 
 dependencies:

--- a/operations/helm/charts/alloy/Chart.yaml
+++ b/operations/helm/charts/alloy/Chart.yaml
@@ -3,7 +3,7 @@ name: alloy
 description: "Grafana Alloy"
 type: application
 version: 1.12.1
-appVersion: "v1.19.2" # x-release-please-version
+appVersion: "v1.19.2"  # x-release-please-version
 icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
 
 dependencies:

--- a/operations/helm/charts/alloy/Chart.yaml
+++ b/operations/helm/charts/alloy/Chart.yaml
@@ -3,7 +3,7 @@ name: alloy
 description: "Grafana Alloy"
 type: application
 version: 1.12.1
-appVersion: "v1.19.2"
+appVersion: "v1.19.2" # x-release-please-version
 icon: https://raw.githubusercontent.com/grafana/alloy/main/docs/sources/assets/alloy_icon_orange.svg
 
 dependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -41,6 +41,10 @@
         {
           "type": "generic",
           "path": "collector/VERSION"
+        },
+        {
+          "type": "generic",
+          "path": "operations/helm/charts/alloy/Chart.yaml"
         }
       ]
     },
@@ -56,6 +60,14 @@
           "path": "/go.mod"
         }
       ]
+    },
+    "operations/helm/charts/alloy": {
+      "component": "helm-chart",
+      "package-name": "alloy",
+      "release-type": "helm",
+      "include-component-in-tag": true,
+      "include-v-in-tag": false,
+      "skip-github-release": true
     }
   }
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -51,8 +51,8 @@ other AI-review bots on the same PR. See
 
 ### `release`
 
-Four subcommands that automate the release flow. Each is driven by a GitHub
-Actions workflow and supports `--dry-run` so you can verify what would happen
+Subcommands that automate the release flow. Each is driven by a GitHub
+Actions workflow. Most support `--dry-run` so you can verify what would happen
 without making changes.
 
 **`release create-release-branch --tag=<v1.X.0>`**
@@ -84,6 +84,15 @@ published release's body, and optionally appends a footer template (with
 `${RELEASE_DOC_TAG}` substituted to `vX.Y`). Component release tags (those
 with a `/` like `syntax/v0.1.2`) skip the footer. Driven by
 `release-enrich-release-notes.yml` (fires on release publish).
+
+**`release prepare-helm --tag=<v1.X.Y>`**
+
+Decides whether the Alloy Helm chart should be published for a stable Alloy
+release. It skips non-stable tags, draft/prerelease GitHub releases, and charts
+that already exist on `grafana/helm-charts`. It fails when `Chart.yaml`
+`appVersion` does not match the Alloy tag or when the `helm-chart/<version>`
+source tag is missing. Writes GitHub Actions outputs consumed by
+`helm-release.yml`.
 
 ### `sync-replaces`
 

--- a/tools/release/backport/command.go
+++ b/tools/release/backport/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-github/v57/github"
 	"github.com/spf13/cobra"
 
+	"github.com/grafana/alloy/tools/release/internal/gha"
 	"github.com/grafana/alloy/tools/release/internal/git"
 	gh "github.com/grafana/alloy/tools/release/internal/github"
 )
@@ -74,7 +75,7 @@ func run(ctx context.Context, flags flags) (retErr error) {
 		return err
 	}
 	if info == nil {
-		return setGitHubOutput("skipped", "true")
+		return gha.SetOutput("skipped", "true")
 	}
 
 	if flags.dryRun {
@@ -212,7 +213,7 @@ func writeBackportOutputs(info *backportInfo, commitMessage string) error {
 	}
 
 	for name, value := range outputs {
-		if err := setGitHubOutput(name, value); err != nil {
+		if err := gha.SetOutput(name, value); err != nil {
 			return err
 		}
 	}
@@ -270,29 +271,6 @@ func appendOriginalAuthorTrailer(message string, author git.CommitAuthor) string
 	}
 
 	return strings.TrimRight(message, "\n") + "\n\n" + trailer
-}
-
-func setGitHubOutput(name, value string) error {
-	outputPath := os.Getenv("GITHUB_OUTPUT")
-	if outputPath == "" {
-		return nil
-	}
-
-	outputFile, err := os.OpenFile(outputPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		return fmt.Errorf("opening GITHUB_OUTPUT: %w", err)
-	}
-	defer outputFile.Close()
-
-	delimiter := "EOF"
-	for strings.Contains(value, delimiter) {
-		delimiter += "_EOF"
-	}
-
-	if _, err := fmt.Fprintf(outputFile, "%s<<%s\n%s\n%s\n", name, delimiter, value, delimiter); err != nil {
-		return fmt.Errorf("writing GITHUB_OUTPUT %s: %w", name, err)
-	}
-	return nil
 }
 
 func commentOnBackportFailure(ctx context.Context, client *gh.Client, info *backportInfo, backportErr error) {

--- a/tools/release/command.go
+++ b/tools/release/command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/alloy/tools/release/createrc"
 	"github.com/grafana/alloy/tools/release/createreleasebranch"
 	"github.com/grafana/alloy/tools/release/enrichreleasenotes"
+	"github.com/grafana/alloy/tools/release/preparehelm"
 )
 
 func Command() *cobra.Command {
@@ -25,6 +26,7 @@ func Command() *cobra.Command {
 		createrc.Command(),
 		createreleasebranch.Command(),
 		enrichreleasenotes.Command(),
+		preparehelm.Command(),
 	)
 
 	return cmd

--- a/tools/release/internal/gha/output.go
+++ b/tools/release/internal/gha/output.go
@@ -1,0 +1,33 @@
+// Package gha writes GitHub Actions workflow outputs.
+package gha
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// SetOutput appends a name/value pair to GITHUB_OUTPUT. It is a no-op when
+// GITHUB_OUTPUT is unset, so commands stay usable outside Actions.
+func SetOutput(name, value string) error {
+	outputPath := os.Getenv("GITHUB_OUTPUT")
+	if outputPath == "" {
+		return nil
+	}
+
+	outputFile, err := os.OpenFile(outputPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening GITHUB_OUTPUT: %w", err)
+	}
+	defer outputFile.Close()
+
+	delimiter := "EOF"
+	for strings.Contains(value, delimiter) {
+		delimiter += "_EOF"
+	}
+
+	if _, err := fmt.Fprintf(outputFile, "%s<<%s\n%s\n%s\n", name, delimiter, value, delimiter); err != nil {
+		return fmt.Errorf("writing GITHUB_OUTPUT %s: %w", name, err)
+	}
+	return nil
+}

--- a/tools/release/internal/github/client.go
+++ b/tools/release/internal/github/client.go
@@ -123,11 +123,7 @@ func (c *Client) Repo() string {
 func (c *Client) BranchExists(ctx context.Context, branch string) (bool, error) {
 	_, resp, err := c.api.Repositories.GetBranch(ctx, c.owner, c.repo, branch, 0)
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return false, nil
-		}
-		var errResp *github.ErrorResponse
-		if errors.As(err, &errResp) && errResp.Response.StatusCode == http.StatusNotFound {
+		if isNotFound(resp, err) {
 			return false, nil
 		}
 		return false, err
@@ -314,6 +310,38 @@ func (c *Client) GetReleaseByTag(ctx context.Context, tag string) (*github.Repos
 		return nil, fmt.Errorf("getting release for tag %s: %w", tag, err)
 	}
 	return release, nil
+}
+
+// HasRelease reports whether a GitHub Release exists for the given tag.
+func (c *Client) HasRelease(ctx context.Context, tag string) (bool, error) {
+	_, resp, err := c.api.Repositories.GetReleaseByTag(ctx, c.owner, c.repo, tag)
+	if err != nil {
+		if isNotFound(resp, err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking release %s: %w", tag, err)
+	}
+	return true, nil
+}
+
+// HasTag reports whether a git tag exists in the repository.
+func (c *Client) HasTag(ctx context.Context, tag string) (bool, error) {
+	_, resp, err := c.api.Git.GetRef(ctx, c.owner, c.repo, "tags/"+tag)
+	if err != nil {
+		if isNotFound(resp, err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking tag %s: %w", tag, err)
+	}
+	return true, nil
+}
+
+func isNotFound(resp *github.Response, err error) bool {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return true
+	}
+	var errResp *github.ErrorResponse
+	return errors.As(err, &errResp) && errResp.Response != nil && errResp.Response.StatusCode == http.StatusNotFound
 }
 
 // UpdateReleaseBody updates only the body of a release.

--- a/tools/release/preparehelm/command.go
+++ b/tools/release/preparehelm/command.go
@@ -1,0 +1,121 @@
+package preparehelm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/alloy/tools/release/internal/gha"
+	gh "github.com/grafana/alloy/tools/release/internal/github"
+)
+
+const (
+	defaultChartPath      = "operations/helm/charts/alloy"
+	defaultHelmChartsRepo = "grafana/helm-charts"
+)
+
+type flags struct {
+	tag            string
+	chartPath      string
+	helmChartsRepo string
+	repoRoot       string
+}
+
+func Command() *cobra.Command {
+	var flags flags
+
+	cmd := &cobra.Command{
+		Use:   "prepare-helm",
+		Short: "Decide whether to publish the Alloy Helm chart and emit GitHub Actions outputs",
+		Long: "Checks that the Alloy tag is a published stable release, Chart.yaml appVersion " +
+			"matches, the helm-chart/<version> source tag exists, and grafana/helm-charts does " +
+			"not already have alloy-<version>. Writes GITHUB_OUTPUT for the Helm release workflow.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.tag, "tag", "", "Alloy release tag (e.g. v1.19.2)")
+	cmd.Flags().StringVar(&flags.chartPath, "chart-path", defaultChartPath, "Path to the Helm chart, relative to --repo-root")
+	cmd.Flags().StringVar(&flags.helmChartsRepo, "helm-charts-repo", defaultHelmChartsRepo, "owner/repo that hosts published charts")
+	cmd.Flags().StringVar(&flags.repoRoot, "repo-root", ".", "Alloy checkout containing Chart.yaml (cwd-relative unless absolute)")
+	_ = cmd.MarkFlagRequired("tag")
+
+	return cmd
+}
+
+func run(ctx context.Context, flags flags) error {
+	alloyClient, err := gh.NewClientFromEnv(ctx)
+	if err != nil {
+		return err
+	}
+
+	helmOwner, helmRepo, err := splitRepo(flags.helmChartsRepo)
+	if err != nil {
+		return err
+	}
+	helmClient := gh.NewClient(ctx, gh.ClientConfig{
+		Token: os.Getenv("GITHUB_TOKEN"),
+		Owner: helmOwner,
+		Repo:  helmRepo,
+	})
+
+	e := evaluator{
+		chartPath: flags.chartPath,
+		repoRoot:  flags.repoRoot,
+		getAlloyRelease: func(ctx context.Context, tag string) (bool, bool, error) {
+			release, err := alloyClient.GetReleaseByTag(ctx, tag)
+			if err != nil {
+				return false, false, err
+			}
+			return release.GetDraft(), release.GetPrerelease(), nil
+		},
+		helmChartTagExists:      alloyClient.HasTag,
+		helmChartsReleaseExists: helmClient.HasRelease,
+		readChart:               readChart,
+		headSHA: func() (string, error) {
+			return headSHA(flags.repoRoot)
+		},
+	}
+
+	result, err := e.evaluate(ctx, flags.tag)
+	if err != nil {
+		return err
+	}
+
+	return writeOutputs(result)
+}
+
+func splitRepo(slug string) (owner, repo string, err error) {
+	owner, repo, ok := strings.Cut(slug, "/")
+	if !ok || owner == "" || repo == "" || strings.Contains(repo, "/") {
+		return "", "", fmt.Errorf("invalid helm-charts repo %q (expected owner/repo)", slug)
+	}
+	return owner, repo, nil
+}
+
+func writeOutputs(result Result) error {
+	if err := gha.SetOutput("changed", strconv.FormatBool(result.Changed)); err != nil {
+		return err
+	}
+	if !result.Changed {
+		return nil
+	}
+
+	for name, value := range map[string]string{
+		"chartpath":   result.ChartPath,
+		"desc":        result.Description,
+		"tagname":     result.TagName,
+		"packagename": result.PackageName,
+		"source_sha":  result.SourceSHA,
+	} {
+		if err := gha.SetOutput(name, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tools/release/preparehelm/command_test.go
+++ b/tools/release/preparehelm/command_test.go
@@ -100,7 +100,7 @@ func TestReadChartParsesAppVersionComment(t *testing.T) {
 name: alloy
 description: Grafana Alloy
 version: 1.12.1
-appVersion: "v1.19.2" # x-release-please-version
+appVersion: "v1.19.2"  # x-release-please-version
 `), 0o600))
 
 	got, err := readChart(path)

--- a/tools/release/preparehelm/command_test.go
+++ b/tools/release/preparehelm/command_test.go
@@ -1,0 +1,152 @@
+package preparehelm
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateSkipsNonStableTags(t *testing.T) {
+	t.Parallel()
+
+	for _, tag := range []string{"v1.19.2-rc.0", "v1.19", "not-a-tag", "v1.19.2+build"} {
+		t.Run(tag, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := evaluator{}.evaluate(context.Background(), tag)
+			require.NoError(t, err)
+			require.False(t, result.Changed)
+		})
+	}
+}
+
+func TestEvaluateSkipsDraftOrPrerelease(t *testing.T) {
+	t.Parallel()
+
+	e := evaluator{
+		getAlloyRelease: func(context.Context, string) (bool, bool, error) {
+			return true, false, nil
+		},
+	}
+
+	result, err := e.evaluate(context.Background(), "v1.19.2")
+	require.NoError(t, err)
+	require.False(t, result.Changed)
+}
+
+func TestEvaluateErrorsWhenAppVersionDoesNotMatch(t *testing.T) {
+	t.Parallel()
+
+	e := readyEvaluator(t)
+	e.readChart = func(string) (chart, error) {
+		return chart{Name: "alloy", Description: "Grafana Alloy", Version: "1.12.1", AppVersion: "v1.19.1"}, nil
+	}
+
+	_, err := e.evaluate(context.Background(), "v1.19.2")
+	require.ErrorContains(t, err, "appVersion v1.19.1 does not match Alloy release v1.19.2")
+}
+
+func TestEvaluateErrorsWhenHelmChartTagIsMissing(t *testing.T) {
+	t.Parallel()
+
+	e := readyEvaluator(t)
+	e.helmChartTagExists = func(context.Context, string) (bool, error) {
+		return false, nil
+	}
+
+	_, err := e.evaluate(context.Background(), "v1.19.2")
+	require.ErrorContains(t, err, "helm-chart/1.12.1")
+}
+
+func TestEvaluateSkipsWhenHelmChartsReleaseExists(t *testing.T) {
+	t.Parallel()
+
+	e := readyEvaluator(t)
+	e.helmChartsReleaseExists = func(context.Context, string) (bool, error) {
+		return true, nil
+	}
+
+	result, err := e.evaluate(context.Background(), "v1.19.2")
+	require.NoError(t, err)
+	require.False(t, result.Changed)
+}
+
+func TestEvaluatePreparesANewChartRelease(t *testing.T) {
+	t.Parallel()
+
+	e := readyEvaluator(t)
+	result, err := e.evaluate(context.Background(), "v1.19.2")
+	require.NoError(t, err)
+	require.Equal(t, result, Result{
+		Changed:     true,
+		ChartPath:   defaultChartPath,
+		Description: "Grafana Alloy",
+		TagName:     "helm-chart/1.12.1",
+		PackageName: "alloy-1.12.1",
+		SourceSHA:   "abc123",
+	})
+}
+
+func TestReadChartParsesAppVersionComment(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Chart.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+name: alloy
+description: Grafana Alloy
+version: 1.12.1
+appVersion: "v1.19.2" # x-release-please-version
+`), 0o600))
+
+	got, err := readChart(path)
+	require.NoError(t, err)
+	require.Equal(t, chart{
+		Name:        "alloy",
+		Description: "Grafana Alloy",
+		Version:     "1.12.1",
+		AppVersion:  "v1.19.2",
+	}, got)
+}
+
+func readyEvaluator(t *testing.T) evaluator {
+	t.Helper()
+	return evaluator{
+		chartPath: defaultChartPath,
+		getAlloyRelease: func(context.Context, string) (bool, bool, error) {
+			return false, false, nil
+		},
+		helmChartTagExists: func(_ context.Context, tag string) (bool, error) {
+			require.Equal(t, "helm-chart/1.12.1", tag)
+			return true, nil
+		},
+		helmChartsReleaseExists: func(_ context.Context, tag string) (bool, error) {
+			require.Equal(t, "alloy-1.12.1", tag)
+			return false, nil
+		},
+		readChart: func(string) (chart, error) {
+			return chart{Name: "alloy", Description: "Grafana Alloy", Version: "1.12.1", AppVersion: "v1.19.2"}, nil
+		},
+		headSHA: func() (string, error) {
+			return "abc123", nil
+		},
+	}
+}
+
+func TestEvaluatePropagatesLookupErrors(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("boom")
+	e := evaluator{
+		getAlloyRelease: func(context.Context, string) (bool, bool, error) {
+			return false, false, boom
+		},
+	}
+
+	_, err := e.evaluate(context.Background(), "v1.19.2")
+	require.ErrorIs(t, err, boom)
+}

--- a/tools/release/preparehelm/command_test.go
+++ b/tools/release/preparehelm/command_test.go
@@ -100,7 +100,9 @@ func TestReadChartParsesAppVersionComment(t *testing.T) {
 name: alloy
 description: Grafana Alloy
 version: 1.12.1
-appVersion: "v1.19.2"  # x-release-please-version
+# x-release-please-start-version
+appVersion: "v1.19.2"
+# x-release-please-end
 `), 0o600))
 
 	got, err := readChart(path)

--- a/tools/release/preparehelm/evaluator.go
+++ b/tools/release/preparehelm/evaluator.go
@@ -1,0 +1,131 @@
+package preparehelm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var stableAlloyTag = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
+
+type chart struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Version     string `yaml:"version"`
+	AppVersion  string `yaml:"appVersion"`
+}
+
+// Result is the GitHub Actions output for a Helm publish decision.
+type Result struct {
+	Changed     bool
+	ChartPath   string
+	Description string
+	TagName     string
+	PackageName string
+	SourceSHA   string
+}
+
+type evaluator struct {
+	chartPath               string
+	repoRoot                string
+	getAlloyRelease         func(ctx context.Context, tag string) (draft, prerelease bool, err error)
+	helmChartTagExists      func(ctx context.Context, tag string) (bool, error)
+	helmChartsReleaseExists func(ctx context.Context, tag string) (bool, error)
+	readChart               func(path string) (chart, error)
+	headSHA                 func() (string, error)
+}
+
+func (e evaluator) evaluate(ctx context.Context, tag string) (Result, error) {
+	if !stableAlloyTag.MatchString(tag) {
+		fmt.Printf("Release tag %s is not a stable Alloy version; skipping Helm release.\n", tag)
+		return Result{}, nil
+	}
+
+	draft, prerelease, err := e.getAlloyRelease(ctx, tag)
+	if err != nil {
+		return Result{}, err
+	}
+	if draft || prerelease {
+		fmt.Printf("Release %s is not a published stable release; skipping Helm release.\n", tag)
+		return Result{}, nil
+	}
+
+	chartPath := e.chartPath
+	if chartPath == "" {
+		chartPath = defaultChartPath
+	}
+
+	ch, err := e.readChart(filepath.Join(e.repoRoot, chartPath, "Chart.yaml"))
+	if err != nil {
+		return Result{}, err
+	}
+	if ch.AppVersion != tag {
+		return Result{}, fmt.Errorf("chart appVersion %s does not match Alloy release %s", ch.AppVersion, tag)
+	}
+
+	sourceTag := "helm-chart/" + ch.Version
+	exists, err := e.helmChartTagExists(ctx, sourceTag)
+	if err != nil {
+		return Result{}, err
+	}
+	if !exists {
+		return Result{}, fmt.Errorf("release-please did not create the expected %s source tag", sourceTag)
+	}
+
+	packageName := ch.Name + "-" + ch.Version
+	exists, err = e.helmChartsReleaseExists(ctx, packageName)
+	if err != nil {
+		return Result{}, err
+	}
+	if exists {
+		fmt.Printf("Chart release %s already exists; skipping Helm release.\n", packageName)
+		return Result{}, nil
+	}
+
+	sha, err := e.headSHA()
+	if err != nil {
+		return Result{}, err
+	}
+
+	fmt.Printf("Releasing %s %s for %s.\n", chartPath, ch.Version, tag)
+	return Result{
+		Changed:     true,
+		ChartPath:   chartPath,
+		Description: ch.Description,
+		TagName:     sourceTag,
+		PackageName: packageName,
+		SourceSHA:   sha,
+	}, nil
+}
+
+func readChart(path string) (chart, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return chart{}, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var ch chart
+	if err := yaml.Unmarshal(data, &ch); err != nil {
+		return chart{}, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if ch.Name == "" || ch.Version == "" || ch.AppVersion == "" {
+		return chart{}, fmt.Errorf("%s is missing name, version, or appVersion", path)
+	}
+	return ch, nil
+}
+
+func headSHA(repoRoot string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolving HEAD: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}


### PR DESCRIPTION
### Brief description of Pull Request

Automate the Alloy Helm chart release lifecycle through Release Please and the published Alloy GitHub release. The chart now receives a versioned source tag with each Alloy release, and the publishing workflow packages and publishes that immutable chart revision to `grafana/helm-charts`.

### Pull Request Details

#### Previous release flow

1. A maintainer created a separate PR to update the Helm chart version and `appVersion`, update its changelog, and regenerate Helm documentation and tests.
2. Every push to `main` ran the Helm release workflow.
3. The workflow used `chart-testing` to compare the working tree with the latest `helm-chart/*` tag and proceeded only if it found one changed chart.
4. The workflow read the chart metadata, packaged the chart, created and pushed the `helm-chart/{version}` source tag itself, created the release in `grafana/helm-charts`, and updated the chart index.

#### New release flow

1. Release Please manages the Helm chart as a package alongside Alloy. When it determines Alloy has a release, an r-p plugin adds a corresponding "synthetic" commit for the chart: a patch bump for Alloy patch releases and a minor bump otherwise.
2. The Release Please PR updates the chart version and `appVersion`, generates the Helm changelog, and regenerates Helm documentation and tests. Release Please creates the immutable `helm-chart/{version}` source tag when the PR is released.
3. Publishing a stable Alloy GitHub release triggers the Helm release workflow; the workflow can also be manually run with an existing stable release tag for recovery.
4. The workflow checks out that release tag and `release prepare-helm` verifies that it is a published stable semver release, `Chart.yaml` has the matching `appVersion`, the expected Helm source tag exists, and the same chart release does not already exist in `grafana/helm-charts`.
5. Only after those checks pass does the workflow package the chart from the tagged source, create the `grafana/helm-charts` release, and update `index.yaml`. It no longer creates or pushes Alloy tags.

The workflow serializes Helm publishes, and release branches created before this automation retain their existing chart state.

### Issue(s) fixed by this Pull Request


### Notes to the Reviewer


### PR Checklist

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
