### PR TITLE
ci: Add non-GA stability tracking tooling (POC)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,10 @@ jobs:
       run: task lint:go
 
     - name: Run Alloy Lint
-      run: task lint:alloylint 
+      run: task lint:alloylint
+
+    - name: Check non-GA component tracking
+      run: task lint:stabilitycheck
 
   govulncheck:
     name: Govulncheck

--- a/.stability.yaml
+++ b/.stability.yaml
@@ -1,14 +1,21 @@
-# Tracking list for non-GA (experimental and public-preview) components.
+# Tracking list for non-GA (experimental and public-preview) behavior.
 #
-# Every experimental or public-preview component MUST have an entry here. Each
-# entry needs a `reason` explaining why the component is not yet generally
+# Every entry needs a `reason` explaining why the item is not yet generally
 # available, and an `expires` date that forces periodic re-review. When `expires`
-# passes, CI fails on that entry until it is renewed or the component graduates.
+# passes, CI fails on that entry until it is renewed or the item graduates.
 # See internal/cmd/stabilitycheck/ for the tool that consumes this file.
 #
-# Community components are NOT tracked here.
+# Two sections:
+#   components: Every non-GA component MUST have an entry. The tool enumerates
+#     the component registry, so an untracked non-GA component fails CI.
+#     Community components are NOT tracked here.
+#   features:   Non-GA behavior that is not a component (config blocks, stdlib
+#     functions, CLI features). This list is HAND-MAINTAINED and NOT guaranteed
+#     complete — there is no registry to enumerate, so the tool cannot detect an
+#     untracked feature. Add an entry when you add a non-GA feature.
 #
-# Keep entries sorted alphabetically by `name`. The check fails if they are not.
+# Keep entries in each section sorted alphabetically by `name`. The check fails
+# if they are not.
 
 components:
   - name: database_observability.sql_server
@@ -148,6 +155,24 @@ components:
     reason: TODO
     expires: 2026-10-01
   - name: pyroscope.enrich
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+
+features:
+  - name: Windows process priority
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: foreach block
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: stdlib array.combine_maps
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: stdlib array.group_by
     stability: experimental
     reason: TODO
     expires: 2026-10-01

--- a/.stability.yaml
+++ b/.stability.yaml
@@ -20,158 +20,158 @@
 components:
   - name: database_observability.sql_server
     stability: experimental
-    reason: TODO
-    expires: 2026-10-01
+    reason: "Added to Alloy in v1.18.0 (2026-07-17)."
+    expires: 2027-01-01
   - name: loki.enrich
     stability: experimental
-    reason: TODO
+    reason: "Added to Alloy in v1.8.0 (2025-04-09)."
     expires: 2026-10-01
   - name: loki.secretfilter
     stability: public-preview
-    reason: TODO
+    reason: "Added to Alloy in v1.5.0 (2024-11-13)."
     expires: 2026-10-01
   - name: mimir.alerts.kubernetes
     stability: experimental
-    reason: TODO
+    reason: "Added to Alloy in v1.12.0 (2025-12-01)."
     expires: 2026-10-01
   - name: otelcol.auth.google
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component googleclientauthextension is beta. Added to Alloy in v1.16.0 (2026-04-22)."
     expires: 2026-10-01
   - name: otelcol.connector.count
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component countconnector is alpha. Added to Alloy in v1.13.0 (2026-02-05)."
     expires: 2026-10-01
   - name: otelcol.connector.signaltometrics
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component signaltometricsconnector is alpha. Added to Alloy in v1.18.0 (2026-07-17)."
     expires: 2026-10-01
   - name: otelcol.exporter.awss3
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component awss3exporter is alpha. Added to Alloy in v1.1.0 (2024-05-14)."
     expires: 2026-10-01
   - name: otelcol.exporter.debug
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component debugexporter is alpha. Added to Alloy in v1.3.0 (2024-08-05)."
     expires: 2026-10-01
   - name: otelcol.exporter.faro
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component faroexporter is alpha. This does not match the current public-preview level; review whether it should be experimental. Added to Alloy in v1.10.0 (2025-07-16)."
     expires: 2026-10-01
   - name: otelcol.exporter.file
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component fileexporter is alpha. This does not match the current public-preview level; review whether it should be experimental. Added to Alloy in v1.12.0 (2025-12-01)."
     expires: 2026-10-01
   - name: otelcol.exporter.syslog
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component syslogexporter is alpha. This does not match the current public-preview level; review whether it should be experimental. Added to Alloy in v1.6.0 (2025-01-22)."
     expires: 2026-10-01
   - name: otelcol.processor.cumulativetodelta
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component cumulativetodeltaprocessor is beta. Added to Alloy in v1.7.0 (2025-02-24)."
     expires: 2026-10-01
   - name: otelcol.processor.deltatocumulative
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component deltatocumulativeprocessor is alpha. Added to Alloy in v1.2.0 (2024-06-26)."
     expires: 2026-10-01
   - name: otelcol.processor.interval
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component intervalprocessor is alpha. Added to Alloy in v1.4.0 (2024-09-25)."
     expires: 2026-10-01
   - name: otelcol.processor.redaction
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component redactionprocessor is beta for traces and alpha for logs and metrics. The beta traces support does not match the current experimental level; review the level. Added to Alloy in v1.19.0 (2026-08-21)."
     expires: 2026-10-01
   - name: otelcol.receiver.awscloudwatch
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component awscloudwatchreceiver is alpha. Added to Alloy in v1.8.0 (2025-04-09)."
     expires: 2026-10-01
   - name: otelcol.receiver.awsecscontainermetrics
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component awsecscontainermetricsreceiver is beta. This does not match the current experimental level; review whether it should be public-preview. Added to Alloy in v1.11.0 (2025-09-30)."
     expires: 2026-10-01
   - name: otelcol.receiver.awss3
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component awss3receiver is alpha. Added to Alloy in v1.13.0 (2026-02-05)."
     expires: 2026-10-01
   - name: otelcol.receiver.cloudflare
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component cloudflarereceiver is alpha. Added to Alloy in v1.12.0 (2025-12-01)."
     expires: 2026-10-01
   - name: otelcol.receiver.datadog
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component datadogreceiver is alpha. Added to Alloy in v1.2.0 (2024-06-26)."
     expires: 2026-10-01
   - name: otelcol.receiver.faro
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component faroreceiver is alpha. This does not match the current public-preview level; review whether it should be experimental. Added to Alloy in v1.10.0 (2025-07-16)."
     expires: 2026-10-01
   - name: otelcol.receiver.filelog
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component filelogreceiver is beta. Added to Alloy in v1.7.0 (2025-02-24)."
     expires: 2026-10-01
   - name: otelcol.receiver.fluentforward
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component fluentforwardreceiver is beta. This does not match the current experimental level; review whether it should be public-preview. Added to Alloy in v1.11.0 (2025-09-30)."
     expires: 2026-10-01
   - name: otelcol.receiver.nginx
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component nginxreceiver is beta. Added to Alloy in v1.17.0 (2026-06-11)."
     expires: 2026-10-01
   - name: otelcol.receiver.splunkhec
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component splunkhecreceiver is beta. Added to Alloy in v1.9.0 (2025-06-02)."
     expires: 2026-10-01
   - name: otelcol.receiver.syslog
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component syslogreceiver is beta. Added to Alloy in v1.6.0 (2025-01-22)."
     expires: 2026-10-01
   - name: otelcol.receiver.tcplog
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component tcplogreceiver is alpha. Added to Alloy in v1.7.0 (2025-02-24)."
     expires: 2026-10-01
   - name: otelcol.receiver.vcenter
     stability: experimental
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component vcenterreceiver is alpha. Added to Alloy before v1.0.0 (not recorded in the changelog)."
     expires: 2026-10-01
   - name: otelcol.storage.file
     stability: public-preview
-    reason: TODO
+    reason: "Upstream OpenTelemetry Collector component filestorage is beta. Added to Alloy in v1.9.0 (2025-06-02)."
     expires: 2026-10-01
   - name: prometheus.enrich
     stability: experimental
-    reason: TODO
+    reason: "Added to Alloy in v1.11.0 (2025-09-30)."
     expires: 2026-10-01
   - name: prometheus.exporter.catchpoint
     stability: experimental
-    reason: TODO
+    reason: "Added to Alloy in v1.2.0 (2024-06-26)."
     expires: 2026-10-01
   - name: prometheus.exporter.static
     stability: experimental
-    reason: TODO
+    reason: "Added to Alloy in v1.11.3 (2025-10-27)."
     expires: 2026-10-01
   - name: prometheus.operator.scrapeconfigs
     stability: experimental
-    reason: TODO
+    reason: "Added to Alloy in v1.8.0 (2025-04-09)."
     expires: 2026-10-01
   - name: pyroscope.enrich
     stability: experimental
-    reason: TODO
+    reason: "Added to Alloy in v1.13.0 (2026-02-05)."
     expires: 2026-10-01
 features:
   - name: Windows process priority
     stability: public-preview
-    reason: TODO
+    reason: "Alloy run feature: the --windows.priority flag sets the Windows process priority for Alloy. Gated at public-preview by the minimum stability level. Added to Alloy in v1.8.0 (2025-04-09)."
     expires: 2026-10-01
   - name: foreach block
     stability: experimental
-    reason: TODO
+    reason: "Alloy config block foreach, which starts a pipeline for each item in a list. Experimental config block gated by the minimum stability level. Added to Alloy in v1.7.0 (2025-02-24)."
     expires: 2026-10-01
   - name: stdlib array.combine_maps
     stability: experimental
-    reason: TODO
+    reason: "Alloy stdlib function array.combine_maps. Experimental stdlib identifier gated by the minimum stability level. Added to Alloy in v1.5.0 (2024-11-13)."
     expires: 2026-10-01
   - name: stdlib array.group_by
     stability: experimental
-    reason: TODO
+    reason: "Alloy stdlib function array.group_by, which groups items in an array by a key. Experimental stdlib identifier gated by the minimum stability level. Added to Alloy in v1.10.0 (2025-07-16)."
     expires: 2026-10-01

--- a/.stability.yaml
+++ b/.stability.yaml
@@ -159,13 +159,53 @@ components:
     reason: "Added to Alloy in v1.13.0 (2026-02-05)."
     expires: 2026-10-01
 features:
+  - name: GraphQL API endpoint
+    stability: experimental
+    reason: "Alloy HTTP GraphQL API (the /graphql endpoint) for querying component and pipeline state. Experimental feature gated by the minimum stability level. Added to Alloy in v1.17.0 (2026-06-11)."
+    expires: 2026-10-01
   - name: Windows process priority
     stability: public-preview
     reason: "Alloy run feature: the --windows.priority flag sets the Windows process priority for Alloy. Gated at public-preview by the minimum stability level. Added to Alloy in v1.8.0 (2025-04-09)."
     expires: 2026-10-01
+  - name: configuration conversion
+    stability: public-preview
+    reason: "Alloy configuration conversion, which converts a supported source configuration (such as Prometheus, Promtail, or Grafana Agent) to Alloy syntax. Exposed as the convert CLI command and the --config.format flag on run. Public-preview feature gated by the minimum stability level. Added to Alloy before v1.0.0 (not recorded in the changelog)."
+    expires: 2026-10-01
+  - name: debug graph page
+    stability: experimental
+    reason: "Alloy debug UI Graph page, which shows the live component graph. Experimental feature gated by the minimum stability level. Added to Alloy before v1.0.0 (not recorded in the changelog)."
+    expires: 2026-10-01
   - name: foreach block
     stability: experimental
     reason: "Alloy config block foreach, which starts a pipeline for each item in a list. Experimental config block gated by the minimum stability level. Added to Alloy in v1.7.0 (2025-02-24)."
+    expires: 2026-10-01
+  - name: gql command
+    stability: experimental
+    reason: "Alloy gql CLI subcommand, which queries a running Alloy instance through its GraphQL API. Experimental feature gated by the minimum stability level. Added to Alloy in v1.17.0 (2026-06-11)."
+    expires: 2026-10-01
+  - name: loki.source.syslog raw_format_options block
+    stability: experimental
+    reason: "Experimental raw_format_options block in the loki.source.syslog component. Gated by the minimum stability level. Added to Alloy in v1.13.0 (2026-02-05); dated from git history, not the changelog."
+    expires: 2026-10-01
+  - name: loki.source.syslog rfc3164_cisco_components block
+    stability: experimental
+    reason: "Experimental rfc3164_cisco_components block in the loki.source.syslog component. Gated by the minimum stability level. Added to Alloy in v1.13.0 (2026-02-05); dated from git history, not the changelog."
+    expires: 2026-10-01
+  - name: loki.write queue_config block
+    stability: experimental
+    reason: "Experimental queue_config block in the loki.write component, which configures the queue-based remote-write client. Gated by the minimum stability level. Added to Alloy before v1.0.0 (not recorded in the changelog)."
+    expires: 2026-10-01
+  - name: loki.write wal block
+    stability: experimental
+    reason: "Experimental wal block in the loki.write component, which configures the Write-Ahead Log for the Loki remote-write client. Gated by the minimum stability level. Added to Alloy before v1.0.0 (not recorded in the changelog)."
+    expires: 2026-10-01
+  - name: otel-supervisor command
+    stability: experimental
+    reason: "Alloy otel-supervisor CLI command, which runs Alloy under an OpenTelemetry supervisor. Experimental feature gated by the minimum stability level. Added to Alloy in v1.19.0 (2026-08-21)."
+    expires: 2026-10-01
+  - name: prometheus.remote_write Remote Write v2
+    stability: experimental
+    reason: "Experimental Remote Write v2 protocol support in prometheus.remote_write, enabled through the protobuf_message argument. Gated by the minimum stability level. Added to Alloy in v1.11.0 (2025-09-30)."
     expires: 2026-10-01
   - name: stdlib array.combine_maps
     stability: experimental

--- a/.stability.yaml
+++ b/.stability.yaml
@@ -158,7 +158,6 @@ components:
     stability: experimental
     reason: TODO
     expires: 2026-10-01
-
 features:
   - name: Windows process priority
     stability: public-preview

--- a/.stability.yaml
+++ b/.stability.yaml
@@ -1,0 +1,153 @@
+# Tracking list for non-GA (experimental and public-preview) components.
+#
+# Every experimental or public-preview component MUST have an entry here. Each
+# entry needs a `reason` explaining why the component is not yet generally
+# available, and an `expires` date that forces periodic re-review. When `expires`
+# passes, CI fails on that entry until it is renewed or the component graduates.
+# See internal/cmd/stabilitycheck/ for the tool that consumes this file.
+#
+# Community components are NOT tracked here.
+#
+# Keep entries sorted alphabetically by `name`. The check fails if they are not.
+
+components:
+  - name: database_observability.sql_server
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: loki.enrich
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: loki.secretfilter
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: mimir.alerts.kubernetes
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.auth.google
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.connector.count
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.connector.signaltometrics
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.exporter.awss3
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.exporter.debug
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.exporter.faro
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.exporter.file
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.exporter.syslog
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.processor.cumulativetodelta
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.processor.deltatocumulative
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.processor.interval
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.processor.redaction
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.awscloudwatch
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.awsecscontainermetrics
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.awss3
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.cloudflare
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.datadog
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.faro
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.filelog
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.fluentforward
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.nginx
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.splunkhec
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.syslog
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.tcplog
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.receiver.vcenter
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: otelcol.storage.file
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+  - name: prometheus.enrich
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: prometheus.exporter.catchpoint
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: prometheus.exporter.static
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: prometheus.operator.scrapeconfigs
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: pyroscope.enrich
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
 ##   test                  Run tests
 ##   lint                  Lint code
 ##   govulncheck           Run govulncheck across all Go modules
+##   stabilitycheck        Check non-GA component tracking in .stability.yaml
 ##   integration-test      Run integration tests
 ##   integration-test-k8s            Run Kubernetes integration tests (CI mode)
 ##   integration-test-k8s-local-dev  Run Kubernetes integration tests via interactive menu
@@ -231,6 +232,13 @@ test:
 # applies the YAML ignore list (see .govulncheck.yaml and tools/govulncheck/).
 govulncheck:
 	go run -C tools ./cmd govulncheck --tags=$(GOVULNCHECK_TAGS)
+
+.PHONY: stabilitycheck
+# Fail when a non-GA component is not tracked, or its entry is stale, in
+# .stability.yaml. Enumerates the component registry at runtime (see
+# internal/cmd/stabilitycheck/).
+stabilitycheck:
+	go run ./internal/cmd/stabilitycheck
 
 test-packages:
 ifeq ($(USE_CONTAINER),1)

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@
 ##   lint                  Lint code
 ##   govulncheck           Run govulncheck across all Go modules
 ##   stabilitycheck        Check non-GA component tracking in .stability.yaml
+##   stabilitycheck-update Format .stability.yaml and scaffold missing entries
 ##   integration-test      Run integration tests
 ##   integration-test-k8s            Run Kubernetes integration tests (CI mode)
 ##   integration-test-k8s-local-dev  Run Kubernetes integration tests via interactive menu
@@ -239,6 +240,12 @@ govulncheck:
 # internal/cmd/stabilitycheck/).
 stabilitycheck:
 	go run ./internal/cmd/stabilitycheck
+
+.PHONY: stabilitycheck-update
+# Format .stability.yaml: add TODO entries for untracked non-GA components and
+# sort both sections. Pass EXPIRES=YYYY-MM-DD to set the expiry for new entries.
+stabilitycheck-update:
+	go run ./internal/cmd/stabilitycheck --update $(if $(EXPIRES),--expires=$(EXPIRES))
 
 test-packages:
 ifeq ($(USE_CONTAINER),1)

--- a/build-tools/task/lint.yml
+++ b/build-tools/task/lint.yml
@@ -9,6 +9,7 @@ tasks:
       - task: alloylint
       - task: shellcheck
       - task: govulncheck
+      - task: stabilitycheck
 
   go:
     desc: Run golangci-lint.
@@ -36,6 +37,11 @@ tasks:
         {{- end -}}
     cmds:
       - mise exec -- go run ./cmd govulncheck --tags='{{.GOVULNCHECK_TAGS}}'
+
+  stabilitycheck:
+    desc: Check non-GA component tracking in .stability.yaml.
+    cmds:
+      - go run ./internal/cmd/stabilitycheck
 
   alloylint:
     desc: Run the alloylint linter.

--- a/build-tools/task/lint.yml
+++ b/build-tools/task/lint.yml
@@ -43,6 +43,11 @@ tasks:
     cmds:
       - go run ./internal/cmd/stabilitycheck
 
+  stabilitycheck-update:
+    desc: Format .stability.yaml and scaffold missing entries. Pass EXPIRES=YYYY-MM-DD to override the new-entry expiry.
+    cmds:
+      - go run ./internal/cmd/stabilitycheck --update {{if .EXPIRES}}--expires={{.EXPIRES}}{{end}}
+
   alloylint:
     desc: Run the alloylint linter.
     vars:

--- a/docs/developer/add-otel-component.md
+++ b/docs/developer/add-otel-component.md
@@ -21,6 +21,12 @@ You can modify the stability level of the component based on maturity, stability
 When you add your component, you must pick a stability level, **Experimental**, **Public Preview**, or **Generally Available**, and provide it in the component registration.
 If the stability of a component isn't set to **Generally Available**, you must [run Alloy](https://grafana.com/docs/alloy/latest/reference/cli/run/#the-run-command) with the `--stability.level` flag to enable the relevant stability level.
 
+If you set a non-GA stability level, you must also add an entry for the component to `.stability.yaml` at the repository root.
+Each entry needs a `reason` that explains why the component is not yet **Generally Available**, and an `expires` date that forces a periodic review.
+CI fails until you add the entry.
+When an entry is missing, the `stabilitycheck` tool prints the exact YAML block to add.
+For details, see [`internal/cmd/stabilitycheck/`](../../internal/cmd/stabilitycheck).
+
 You'll need to select a unique identifier for your component.
 Most Alloy components fall into one of several [categories](https://grafana.com/docs/alloy/latest/reference/components/).
 For this example, you can assume you're adding a fictional OpenTelemetry processor named `exampleprocessor`.

--- a/internal/cmd/stabilitycheck/classify.go
+++ b/internal/cmd/stabilitycheck/classify.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// gaStability is the stability string of a generally-available component. GA
+// components are not tracked.
+const gaStability = "generally-available"
+
+// registeredComponent is the view of a registered component the checker needs.
+// It decouples classification from the component registry so the logic is
+// testable without importing every component.
+type registeredComponent struct {
+	Name      string
+	Stability string // "experimental", "public-preview", or "generally-available"
+	Community bool
+}
+
+// findingKind names why a component or entry failed the check.
+type findingKind int
+
+const (
+	// missingEntry: a non-GA component has no entry.
+	missingEntry findingKind = iota
+	// levelMismatch: the entry stability disagrees with the code.
+	levelMismatch
+	// expired: the entry review deadline has passed.
+	expired
+	// staleGA: an entry names a component that is now GA.
+	staleGA
+	// staleMissing: an entry names a component that no longer exists.
+	staleMissing
+	// staleCommunity: an entry names a community component, which is not tracked.
+	staleCommunity
+)
+
+// finding is one failure to report.
+type finding struct {
+	kind    findingKind
+	name    string
+	message string
+}
+
+// classify compares the registered components against the config and returns
+// every failure. It never mutates its inputs. Results are sorted by name so
+// output is stable.
+func classify(comps []registeredComponent, cfg *Config, now time.Time) []finding {
+	byName := make(map[string]registeredComponent, len(comps))
+	for _, c := range comps {
+		byName[c.Name] = c
+	}
+	entries := cfg.entryByName()
+
+	var findings []finding
+
+	// Every non-GA component must have a valid, current, level-matching entry.
+	for _, c := range comps {
+		if c.Community || c.Stability == gaStability {
+			continue
+		}
+		e, ok := entries[c.Name]
+		if !ok {
+			findings = append(findings, finding{
+				kind:    missingEntry,
+				name:    c.Name,
+				message: missingEntrySnippet(c),
+			})
+			continue
+		}
+		if e.Stability != c.Stability {
+			findings = append(findings, finding{
+				kind:    levelMismatch,
+				name:    c.Name,
+				message: fmt.Sprintf("entry says stability %q but code says %q — update and re-justify", e.Stability, c.Stability),
+			})
+		}
+		if now.After(e.Expires) {
+			findings = append(findings, finding{
+				kind:    expired,
+				name:    c.Name,
+				message: fmt.Sprintf("review expired on %s — renew or remove the entry", e.Expires.Format("2006-01-02")),
+			})
+		}
+	}
+
+	// Every entry must name a currently non-GA, non-community component.
+	for _, e := range cfg.Components {
+		c, ok := byName[e.Name]
+		switch {
+		case !ok:
+			findings = append(findings, finding{
+				kind:    staleMissing,
+				name:    e.Name,
+				message: "component no longer exists — remove the entry",
+			})
+		case c.Community:
+			findings = append(findings, finding{
+				kind:    staleCommunity,
+				name:    e.Name,
+				message: "component is a community component and must not be tracked — remove the entry",
+			})
+		case c.Stability == gaStability:
+			findings = append(findings, finding{
+				kind:    staleGA,
+				name:    e.Name,
+				message: "component is now generally available — remove the entry",
+			})
+		}
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].name != findings[j].name {
+			return findings[i].name < findings[j].name
+		}
+		return findings[i].kind < findings[j].kind
+	})
+	return findings
+}
+
+// missingEntrySnippet returns a paste-ready YAML block for a component that has
+// no entry. The reason and expires fields are left for a human.
+func missingEntrySnippet(c registeredComponent) string {
+	return fmt.Sprintf("no entry in .stability.yaml — add (keep entries sorted by name):\n"+
+		"      - name: %s\n"+
+		"        stability: %s\n"+
+		"        reason: <why this is not yet generally available>\n"+
+		"        expires: <YYYY-MM-DD>",
+		c.Name, c.Stability)
+}

--- a/internal/cmd/stabilitycheck/classify.go
+++ b/internal/cmd/stabilitycheck/classify.go
@@ -37,9 +37,16 @@ const (
 	staleCommunity
 )
 
+// Section names distinguish component findings from feature findings in output.
+const (
+	sectionComponent = "component"
+	sectionFeature   = "feature"
+)
+
 // finding is one failure to report.
 type finding struct {
 	kind    findingKind
+	section string
 	name    string
 	message string
 }
@@ -65,6 +72,7 @@ func classify(comps []registeredComponent, cfg *Config, now time.Time) []finding
 		if !ok {
 			findings = append(findings, finding{
 				kind:    missingEntry,
+				section: sectionComponent,
 				name:    c.Name,
 				message: missingEntrySnippet(c),
 			})
@@ -73,6 +81,7 @@ func classify(comps []registeredComponent, cfg *Config, now time.Time) []finding
 		if e.Stability != c.Stability {
 			findings = append(findings, finding{
 				kind:    levelMismatch,
+				section: sectionComponent,
 				name:    c.Name,
 				message: fmt.Sprintf("entry says stability %q but code says %q — update and re-justify", e.Stability, c.Stability),
 			})
@@ -80,6 +89,7 @@ func classify(comps []registeredComponent, cfg *Config, now time.Time) []finding
 		if now.After(e.Expires) {
 			findings = append(findings, finding{
 				kind:    expired,
+				section: sectionComponent,
 				name:    c.Name,
 				message: fmt.Sprintf("review expired on %s — renew or remove the entry", e.Expires.Format("2006-01-02")),
 			})
@@ -93,25 +103,44 @@ func classify(comps []registeredComponent, cfg *Config, now time.Time) []finding
 		case !ok:
 			findings = append(findings, finding{
 				kind:    staleMissing,
+				section: sectionComponent,
 				name:    e.Name,
 				message: "component no longer exists — remove the entry",
 			})
 		case c.Community:
 			findings = append(findings, finding{
 				kind:    staleCommunity,
+				section: sectionComponent,
 				name:    e.Name,
 				message: "component is a community component and must not be tracked — remove the entry",
 			})
 		case c.Stability == gaStability:
 			findings = append(findings, finding{
 				kind:    staleGA,
+				section: sectionComponent,
 				name:    e.Name,
 				message: "component is now generally available — remove the entry",
 			})
 		}
 	}
 
+	// Features are hand-maintained and not enumerable, so the only runtime check
+	// is expiry. Everything else is enforced when the config is parsed.
+	for _, e := range cfg.Features {
+		if now.After(e.Expires) {
+			findings = append(findings, finding{
+				kind:    expired,
+				section: sectionFeature,
+				name:    e.Name,
+				message: fmt.Sprintf("review expired on %s — renew or remove the entry", e.Expires.Format("2006-01-02")),
+			})
+		}
+	}
+
 	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].section != findings[j].section {
+			return findings[i].section < findings[j].section
+		}
 		if findings[i].name != findings[j].name {
 			return findings[i].name < findings[j].name
 		}

--- a/internal/cmd/stabilitycheck/classify_test.go
+++ b/internal/cmd/stabilitycheck/classify_test.go
@@ -27,14 +27,19 @@ func TestClassify(t *testing.T) {
 		{Name: "community.comp", Stability: "experimental", Reason: "ok", Expires: future},
 		{Name: "now.ga", Stability: "experimental", Reason: "ok", Expires: future},
 		{Name: "gone.comp", Stability: "experimental", Reason: "ok", Expires: future},
+	}, Features: []Entry{
+		{Name: "current.feature", Stability: "experimental", Reason: "ok", Expires: future},
+		{Name: "expired.feature", Stability: "public-preview", Reason: "ok", Expires: past},
 	}}
 
 	findings := classify(comps, cfg, now)
 
 	// Index findings by name+kind for assertions.
 	got := make(map[string]findingKind)
+	gotSection := make(map[string]string)
 	for _, f := range findings {
 		got[f.name] = f.kind
+		gotSection[f.name] = f.section
 	}
 
 	want := map[string]findingKind{
@@ -44,6 +49,7 @@ func TestClassify(t *testing.T) {
 		"community.comp":  staleCommunity,
 		"now.ga":          staleGA,
 		"gone.comp":       staleMissing,
+		"expired.feature": expired,
 	}
 
 	if len(findings) != len(want) {
@@ -62,5 +68,16 @@ func TestClassify(t *testing.T) {
 	// GA components without entries must not be flagged.
 	if _, ok := got["ga.comp"]; ok {
 		t.Errorf("ga.comp should not be flagged")
+	}
+	// A current feature entry must not be flagged.
+	if _, ok := got["current.feature"]; ok {
+		t.Errorf("current.feature should not be flagged")
+	}
+	// Feature findings carry the feature section label.
+	if gotSection["expired.feature"] != sectionFeature {
+		t.Errorf("expired.feature section = %q, want %q", gotSection["expired.feature"], sectionFeature)
+	}
+	if gotSection["exp.untracked"] != sectionComponent {
+		t.Errorf("exp.untracked section = %q, want %q", gotSection["exp.untracked"], sectionComponent)
 	}
 }

--- a/internal/cmd/stabilitycheck/classify_test.go
+++ b/internal/cmd/stabilitycheck/classify_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClassify(t *testing.T) {
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	future := now.AddDate(0, 1, 0)
+	past := now.AddDate(0, -1, 0)
+
+	comps := []registeredComponent{
+		{Name: "ga.comp", Stability: "generally-available"},
+		{Name: "exp.tracked", Stability: "experimental"},
+		{Name: "exp.untracked", Stability: "experimental"},
+		{Name: "preview.expired", Stability: "public-preview"},
+		{Name: "exp.mismatch", Stability: "experimental"},
+		{Name: "community.comp", Community: true},
+		{Name: "now.ga", Stability: "generally-available"},
+	}
+
+	cfg := &Config{Components: []Entry{
+		{Name: "exp.tracked", Stability: "experimental", Reason: "ok", Expires: future},
+		{Name: "preview.expired", Stability: "public-preview", Reason: "ok", Expires: past},
+		{Name: "exp.mismatch", Stability: "public-preview", Reason: "ok", Expires: future},
+		{Name: "community.comp", Stability: "experimental", Reason: "ok", Expires: future},
+		{Name: "now.ga", Stability: "experimental", Reason: "ok", Expires: future},
+		{Name: "gone.comp", Stability: "experimental", Reason: "ok", Expires: future},
+	}}
+
+	findings := classify(comps, cfg, now)
+
+	// Index findings by name+kind for assertions.
+	got := make(map[string]findingKind)
+	for _, f := range findings {
+		got[f.name] = f.kind
+	}
+
+	want := map[string]findingKind{
+		"exp.untracked":   missingEntry,
+		"preview.expired": expired,
+		"exp.mismatch":    levelMismatch,
+		"community.comp":  staleCommunity,
+		"now.ga":          staleGA,
+		"gone.comp":       staleMissing,
+	}
+
+	if len(findings) != len(want) {
+		t.Fatalf("got %d findings, want %d: %+v", len(findings), len(want), findings)
+	}
+	for name, kind := range want {
+		if got[name] != kind {
+			t.Errorf("%s: got kind %d, want %d", name, got[name], kind)
+		}
+	}
+
+	// A valid, current, matching entry must produce no finding.
+	if _, ok := got["exp.tracked"]; ok {
+		t.Errorf("exp.tracked should not be flagged")
+	}
+	// GA components without entries must not be flagged.
+	if _, ok := got["ga.comp"]; ok {
+		t.Errorf("ga.comp should not be flagged")
+	}
+}

--- a/internal/cmd/stabilitycheck/config.go
+++ b/internal/cmd/stabilitycheck/config.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// validStability lists the stability levels this tool tracks. GA is not tracked
+// and community components have no stability, so neither is a valid entry value.
+var validStability = map[string]bool{
+	"experimental":   true,
+	"public-preview": true,
+}
+
+// placeholderReason is the scaffold reason. CI must fail until a human replaces
+// it, so it is rejected as an invalid reason.
+const placeholderReason = "TODO"
+
+// Config is the parsed .stability.yaml file.
+type Config struct {
+	Components []Entry `yaml:"components"`
+}
+
+// Entry justifies why one component is not yet generally available.
+type Entry struct {
+	Name      string    `yaml:"name"`
+	Stability string    `yaml:"stability"`
+	Reason    string    `yaml:"reason"`
+	Expires   time.Time `yaml:"expires"` // YAML accepts YYYY-MM-DD or RFC3339.
+}
+
+// loadConfig reads path. A missing file is an empty config, so CI fails loudly
+// on every non-GA component instead of passing silently.
+func loadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &Config{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return parseConfig(data)
+}
+
+func parseConfig(data []byte) (*Config, error) {
+	var cfg Config
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	// io.EOF means empty input (including comment-only YAML).
+	if err := dec.Decode(&cfg); err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (c *Config) validate() error {
+	seen := make(map[string]bool, len(c.Components))
+	for i, e := range c.Components {
+		if e.Name == "" {
+			return fmt.Errorf("components[%d]: name is required", i)
+		}
+		if seen[e.Name] {
+			return fmt.Errorf("components[%d]: duplicate name %q", i, e.Name)
+		}
+		seen[e.Name] = true
+		// Entries must stay sorted by name so the file is easy to scan and edit.
+		if i > 0 && e.Name < c.Components[i-1].Name {
+			return fmt.Errorf("components[%d] (%s): entries must be sorted by name; %q must come before %q", i, e.Name, e.Name, c.Components[i-1].Name)
+		}
+		if !validStability[e.Stability] {
+			return fmt.Errorf("components[%d] (%s): stability must be one of experimental or public-preview, got %q", i, e.Name, e.Stability)
+		}
+		if e.Reason == "" {
+			return fmt.Errorf("components[%d] (%s): reason is required", i, e.Name)
+		}
+		if e.Reason == placeholderReason {
+			return fmt.Errorf("components[%d] (%s): reason is still the %q placeholder — write a real justification", i, e.Name, placeholderReason)
+		}
+		if e.Expires.IsZero() {
+			return fmt.Errorf("components[%d] (%s): expires is required (YYYY-MM-DD)", i, e.Name)
+		}
+	}
+	return nil
+}
+
+// entryByName indexes entries by component name. Duplicates are rejected by
+// validate, so each name maps to one entry.
+func (c *Config) entryByName() map[string]*Entry {
+	m := make(map[string]*Entry, len(c.Components))
+	for i := range c.Components {
+		m[c.Components[i].Name] = &c.Components[i]
+	}
+	return m
+}

--- a/internal/cmd/stabilitycheck/config.go
+++ b/internal/cmd/stabilitycheck/config.go
@@ -25,6 +25,10 @@ const placeholderReason = "TODO"
 // Config is the parsed .stability.yaml file.
 type Config struct {
 	Components []Entry `yaml:"components"`
+	// Features tracks non-GA behavior that is not a component (config blocks,
+	// stdlib functions, CLI features). This list is hand-maintained: there is no
+	// registry to enumerate, so the tool cannot detect an untracked feature.
+	Features []Entry `yaml:"features"`
 }
 
 // Entry justifies why one component is not yet generally available.
@@ -63,30 +67,40 @@ func parseConfig(data []byte) (*Config, error) {
 }
 
 func (c *Config) validate() error {
-	seen := make(map[string]bool, len(c.Components))
-	for i, e := range c.Components {
+	if err := validateEntries(c.Components, "components"); err != nil {
+		return err
+	}
+	return validateEntries(c.Features, "features")
+}
+
+// validateEntries checks one entry list. Names must be unique and sorted within
+// the list, and every entry needs a valid non-GA stability, a real reason, and
+// an expiry date.
+func validateEntries(entries []Entry, section string) error {
+	seen := make(map[string]bool, len(entries))
+	for i, e := range entries {
 		if e.Name == "" {
-			return fmt.Errorf("components[%d]: name is required", i)
+			return fmt.Errorf("%s[%d]: name is required", section, i)
 		}
 		if seen[e.Name] {
-			return fmt.Errorf("components[%d]: duplicate name %q", i, e.Name)
+			return fmt.Errorf("%s[%d]: duplicate name %q", section, i, e.Name)
 		}
 		seen[e.Name] = true
 		// Entries must stay sorted by name so the file is easy to scan and edit.
-		if i > 0 && e.Name < c.Components[i-1].Name {
-			return fmt.Errorf("components[%d] (%s): entries must be sorted by name; %q must come before %q", i, e.Name, e.Name, c.Components[i-1].Name)
+		if i > 0 && e.Name < entries[i-1].Name {
+			return fmt.Errorf("%s[%d] (%s): entries must be sorted by name; %q must come before %q", section, i, e.Name, e.Name, entries[i-1].Name)
 		}
 		if !validStability[e.Stability] {
-			return fmt.Errorf("components[%d] (%s): stability must be one of experimental or public-preview, got %q", i, e.Name, e.Stability)
+			return fmt.Errorf("%s[%d] (%s): stability must be one of experimental or public-preview, got %q", section, i, e.Name, e.Stability)
 		}
 		if e.Reason == "" {
-			return fmt.Errorf("components[%d] (%s): reason is required", i, e.Name)
+			return fmt.Errorf("%s[%d] (%s): reason is required", section, i, e.Name)
 		}
 		if e.Reason == placeholderReason {
-			return fmt.Errorf("components[%d] (%s): reason is still the %q placeholder — write a real justification", i, e.Name, placeholderReason)
+			return fmt.Errorf("%s[%d] (%s): reason is still the %q placeholder — write a real justification", section, i, e.Name, placeholderReason)
 		}
 		if e.Expires.IsZero() {
-			return fmt.Errorf("components[%d] (%s): expires is required (YYYY-MM-DD)", i, e.Name)
+			return fmt.Errorf("%s[%d] (%s): expires is required (YYYY-MM-DD)", section, i, e.Name)
 		}
 	}
 	return nil

--- a/internal/cmd/stabilitycheck/config_test.go
+++ b/internal/cmd/stabilitycheck/config_test.go
@@ -17,6 +17,11 @@ components:
     stability: public-preview
     reason: "needs load testing before GA"
     expires: 2027-01-01
+features:
+  - name: foreach block
+    stability: experimental
+    reason: "iteration semantics still changing"
+    expires: 2026-10-01
 `
 	cfg, err := parseConfig([]byte(yaml))
 	if err != nil {
@@ -24,6 +29,9 @@ components:
 	}
 	if got, want := len(cfg.Components), 2; got != want {
 		t.Fatalf("component count = %d, want %d", got, want)
+	}
+	if got, want := len(cfg.Features), 1; got != want {
+		t.Fatalf("feature count = %d, want %d", got, want)
 	}
 	wantExp := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
 	if !cfg.Components[0].Expires.Equal(wantExp) {
@@ -76,6 +84,16 @@ func TestParseConfig_Errors(t *testing.T) {
 			name:       "unknown field rejected",
 			yaml:       "components:\n  - name: a.b\n    stability: experimental\n    reason: x\n    expires: 2026-10-01\n    severity: high\n",
 			wantSubstr: "field severity not found",
+		},
+		{
+			name:       "feature missing reason",
+			yaml:       "features:\n  - name: foreach block\n    stability: experimental\n    expires: 2026-10-01\n",
+			wantSubstr: "features[0] (foreach block): reason is required",
+		},
+		{
+			name:       "features not sorted by name",
+			yaml:       "features:\n  - name: foreach block\n    stability: experimental\n    reason: x\n    expires: 2026-10-01\n  - name: Windows process priority\n    stability: public-preview\n    reason: y\n    expires: 2026-10-01\n",
+			wantSubstr: "features[1] (Windows process priority): entries must be sorted by name",
 		},
 	}
 	for _, tc := range tests {

--- a/internal/cmd/stabilitycheck/config_test.go
+++ b/internal/cmd/stabilitycheck/config_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseConfig_Valid(t *testing.T) {
+	yaml := `
+components:
+  - name: loki.source.foo
+    stability: experimental
+    reason: "waiting on upstream API to settle"
+    expires: 2026-10-01
+  - name: prometheus.write.bar
+    stability: public-preview
+    reason: "needs load testing before GA"
+    expires: 2027-01-01
+`
+	cfg, err := parseConfig([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if got, want := len(cfg.Components), 2; got != want {
+		t.Fatalf("component count = %d, want %d", got, want)
+	}
+	wantExp := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+	if !cfg.Components[0].Expires.Equal(wantExp) {
+		t.Errorf("Expires[0] = %v, want %v", cfg.Components[0].Expires, wantExp)
+	}
+}
+
+func TestParseConfig_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		wantSubstr string
+	}{
+		{
+			name:       "missing name",
+			yaml:       "components:\n  - stability: experimental\n    reason: x\n    expires: 2026-10-01\n",
+			wantSubstr: "name is required",
+		},
+		{
+			name:       "duplicate name",
+			yaml:       "components:\n  - name: a.b\n    stability: experimental\n    reason: x\n    expires: 2026-10-01\n  - name: a.b\n    stability: experimental\n    reason: y\n    expires: 2026-10-01\n",
+			wantSubstr: "duplicate name",
+		},
+		{
+			name:       "invalid stability",
+			yaml:       "components:\n  - name: a.b\n    stability: generally-available\n    reason: x\n    expires: 2026-10-01\n",
+			wantSubstr: "stability must be one of",
+		},
+		{
+			name:       "missing reason",
+			yaml:       "components:\n  - name: a.b\n    stability: experimental\n    expires: 2026-10-01\n",
+			wantSubstr: "reason is required",
+		},
+		{
+			name:       "placeholder reason rejected",
+			yaml:       "components:\n  - name: a.b\n    stability: experimental\n    reason: TODO\n    expires: 2026-10-01\n",
+			wantSubstr: "placeholder",
+		},
+		{
+			name:       "missing expires",
+			yaml:       "components:\n  - name: a.b\n    stability: experimental\n    reason: x\n",
+			wantSubstr: "expires is required",
+		},
+		{
+			name:       "entries not sorted by name",
+			yaml:       "components:\n  - name: b.comp\n    stability: experimental\n    reason: x\n    expires: 2026-10-01\n  - name: a.comp\n    stability: experimental\n    reason: y\n    expires: 2026-10-01\n",
+			wantSubstr: "must be sorted by name",
+		},
+		{
+			name:       "unknown field rejected",
+			yaml:       "components:\n  - name: a.b\n    stability: experimental\n    reason: x\n    expires: 2026-10-01\n    severity: high\n",
+			wantSubstr: "field severity not found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseConfig([]byte(tc.yaml))
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.wantSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_MissingFileIsEmpty(t *testing.T) {
+	cfg, err := loadConfig("./does-not-exist.yaml")
+	if err != nil {
+		t.Fatalf("missing file should be empty config, got error: %v", err)
+	}
+	if len(cfg.Components) != 0 {
+		t.Errorf("empty config expected, got %d entries", len(cfg.Components))
+	}
+}
+
+func TestParseConfig_EmptyAndCommentOnlyFilesAreValid(t *testing.T) {
+	for _, in := range []string{"", "# only a comment\n"} {
+		cfg, err := parseConfig([]byte(in))
+		if err != nil {
+			t.Errorf("parseConfig(%q): unexpected error %v", in, err)
+			continue
+		}
+		if len(cfg.Components) != 0 {
+			t.Errorf("parseConfig(%q): want empty, got %d entries", in, len(cfg.Components))
+		}
+	}
+}

--- a/internal/cmd/stabilitycheck/main.go
+++ b/internal/cmd/stabilitycheck/main.go
@@ -1,0 +1,77 @@
+// Command stabilitycheck fails CI when a non-GA component is not tracked, or
+// its tracking entry is stale, in .stability.yaml.
+//
+// The component registry is the source of findings. Every experimental or
+// public-preview component must have an entry with a reason and a review
+// deadline. When the deadline passes, or the code and entry disagree, CI fails
+// until a human renews or removes the entry. This mirrors the .govulncheck.yaml
+// model, where a justification must not go stale.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/grafana/alloy/internal/component"
+
+	_ "github.com/grafana/alloy/internal/component/all" // Import all component definitions.
+)
+
+func main() {
+	configPath := flag.String("config", ".stability.yaml", "path to the stability tracking config")
+	flag.Parse()
+
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load config: %v\n", err)
+		os.Exit(2)
+	}
+
+	findings := classify(enumerate(), cfg, time.Now())
+	report(os.Stdout, findings)
+	if len(findings) > 0 {
+		os.Exit(1)
+	}
+}
+
+// enumerate reads every registered component from the runtime registry.
+func enumerate() []registeredComponent {
+	names := component.AllNames()
+	sort.Strings(names)
+
+	out := make([]registeredComponent, 0, len(names))
+	for _, name := range names {
+		reg, ok := component.Get(name)
+		if !ok {
+			continue
+		}
+		// Community components have an undefined stability whose String() is not
+		// quoted; Unquote fails and leaves stability empty, which is fine
+		// because classify checks the Community flag first.
+		stability, _ := strconv.Unquote(reg.Stability.String())
+		out = append(out, registeredComponent{
+			Name:      reg.Name,
+			Stability: stability,
+			Community: reg.Community,
+		})
+	}
+	return out
+}
+
+// report writes each finding, then a summary. It mirrors the govulncheck
+// wrapper report style.
+func report(w io.Writer, findings []finding) {
+	if len(findings) == 0 {
+		_, _ = fmt.Fprintln(w, "stabilitycheck: all non-GA components are tracked and current")
+		return
+	}
+	for _, f := range findings {
+		_, _ = fmt.Fprintf(w, "  [FAIL] %s: %s\n", f.name, f.message)
+	}
+	_, _ = fmt.Fprintf(w, "  → %d problem(s) found\n", len(findings))
+}

--- a/internal/cmd/stabilitycheck/main.go
+++ b/internal/cmd/stabilitycheck/main.go
@@ -67,11 +67,11 @@ func enumerate() []registeredComponent {
 // wrapper report style.
 func report(w io.Writer, findings []finding) {
 	if len(findings) == 0 {
-		_, _ = fmt.Fprintln(w, "stabilitycheck: all non-GA components are tracked and current")
+		_, _ = fmt.Fprintln(w, "stabilitycheck: all non-GA components and features are tracked and current")
 		return
 	}
 	for _, f := range findings {
-		_, _ = fmt.Fprintf(w, "  [FAIL] %s: %s\n", f.name, f.message)
+		_, _ = fmt.Fprintf(w, "  [FAIL] (%s) %s: %s\n", f.section, f.name, f.message)
 	}
 	_, _ = fmt.Fprintf(w, "  → %d problem(s) found\n", len(findings))
 }

--- a/internal/cmd/stabilitycheck/main.go
+++ b/internal/cmd/stabilitycheck/main.go
@@ -24,7 +24,26 @@ import (
 
 func main() {
 	configPath := flag.String("config", ".stability.yaml", "path to the stability tracking config")
+	update := flag.Bool("update", false, "add TODO entries for untracked non-GA components, sort the file, then exit")
+	expiresFlag := flag.String("expires", "", "expiry date (YYYY-MM-DD) for entries added by --update; default is 6 months from today")
 	flag.Parse()
+
+	if *update {
+		expires := time.Now().AddDate(0, 6, 0)
+		if *expiresFlag != "" {
+			parsed, err := time.Parse("2006-01-02", *expiresFlag)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid --expires %q: want YYYY-MM-DD\n", *expiresFlag)
+				os.Exit(2)
+			}
+			expires = parsed
+		}
+		if err := runUpdate(*configPath, enumerate(), expires, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "update: %v\n", err)
+			os.Exit(2)
+		}
+		return
+	}
 
 	cfg, err := loadConfig(*configPath)
 	if err != nil {

--- a/internal/cmd/stabilitycheck/update.go
+++ b/internal/cmd/stabilitycheck/update.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// updateResult reports what runUpdate changed.
+type updateResult struct {
+	added []string // names of component entries added
+	stale []string // existing component entries that are no longer non-GA
+}
+
+// runUpdate rewrites path in place: it adds a TODO entry for every non-GA
+// component that has no entry, and sorts both sections by name. Existing entries
+// are never modified. Stale entries are reported, not removed, because removing
+// an entry would discard its human-written reason. It works on a yaml.Node tree
+// so the file header and comments survive.
+func runUpdate(path string, comps []registeredComponent, defaultExpires time.Time, w io.Writer) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	var doc yaml.Node
+	if len(bytes.TrimSpace(data)) > 0 {
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("parse YAML: %w", err)
+		}
+	}
+	top := topMapping(&doc)
+
+	compSeq := findOrCreateSeq(top, "components")
+	featSeq := findSeq(top, "features") // features are sorted only, never added.
+
+	nonGA := make(map[string]string, len(comps)) // name -> stability
+	for _, c := range comps {
+		if c.Community || c.Stability == gaStability {
+			continue
+		}
+		nonGA[c.Name] = c.Stability
+	}
+
+	existing := namesInSeq(compSeq)
+
+	var res updateResult
+	for name, stability := range nonGA {
+		if existing[name] {
+			continue
+		}
+		compSeq.Content = append(compSeq.Content, newEntryNode(name, stability, placeholderReason, defaultExpires))
+		res.added = append(res.added, name)
+	}
+	// An existing entry whose component is not currently non-GA is stale.
+	for name := range existing {
+		if _, ok := nonGA[name]; !ok {
+			res.stale = append(res.stale, name)
+		}
+	}
+
+	sortSeqByName(compSeq)
+	if featSeq != nil {
+		sortSeqByName(featSeq)
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2) // Match the existing 2-space style.
+	if err := enc.Encode(&doc); err != nil {
+		return fmt.Errorf("encode YAML: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("close encoder: %w", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		return err
+	}
+
+	res.report(w, path)
+	return nil
+}
+
+func (r updateResult) report(w io.Writer, path string) {
+	sort.Strings(r.added)
+	sort.Strings(r.stale)
+	_, _ = fmt.Fprintf(w, "stabilitycheck --update: wrote %s\n", path)
+	_, _ = fmt.Fprintf(w, "  added %d component entr(y/ies), sorted all sections\n", len(r.added))
+	for _, n := range r.added {
+		_, _ = fmt.Fprintf(w, "    + %s (reason left as %s)\n", n, placeholderReason)
+	}
+	if len(r.stale) > 0 {
+		_, _ = fmt.Fprintf(w, "  %d stale entr(y/ies) left in place — remove by hand (they keep their reason):\n", len(r.stale))
+		for _, n := range r.stale {
+			_, _ = fmt.Fprintf(w, "    ! %s\n", n)
+		}
+	}
+}
+
+// topMapping returns the top-level mapping node, creating the document and
+// mapping if the file was empty.
+func topMapping(doc *yaml.Node) *yaml.Node {
+	if len(doc.Content) == 0 {
+		m := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		doc.Kind = yaml.DocumentNode
+		doc.Content = []*yaml.Node{m}
+		return m
+	}
+	return doc.Content[0]
+}
+
+// findSeq returns the sequence node for key, or nil if the key is absent.
+func findSeq(top *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(top.Content); i += 2 {
+		if top.Content[i].Value == key {
+			return top.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// findOrCreateSeq returns the sequence node for key, appending an empty one if
+// the key is absent.
+func findOrCreateSeq(top *yaml.Node, key string) *yaml.Node {
+	if seq := findSeq(top, key); seq != nil {
+		return seq
+	}
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	top.Content = append(top.Content, keyNode, seq)
+	return seq
+}
+
+// namesInSeq returns the set of entry names in a sequence node.
+func namesInSeq(seq *yaml.Node) map[string]bool {
+	out := make(map[string]bool, len(seq.Content))
+	for _, e := range seq.Content {
+		if n := entryName(e); n != "" {
+			out[n] = true
+		}
+	}
+	return out
+}
+
+// entryName reads the `name` value from an entry mapping node.
+func entryName(m *yaml.Node) string {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == "name" {
+			return m.Content[i+1].Value
+		}
+	}
+	return ""
+}
+
+// sortSeqByName sorts a sequence node's entries alphabetically by name.
+func sortSeqByName(seq *yaml.Node) {
+	sort.SliceStable(seq.Content, func(i, j int) bool {
+		return entryName(seq.Content[i]) < entryName(seq.Content[j])
+	})
+}
+
+// newEntryNode builds an entry mapping node with a TODO reason.
+func newEntryNode(name, stability, reason string, expires time.Time) *yaml.Node {
+	str := func(v string) *yaml.Node { return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: v} }
+	m := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	m.Content = []*yaml.Node{
+		str("name"), str(name),
+		str("stability"), str(stability),
+		str("reason"), str(reason),
+		str("expires"), {Kind: yaml.ScalarNode, Tag: "!!timestamp", Value: expires.Format("2006-01-02")},
+	}
+	return m
+}

--- a/internal/cmd/stabilitycheck/update_test.go
+++ b/internal/cmd/stabilitycheck/update_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestRunUpdate(t *testing.T) {
+	expires := time.Date(2027, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// Start unsorted, missing one non-GA component, with a stale entry and an
+	// existing entry whose reason must be preserved.
+	initial := `# managed header
+components:
+  - name: z.comp
+    stability: experimental
+    reason: "real reason to keep"
+    expires: 2026-10-01
+  - name: a.comp
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: stale.comp
+    stability: experimental
+    reason: "was tracked"
+    expires: 2026-10-01
+features:
+  - name: zeta feature
+    stability: experimental
+    reason: TODO
+    expires: 2026-10-01
+  - name: alpha feature
+    stability: public-preview
+    reason: TODO
+    expires: 2026-10-01
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stability.yaml")
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	comps := []registeredComponent{
+		{Name: "a.comp", Stability: "experimental"},
+		{Name: "z.comp", Stability: "experimental"},
+		{Name: "m.comp", Stability: "public-preview"}, // new, must be added
+		{Name: "ga.comp", Stability: "generally-available"},
+		{Name: "community.comp", Community: true},
+		// stale.comp is absent from the registry.
+	}
+
+	var out bytes.Buffer
+	if err := runUpdate(path, comps, expires, &out); err != nil {
+		t.Fatalf("runUpdate: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+
+	// Components sorted by name, with the new entry inserted.
+	wantComps := []string{"a.comp", "m.comp", "stale.comp", "z.comp"}
+	if got := names(cfg.Components); !equal(got, wantComps) {
+		t.Errorf("components = %v, want %v", got, wantComps)
+	}
+
+	// The new entry has the detected stability, a TODO reason, and the given expiry.
+	m := byName(cfg.Components)["m.comp"]
+	if m.Stability != "public-preview" || m.Reason != "TODO" || !m.Expires.Equal(expires) {
+		t.Errorf("m.comp = %+v, want stability=public-preview reason=TODO expires=%v", m, expires)
+	}
+
+	// An existing real reason is preserved untouched.
+	if got := byName(cfg.Components)["z.comp"].Reason; got != "real reason to keep" {
+		t.Errorf("z.comp reason = %q, want it preserved", got)
+	}
+
+	// The stale entry is kept, not removed.
+	if _, ok := byName(cfg.Components)["stale.comp"]; !ok {
+		t.Errorf("stale.comp should be kept in place")
+	}
+
+	// Features are sorted but never added to.
+	wantFeatures := []string{"alpha feature", "zeta feature"}
+	if got := names(cfg.Features); !equal(got, wantFeatures) {
+		t.Errorf("features = %v, want %v", got, wantFeatures)
+	}
+
+	// The report mentions the added component and the stale one.
+	report := out.String()
+	if !bytes.Contains([]byte(report), []byte("m.comp")) {
+		t.Errorf("report should mention added m.comp:\n%s", report)
+	}
+	if !bytes.Contains([]byte(report), []byte("stale.comp")) {
+		t.Errorf("report should mention stale.comp:\n%s", report)
+	}
+
+	// The managed header comment survives the rewrite.
+	if !bytes.Contains(data, []byte("# managed header")) {
+		t.Errorf("header comment lost:\n%s", data)
+	}
+
+	// Running again changes nothing.
+	before := data
+	var out2 bytes.Buffer
+	if err := runUpdate(path, comps, expires, &out2); err != nil {
+		t.Fatalf("runUpdate second run: %v", err)
+	}
+	after, _ := os.ReadFile(path)
+	if !bytes.Equal(before, after) {
+		t.Errorf("update is not idempotent:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func names(entries []Entry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Name
+	}
+	return out
+}
+
+func byName(entries []Entry) map[string]Entry {
+	out := make(map[string]Entry, len(entries))
+	for _, e := range entries {
+		out[e.Name] = e
+	}
+	return out
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
### Brief description of Pull Request

POC: CI tooling that tracks non-GA (experimental and public-preview) components
and features, modeled on the `.govulncheck.yaml` pattern where each justification
carries an `expires` date that forces periodic re-review.

- `internal/cmd/stabilitycheck` enumerates the component registry and enforces
  `.stability.yaml`: every non-GA component needs an entry with a reason and an
  expiry. CI fails when a non-GA component is untracked, an entry expires, the
  recorded level drifts from the code, or an entry is stale (now GA, removed, or
  community).
- A hand-maintained `features:` section tracks non-GA behavior that is not a
  component (config blocks, experimental stdlib functions, CLI features).
- `stabilitycheck --update` formats the file and scaffolds `TODO` entries.
- Wired into the Makefile, the lint task group, and the CI lint job.

### Pull Request Details

Modeled on the existing govulncheck wrapper so justifications cannot silently rot.

Key decisions:
- Components are enumerated from the runtime registry for a completeness
  guarantee. The features list is hand-maintained — a deliberate trade-off, since
  non-component features have no single registry (a central registry is future
  work).
- `expires` is required; the initial rollout uses a uniform short window to force
  a first-pass review.
- Reasons are seeded as `TODO` and rejected by the tool, so CI stays red until
  component owners write real justifications.

As a POC: the reasons in `.stability.yaml` are `TODO` placeholders, and the
features list is best-effort, not exhaustive.

### Issue(s) fixed by this Pull Request


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Can leave empty if not needed. -->


### PR Checklist

<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
