### PR TITLE
refactor: Add partial lines store for loki.process and implement more performant version

### DIFF
--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -36,6 +36,14 @@ func (b *Batch) Add(stream Stream) {
 	b.entryLen += len(stream.Entries)
 }
 
+func (b *Batch) AddEntry(labels model.LabelSet, entry push.Entry) {
+	if b.created == 0 {
+		b.created = time.Now().UnixMicro()
+	}
+	b.add(labels, entry)
+	b.entryLen += 1
+}
+
 func (b *Batch) add(labels model.LabelSet, entries ...push.Entry) {
 	i := slices.IndexFunc(b.streams, func(s Stream) bool {
 		return s.Labels.Equal(labels)

--- a/internal/component/common/loki/batch.go
+++ b/internal/component/common/loki/batch.go
@@ -80,10 +80,7 @@ func (b *Batch) FilterMap(fn func(entry *Entry) (keep bool)) {
 		)
 
 		for _, e := range stream.Entries {
-			// FIXME(kalleep): This clone protects stream.Labels from in-place mutation
-			// through Entry.Labels, which is a map. Most FilterMap callbacks do not change
-			// labels, so once the new batched pipeline owns this path, consider replacing
-			// direct label access with copy-on-write label mutation methods.
+			//FIXME(kalleep): this clone will be removed when https://github.com/grafana/alloy/issues/6835 is implemented.
 			entry := NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), b.created, e)
 			if !fn(&entry) {
 				continue
@@ -143,8 +140,7 @@ func (b *Batch) FilterMapStreams(fn func(stream *Stream) (keep bool)) {
 	// and may merge into an existing stream.
 	for i := range b.streams {
 		stream := Stream{
-			// FIXME(kalleep): Once the new batched pipeline owns this path, consider
-			// copy-on-write label mutation methods so unchanged streams skip the copy.
+			//FIXME(kalleep): this clone will be removed when https://github.com/grafana/alloy/issues/6835 is implemented.
 			Labels:  b.streams[i].Labels.Clone(),
 			Entries: b.streams[i].Entries,
 		}

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -210,7 +210,7 @@ func (c *criStage) flushPartialLinesIfExceeded(buf []Entry) []Entry {
 		return buf
 	}
 
-	buf = slices.Grow(buf, len(buf)+len(c.partialLines))
+	buf = slices.Grow(buf, len(c.partialLines))
 
 	c.logger.Warn("partial lines upperbound exceeded, merging it to single line", "threshold", c.cfg.MaxPartialLines)
 	if c.partialLinesFlushedMetric != nil {

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -111,8 +111,7 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 		// We received partial-line (tag: "P")
 		if parsed.Flag == crip.FlagPartial {
 			// flush any partial lines if we have buffered too many.
-			entries := make([]Entry, 0, c.partialLines.Size())
-			entries = c.flushPartialLinesIfExceeded(entries)
+			entries := c.flushPartialLinesIfExceeded()
 			// it's a partial-line buffer it and move on.
 			c.partialLines.Append(fingerprint, e)
 			return entries, len(entries) == 0
@@ -125,19 +124,13 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 	})
 }
 
-// process implements entryProcessor and is only used by our new pipeline.
-// flushPartialLinesIfExceeded can sweep up and forward a stream owned by a
-// different, concurrently-running caller through this caller's next() call,
-// causing OOO for that stream. For now this is an acceptable tradeoff and we
-// consider this a failure case. We can revisit this in the future.
+// process implements entryProcessor and is only used by our new pipeline. A
+// flush can forward a stream owned by a different, concurrently-running caller
+// through this caller's next() call, causing OOO for that stream. We accept
+// that tradeoff for now.
 func (c *criStage) process(ctx context.Context, entries []Entry) error {
-	// dst compacts entries in place, extra only grows when the
-	// MaxPartialLines branch below flushes held partial lines. So in
-	// the common case this call never allocates a new slice.
-	var (
-		dst   int
-		extra []Entry
-	)
+	// dst compacts entries in place.
+	var dst int
 	for _, e := range entries {
 		parsed, ok := crip.ParseCRI(e.Line)
 		if !ok {
@@ -149,26 +142,26 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 		setCRIProperties(&e, parsed)
 
 		fingerprint := e.Labels.Fingerprint()
-		// We received partial-line (tag: "P")
 		if parsed.Flag == crip.FlagPartial {
-			// flush any partial lines if we have buffered too many.
-			extra = c.flushPartialLinesIfExceeded(extra)
-			// it's a partial-line buffer it and move on.
 			c.partialLines.Append(fingerprint, e)
 			continue
 		}
 
-		// We got full-line 'F'.
-		// If any old partial lines matches with this full-line stream, merge it,
-		// else just return the full line.
 		entries[dst] = c.completeFullLine(fingerprint, e)
 		dst++
 	}
 
 	out := entries[:dst]
+
+	// Checking once per batch lets the store overshoot by up to one batch, which
+	// is acceptable because those entries already fit in memory as part of it.
+	// In the future a background goroutine could own this check, so that batches
+	// do not pay the cost of calling this at all.
+	extra := c.flushPartialLinesIfExceeded()
 	if len(extra) > 0 {
-		// NOTE: We append to extra to make sure buffered entries are
-		// ordered before passed in entries.
+		// Buffered entries go out before the entries passed in. We are assuming that
+		// these are older entries, but this can still lead to some out-of-order results,
+		// which we consider acceptable for this safety mechanism.
 		out = append(extra, out...)
 	}
 
@@ -188,21 +181,18 @@ func (c *criStage) completeFullLine(fp model.Fingerprint, e Entry) Entry {
 	return e
 }
 
-func (c *criStage) flushPartialLinesIfExceeded(buf []Entry) []Entry {
-	before := len(buf)
-	buf = c.partialLines.DrainIfAtLeast(c.cfg.MaxPartialLines, buf)
-
-	flushed := len(buf) - before
-	if flushed == 0 {
-		return buf
+func (c *criStage) flushPartialLinesIfExceeded() []Entry {
+	flushed := c.partialLines.DrainIfAtLeast(c.cfg.MaxPartialLines)
+	if len(flushed) == 0 {
+		return nil
 	}
 
 	c.logger.Warn("partial lines upperbound exceeded, merging it to single line", "threshold", c.cfg.MaxPartialLines)
 	if c.partialLinesFlushedMetric != nil {
-		c.partialLinesFlushedMetric.Add(float64(flushed))
+		c.partialLinesFlushedMetric.Add(float64(len(flushed)))
 	}
 
-	return buf
+	return flushed
 }
 
 // stop implements stopper and is only used by our new pipeline.
@@ -211,7 +201,7 @@ func (c *criStage) stop() {
 	ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
 	defer cancel()
 
-	out := c.partialLines.DrainAll(nil)
+	out := c.partialLines.DrainAll()
 	if len(out) == 0 {
 		return
 	}

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -267,6 +267,8 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	return c.next(ctx, out)
 }
 
+func (c *criStage) cleanup() {}
+
 func (c *criStage) ensureTruncateIfRequired(e *Entry) {
 	if c.cfg.MaxPartialLineSizeTruncate && len(e.Line) > int(c.cfg.MaxPartialLineSize) {
 		e.Line = e.Line[:c.cfg.MaxPartialLineSize]

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -292,7 +292,7 @@ func (c *criStage) stop() {
 	for _, e := range c.partialLines {
 		out = append(out, e)
 	}
-	c.partialLines = nil
+	c.partialLines = make(map[model.Fingerprint]Entry)
 	c.mut.Unlock()
 
 	if len(out) == 0 {

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -79,7 +79,7 @@ var (
 	_ Stage = (*criStage)(nil)
 
 	_ stage   = (*criStage)(nil)
-	_ cleaner = (*criStage)(nil)
+	_ stopper = (*criStage)(nil)
 )
 
 type criStage struct {
@@ -183,7 +183,7 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 	})
 }
 
-// cleanup implements stage and is only used by our new pipeline.
+// process implements stage and is only used by our new pipeline.
 func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	c.mut.Lock()
 
@@ -285,8 +285,8 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	return c.next(ctx, out)
 }
 
-// cleanup implements cleaner and is only used by our new pipeline.
-func (c *criStage) cleanup() {
+// stop implements stopper and is only used by our new pipeline.
+func (c *criStage) stop() {
 	c.mut.Lock()
 	out := make([]Entry, 0, len(c.partialLines))
 	for _, e := range c.partialLines {
@@ -303,7 +303,7 @@ func (c *criStage) cleanup() {
 	ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
 	defer cancel()
 	if err := c.next(ctx, out); err != nil {
-		c.logger.Error("failed to flush held partial lines on cleanup", "err", err)
+		c.logger.Error("failed to flush held partial lines on stop", "err", err)
 	}
 }
 

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/common/model"
 
 	crip "github.com/grafana/alloy/internal/component/loki/process/stages/cri"
-	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/util"
 	"github.com/grafana/alloy/syntax"
 )
@@ -48,14 +47,14 @@ func (args *CRIConfig) Validate() error {
 	return nil
 }
 
-func newCRIStage(logger *slog.Logger, cfg CRIConfig, registerer prometheus.Registerer, _ featuregate.Stability, next NextFn) *criStage {
+func newCRIStage(cfg CRIConfig, opts stageOpts) *criStage {
 	return &criStage{
-		next:                      next,
-		logger:                    logger.With("stage", "cri"),
+		next:                      opts.next,
+		logger:                    opts.slogger.With("stage", "cri"),
 		cfg:                       cfg,
 		partialLines:              make(map[model.Fingerprint]Entry, cfg.MaxPartialLines),
-		partialLinesFlushedMetric: getPartialLinesFlushedMetric(registerer),
-		linesTruncatedMetric:      getLinesTruncatedMetric(registerer),
+		partialLinesFlushedMetric: getPartialLinesFlushedMetric(opts.registerer),
+		linesTruncatedMetric:      getLinesTruncatedMetric(opts.registerer),
 	}
 }
 
@@ -83,9 +82,9 @@ var (
 )
 
 type criStage struct {
-	next   NextFn
-	logger *slog.Logger
+	next   nextFn
 	cfg    CRIConfig
+	logger *slog.Logger
 
 	mut          sync.Mutex
 	partialLines map[model.Fingerprint]Entry
@@ -103,9 +102,6 @@ const (
 
 func (c *criStage) Run(in chan Entry) chan Entry {
 	return RunWithSkipOrSendMany(in, func(e Entry) ([]Entry, bool) {
-		c.mut.Lock()
-		defer c.mut.Unlock()
-
 		parsed, ok := crip.ParseCRI(e.Line)
 		if !ok {
 			return []Entry{e}, false
@@ -183,7 +179,7 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 	})
 }
 
-// process implements stage and is only used by our new pipeline.
+// process implements entryProcessor and is only used by our new pipeline.
 func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	c.mut.Lock()
 
@@ -289,21 +285,23 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 
 // stop implements stopper and is only used by our new pipeline.
 func (c *criStage) stop() {
+	const flushTimeout = 5 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
+	defer cancel()
+
 	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	if len(c.partialLines) == 0 {
+		return
+	}
+
 	out := make([]Entry, 0, len(c.partialLines))
 	for _, e := range c.partialLines {
 		out = append(out, e)
 	}
 	c.partialLines = make(map[model.Fingerprint]Entry)
-	c.mut.Unlock()
 
-	if len(out) == 0 {
-		return
-	}
-
-	const flushTimeout = 5 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
-	defer cancel()
 	if err := c.next(ctx, out); err != nil {
 		c.logger.Error("failed to flush held partial lines on stop", "err", err)
 	}

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -183,6 +183,7 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 	})
 }
 
+// cleanup implements stage and is only used by our new pipeline.
 func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	c.mut.Lock()
 
@@ -267,7 +268,27 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	return c.next(ctx, out)
 }
 
-func (c *criStage) cleanup() {}
+// cleanup implements cleaner and is only used by our new pipeline.
+func (c *criStage) cleanup() {
+	c.mut.Lock()
+	out := make([]Entry, 0, len(c.partialLines))
+	for _, e := range c.partialLines {
+		out = append(out, e)
+	}
+	c.partialLines = nil
+	c.mut.Unlock()
+
+	if len(out) == 0 {
+		return
+	}
+
+	const flushTimeout = 5 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
+	defer cancel()
+	if err := c.next(ctx, out); err != nil {
+		c.logger.Error("failed to flush held partial lines on cleanup", "err", err)
+	}
+}
 
 func (c *criStage) ensureTruncateIfRequired(e *Entry) {
 	if c.cfg.MaxPartialLineSizeTruncate && len(e.Line) > int(c.cfg.MaxPartialLineSize) {

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -275,7 +275,9 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 
 	out := entries[:dst]
 	if len(extra) > 0 {
-		out = append(out, extra...)
+		// NOTE: We append to extra to make sure buffered entries are
+		// ordered before passed in entries.
+		out = append(extra, out...)
 	}
 
 	if len(out) == 0 {

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -128,6 +128,11 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 }
 
 // process implements entryProcessor and is only used by our new pipeline.
+// c.mut is released before calling next(), so flushPartialLinesIfExceeded
+// can sweep up and forward a stream owned by a different, concurrently-
+// running caller through this caller's next() call, causing OOO for that
+// stream. For now this is an acceptable tradeoff and we consider this a
+// failure case. We can revisit this in the future.
 func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	c.mut.Lock()
 

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -187,11 +187,18 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	c.mut.Lock()
 
-	out := make([]Entry, 0, len(entries))
+	// dst compacts entries in place, extra only grows when the
+	// MaxPartialLines branch below flushes held partial lines. So in
+	// the common case this call never allocates a new slice.
+	var (
+		dst   int
+		extra []Entry
+	)
 	for _, e := range entries {
 		parsed, ok := crip.ParseCRI(e.Line)
 		if !ok {
-			out = append(out, e)
+			entries[dst] = e
+			dst++
 			continue
 		}
 
@@ -225,7 +232,7 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 
 				// Add existing partialLines
 				for _, v := range c.partialLines {
-					out = append(out, v)
+					extra = append(extra, v)
 				}
 
 				c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
@@ -260,10 +267,20 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 			delete(c.partialLines, fingerprint)
 		}
 
-		out = append(out, e)
+		entries[dst] = e
+		dst++
 	}
 
 	c.mut.Unlock()
+
+	out := entries[:dst]
+	if len(extra) > 0 {
+		out = append(out, extra...)
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
 
 	return c.next(ctx, out)
 }

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -78,8 +78,8 @@ func getLinesTruncatedMetric(registerer prometheus.Registerer) prometheus.Counte
 var (
 	_ Stage = (*criStage)(nil)
 
-	_ stage   = (*criStage)(nil)
-	_ stopper = (*criStage)(nil)
+	_ entryProcessor = (*criStage)(nil)
+	_ stopper        = (*criStage)(nil)
 )
 
 type criStage struct {

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
+	"slices"
 	"sync"
 	"time"
 
@@ -107,75 +107,23 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 			return []Entry{e}, false
 		}
 
-		// NOTE: Previous implementation used a "sub-pipeline"
-		// to parse CRI logs where the regex stage added these fields
-		// as "extracted" values so the other stages could operate on them.
-		// We don't need this anymore but it would be a breaking change to
-		// no longer set these.
-		e.Extracted[criFlags] = parsed.Flag.String()
-		e.Extracted[criStream] = parsed.Stream.String()
-		e.Extracted[criContent] = parsed.Content
-		e.Extracted[criTime] = parsed.Timestamp
-
-		e.Line = parsed.Content
-
-		ts, err := time.Parse(time.RFC3339Nano, parsed.Timestamp)
-		if err == nil {
-			e.Timestamp = ts
-		}
-
-		e.Labels[criStream] = model.LabelValue(parsed.Stream.String())
+		setCRIProperties(&e, parsed)
 
 		fingerprint := e.Labels.Fingerprint()
 		// We received partial-line (tag: "P")
 		if parsed.Flag == crip.FlagPartial {
-			if len(c.partialLines) >= c.cfg.MaxPartialLines {
-				c.logger.Warn("partial lines upperbound exceeded, merging it to single line", "threshold", c.cfg.MaxPartialLines)
-				if c.partialLinesFlushedMetric != nil {
-					c.partialLinesFlushedMetric.Add(float64(len(c.partialLines)))
-				}
-
-				// Merge existing partialLines
-				entries := make([]Entry, 0, len(c.partialLines))
-				for _, v := range c.partialLines {
-					entries = append(entries, v)
-				}
-
-				c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
-				c.ensureTruncateIfRequired(&e)
-				c.partialLines[fingerprint] = e
-
-				return entries, false
-			}
-
-			prev, ok := c.partialLines[fingerprint]
-			if ok {
-				var builder strings.Builder
-				builder.WriteString(prev.Line)
-				builder.WriteString(e.Line)
-				e.Line = builder.String()
-			}
-			c.ensureTruncateIfRequired(&e)
-			c.partialLines[fingerprint] = e
-
-			// it's a partial-line so skip it.
-			return nil, true
+			// flush any partial lines if we have buffered too many.
+			entries := make([]Entry, 0, len(c.partialLines))
+			entries = c.flushPartialLinesIfExceeded(entries)
+			// it's a partial-line buffer it and move on.
+			c.addPartialLine(fingerprint, e)
+			return entries, len(entries) == 0
 		}
 
 		// We got full-line 'F'.
 		// If any old partial lines matches with this full-line stream, merge it,
 		// else just return the full line.
-		prev, ok := c.partialLines[fingerprint]
-		if ok {
-			var builder strings.Builder
-			builder.WriteString(prev.Line)
-			builder.WriteString(e.Line)
-			e.Line = builder.String()
-			c.ensureTruncateIfRequired(&e)
-			delete(c.partialLines, fingerprint)
-		}
-
-		return []Entry{e}, false
+		return []Entry{c.completeFullLine(fingerprint, e)}, false
 	})
 }
 
@@ -198,72 +146,22 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 			continue
 		}
 
-		// NOTE: Previous implementation used a "sub-pipeline"
-		// to parse CRI logs where the regex stage added these fields
-		// as "extracted" values so the other stages could operate on them.
-		// We don't need this anymore but it would be a breaking change to
-		// no longer set these.
-		e.Extracted[criFlags] = parsed.Flag.String()
-		e.Extracted[criStream] = parsed.Stream.String()
-		e.Extracted[criContent] = parsed.Content
-		e.Extracted[criTime] = parsed.Timestamp
-
-		e.Line = parsed.Content
-
-		ts, err := time.Parse(time.RFC3339Nano, parsed.Timestamp)
-		if err == nil {
-			e.Timestamp = ts
-		}
-
-		e.Labels[criStream] = model.LabelValue(parsed.Stream.String())
+		setCRIProperties(&e, parsed)
 
 		fingerprint := e.Labels.Fingerprint()
 		// We received partial-line (tag: "P")
 		if parsed.Flag == crip.FlagPartial {
-			if len(c.partialLines) >= c.cfg.MaxPartialLines {
-				c.logger.Warn("partial lines upperbound exceeded, merging it to single line", "threshold", c.cfg.MaxPartialLines)
-				if c.partialLinesFlushedMetric != nil {
-					c.partialLinesFlushedMetric.Add(float64(len(c.partialLines)))
-				}
-
-				// Add existing partialLines
-				for _, v := range c.partialLines {
-					extra = append(extra, v)
-				}
-
-				c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
-				c.ensureTruncateIfRequired(&e)
-				c.partialLines[fingerprint] = e
-				continue
-			}
-
-			prev, ok := c.partialLines[fingerprint]
-			if ok {
-				var builder strings.Builder
-				builder.WriteString(prev.Line)
-				builder.WriteString(e.Line)
-				e.Line = builder.String()
-			}
-			c.ensureTruncateIfRequired(&e)
-			c.partialLines[fingerprint] = e
-			// it's a partial-line so skip it.
+			// flush any partial lines if we have buffered too many.
+			extra = c.flushPartialLinesIfExceeded(extra)
+			// it's a partial-line buffer it and move on.
+			c.addPartialLine(fingerprint, e)
 			continue
 		}
 
 		// We got full-line 'F'.
 		// If any old partial lines matches with this full-line stream, merge it,
 		// else just return the full line.
-		prev, ok := c.partialLines[fingerprint]
-		if ok {
-			var builder strings.Builder
-			builder.WriteString(prev.Line)
-			builder.WriteString(e.Line)
-			e.Line = builder.String()
-			c.ensureTruncateIfRequired(&e)
-			delete(c.partialLines, fingerprint)
-		}
-
-		entries[dst] = e
+		entries[dst] = c.completeFullLine(fingerprint, e)
 		dst++
 	}
 
@@ -281,6 +179,46 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	}
 
 	return c.next(ctx, out)
+}
+
+func (c *criStage) addPartialLine(fp model.Fingerprint, e Entry) {
+	prev, ok := c.partialLines[fp]
+	if ok {
+		e.Line = prev.Line + e.Line
+	}
+	c.ensureTruncateIfRequired(&e)
+	c.partialLines[fp] = e
+}
+
+func (c *criStage) completeFullLine(fp model.Fingerprint, e Entry) Entry {
+	prev, ok := c.partialLines[fp]
+	if ok {
+		e.Line = prev.Line + e.Line
+		c.ensureTruncateIfRequired(&e)
+		delete(c.partialLines, fp)
+	}
+	return e
+}
+
+func (c *criStage) flushPartialLinesIfExceeded(buf []Entry) []Entry {
+	if len(c.partialLines) < c.cfg.MaxPartialLines {
+		return buf
+	}
+
+	buf = slices.Grow(buf, len(buf)+len(c.partialLines))
+
+	c.logger.Warn("partial lines upperbound exceeded, merging it to single line", "threshold", c.cfg.MaxPartialLines)
+	if c.partialLinesFlushedMetric != nil {
+		c.partialLinesFlushedMetric.Add(float64(len(c.partialLines)))
+	}
+
+	for _, v := range c.partialLines {
+		buf = append(buf, v)
+	}
+
+	c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
+
+	return buf
 }
 
 // stop implements stopper and is only used by our new pipeline.
@@ -317,3 +255,24 @@ func (c *criStage) ensureTruncateIfRequired(e *Entry) {
 }
 
 func (c *criStage) Cleanup() {}
+
+func setCRIProperties(e *Entry, parsed crip.Parsed) {
+	// NOTE: Previous implementation used a "sub-pipeline"
+	// to parse CRI logs where the regex stage added these fields
+	// as "extracted" values so the other stages could operate on them.
+	// We don't need this anymore but it would be a breaking change to
+	// no longer set these.
+	e.Extracted[criFlags] = parsed.Flag.String()
+	e.Extracted[criStream] = parsed.Stream.String()
+	e.Extracted[criContent] = parsed.Content
+	e.Extracted[criTime] = parsed.Timestamp
+
+	e.Line = parsed.Content
+
+	ts, err := time.Parse(time.RFC3339Nano, parsed.Timestamp)
+	if err == nil {
+		e.Timestamp = ts
+	}
+
+	e.Labels[criStream] = model.LabelValue(parsed.Stream.String())
+}

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -1,9 +1,11 @@
 package stages
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,8 +17,6 @@ import (
 	"github.com/grafana/alloy/syntax"
 )
 
-// CRIConfig is an empty struct that is used to enable a pre-defined pipeline
-// for decoding entries that are using the CRI logging format.
 type CRIConfig struct {
 	MaxPartialLines            int    `alloy:"max_partial_lines,attr,optional"`
 	MaxPartialLineSize         uint64 `alloy:"max_partial_line_size,attr,optional"`
@@ -28,8 +28,7 @@ var (
 	_ syntax.Validator = (*CRIConfig)(nil)
 )
 
-// DefaultCRIConfig contains the default CRIConfig values.
-var DefaultCRIConfig = CRIConfig{
+var defaultCRIConfig = CRIConfig{
 	MaxPartialLines:            100,
 	MaxPartialLineSize:         0,
 	MaxPartialLineSizeTruncate: false,
@@ -37,7 +36,7 @@ var DefaultCRIConfig = CRIConfig{
 
 // SetToDefault implements syntax.Defaulter.
 func (args *CRIConfig) SetToDefault() {
-	*args = DefaultCRIConfig
+	*args = defaultCRIConfig
 }
 
 // Validate implements syntax.Validator.
@@ -49,16 +48,15 @@ func (args *CRIConfig) Validate() error {
 	return nil
 }
 
-func NewCRI(logger *slog.Logger, cfg CRIConfig, registerer prometheus.Registerer, _ featuregate.Stability) (Stage, error) {
-	partialLinesFlushedMetric := getPartialLinesFlushedMetric(registerer)
-	linesTruncatedMetric := getLinesTruncatedMetric(registerer)
-	return &cri{
+func newCRIStage(logger *slog.Logger, cfg CRIConfig, registerer prometheus.Registerer, _ featuregate.Stability, next NextFn) *criStage {
+	return &criStage{
+		next:                      next,
 		logger:                    logger.With("stage", "cri"),
 		cfg:                       cfg,
 		partialLines:              make(map[model.Fingerprint]Entry, cfg.MaxPartialLines),
-		partialLinesFlushedMetric: partialLinesFlushedMetric,
-		linesTruncatedMetric:      linesTruncatedMetric,
-	}, nil
+		partialLinesFlushedMetric: getPartialLinesFlushedMetric(registerer),
+		linesTruncatedMetric:      getLinesTruncatedMetric(registerer),
+	}
 }
 
 func getPartialLinesFlushedMetric(registerer prometheus.Registerer) prometheus.Counter {
@@ -77,12 +75,21 @@ func getLinesTruncatedMetric(registerer prometheus.Registerer) prometheus.Counte
 	return util.MustRegisterOrGet(registerer, metric).(prometheus.Counter)
 }
 
-var _ Stage = (*cri)(nil)
+var (
+	_ Stage = (*criStage)(nil)
 
-type cri struct {
-	logger                    *slog.Logger
-	cfg                       CRIConfig
-	partialLines              map[model.Fingerprint]Entry
+	_ stage   = (*criStage)(nil)
+	_ cleaner = (*criStage)(nil)
+)
+
+type criStage struct {
+	next   NextFn
+	logger *slog.Logger
+	cfg    CRIConfig
+
+	mut          sync.Mutex
+	partialLines map[model.Fingerprint]Entry
+
 	partialLinesFlushedMetric prometheus.Counter
 	linesTruncatedMetric      prometheus.Counter
 }
@@ -94,8 +101,11 @@ const (
 	criTime    = "time"
 )
 
-func (c *cri) Run(in chan Entry) chan Entry {
+func (c *criStage) Run(in chan Entry) chan Entry {
 	return RunWithSkipOrSendMany(in, func(e Entry) ([]Entry, bool) {
+		c.mut.Lock()
+		defer c.mut.Unlock()
+
 		parsed, ok := crip.ParseCRI(e.Line)
 		if !ok {
 			return []Entry{e}, false
@@ -173,7 +183,91 @@ func (c *cri) Run(in chan Entry) chan Entry {
 	})
 }
 
-func (c *cri) ensureTruncateIfRequired(e *Entry) {
+func (c *criStage) process(ctx context.Context, entries []Entry) error {
+	c.mut.Lock()
+
+	out := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		parsed, ok := crip.ParseCRI(e.Line)
+		if !ok {
+			out = append(out, e)
+			continue
+		}
+
+		// NOTE: Previous implementation used a "sub-pipeline"
+		// to parse CRI logs where the regex stage added these fields
+		// as "extracted" values so the other stages could operate on them.
+		// We don't need this anymore but it would be a breaking change to
+		// no longer set these.
+		e.Extracted[criFlags] = parsed.Flag.String()
+		e.Extracted[criStream] = parsed.Stream.String()
+		e.Extracted[criContent] = parsed.Content
+		e.Extracted[criTime] = parsed.Timestamp
+
+		e.Line = parsed.Content
+
+		ts, err := time.Parse(time.RFC3339Nano, parsed.Timestamp)
+		if err == nil {
+			e.Timestamp = ts
+		}
+
+		e.Labels[criStream] = model.LabelValue(parsed.Stream.String())
+
+		fingerprint := e.Labels.Fingerprint()
+		// We received partial-line (tag: "P")
+		if parsed.Flag == crip.FlagPartial {
+			if len(c.partialLines) >= c.cfg.MaxPartialLines {
+				c.logger.Warn("partial lines upperbound exceeded, merging it to single line", "threshold", c.cfg.MaxPartialLines)
+				if c.partialLinesFlushedMetric != nil {
+					c.partialLinesFlushedMetric.Add(float64(len(c.partialLines)))
+				}
+
+				// Add existing partialLines
+				for _, v := range c.partialLines {
+					out = append(out, v)
+				}
+
+				c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
+				c.ensureTruncateIfRequired(&e)
+				c.partialLines[fingerprint] = e
+				continue
+			}
+
+			prev, ok := c.partialLines[fingerprint]
+			if ok {
+				var builder strings.Builder
+				builder.WriteString(prev.Line)
+				builder.WriteString(e.Line)
+				e.Line = builder.String()
+			}
+			c.ensureTruncateIfRequired(&e)
+			c.partialLines[fingerprint] = e
+			// it's a partial-line so skip it.
+			continue
+		}
+
+		// We got full-line 'F'.
+		// If any old partial lines matches with this full-line stream, merge it,
+		// else just return the full line.
+		prev, ok := c.partialLines[fingerprint]
+		if ok {
+			var builder strings.Builder
+			builder.WriteString(prev.Line)
+			builder.WriteString(e.Line)
+			e.Line = builder.String()
+			c.ensureTruncateIfRequired(&e)
+			delete(c.partialLines, fingerprint)
+		}
+
+		out = append(out, e)
+	}
+
+	c.mut.Unlock()
+
+	return c.next(ctx, out)
+}
+
+func (c *criStage) ensureTruncateIfRequired(e *Entry) {
 	if c.cfg.MaxPartialLineSizeTruncate && len(e.Line) > int(c.cfg.MaxPartialLineSize) {
 		e.Line = e.Line[:c.cfg.MaxPartialLineSize]
 		if c.linesTruncatedMetric != nil {
@@ -182,4 +276,4 @@ func (c *cri) ensureTruncateIfRequired(e *Entry) {
 	}
 }
 
-func (c *cri) Cleanup() {}
+func (c *criStage) Cleanup() {}

--- a/internal/component/loki/process/stages/cri.go
+++ b/internal/component/loki/process/stages/cri.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"slices"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -48,14 +46,15 @@ func (args *CRIConfig) Validate() error {
 }
 
 func newCRIStage(cfg CRIConfig, opts stageOpts) *criStage {
-	return &criStage{
+	c := &criStage{
 		next:                      opts.next,
 		logger:                    opts.slogger.With("stage", "cri"),
 		cfg:                       cfg,
-		partialLines:              make(map[model.Fingerprint]Entry, cfg.MaxPartialLines),
 		partialLinesFlushedMetric: getPartialLinesFlushedMetric(opts.registerer),
 		linesTruncatedMetric:      getLinesTruncatedMetric(opts.registerer),
 	}
+	c.partialLines = newPartialLineStore(cfg, c.linesTruncatedMetric)
+	return c
 }
 
 func getPartialLinesFlushedMetric(registerer prometheus.Registerer) prometheus.Counter {
@@ -86,8 +85,7 @@ type criStage struct {
 	cfg    CRIConfig
 	logger *slog.Logger
 
-	mut          sync.Mutex
-	partialLines map[model.Fingerprint]Entry
+	partialLines *partialLineStore
 
 	partialLinesFlushedMetric prometheus.Counter
 	linesTruncatedMetric      prometheus.Counter
@@ -113,10 +111,10 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 		// We received partial-line (tag: "P")
 		if parsed.Flag == crip.FlagPartial {
 			// flush any partial lines if we have buffered too many.
-			entries := make([]Entry, 0, len(c.partialLines))
+			entries := make([]Entry, 0, c.partialLines.Size())
 			entries = c.flushPartialLinesIfExceeded(entries)
 			// it's a partial-line buffer it and move on.
-			c.addPartialLine(fingerprint, e)
+			c.partialLines.Append(fingerprint, e)
 			return entries, len(entries) == 0
 		}
 
@@ -128,14 +126,11 @@ func (c *criStage) Run(in chan Entry) chan Entry {
 }
 
 // process implements entryProcessor and is only used by our new pipeline.
-// c.mut is released before calling next(), so flushPartialLinesIfExceeded
-// can sweep up and forward a stream owned by a different, concurrently-
-// running caller through this caller's next() call, causing OOO for that
-// stream. For now this is an acceptable tradeoff and we consider this a
-// failure case. We can revisit this in the future.
+// flushPartialLinesIfExceeded can sweep up and forward a stream owned by a
+// different, concurrently-running caller through this caller's next() call,
+// causing OOO for that stream. For now this is an acceptable tradeoff and we
+// consider this a failure case. We can revisit this in the future.
 func (c *criStage) process(ctx context.Context, entries []Entry) error {
-	c.mut.Lock()
-
 	// dst compacts entries in place, extra only grows when the
 	// MaxPartialLines branch below flushes held partial lines. So in
 	// the common case this call never allocates a new slice.
@@ -159,7 +154,7 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 			// flush any partial lines if we have buffered too many.
 			extra = c.flushPartialLinesIfExceeded(extra)
 			// it's a partial-line buffer it and move on.
-			c.addPartialLine(fingerprint, e)
+			c.partialLines.Append(fingerprint, e)
 			continue
 		}
 
@@ -169,8 +164,6 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 		entries[dst] = c.completeFullLine(fingerprint, e)
 		dst++
 	}
-
-	c.mut.Unlock()
 
 	out := entries[:dst]
 	if len(extra) > 0 {
@@ -186,42 +179,28 @@ func (c *criStage) process(ctx context.Context, entries []Entry) error {
 	return c.next(ctx, out)
 }
 
-func (c *criStage) addPartialLine(fp model.Fingerprint, e Entry) {
-	prev, ok := c.partialLines[fp]
-	if ok {
-		e.Line = prev.Line + e.Line
-	}
-	c.ensureTruncateIfRequired(&e)
-	c.partialLines[fp] = e
-}
-
 func (c *criStage) completeFullLine(fp model.Fingerprint, e Entry) Entry {
-	prev, ok := c.partialLines[fp]
+	prev, ok := c.partialLines.Take(fp)
 	if ok {
 		e.Line = prev.Line + e.Line
-		c.ensureTruncateIfRequired(&e)
-		delete(c.partialLines, fp)
+		truncatePartialLine(&e, c.cfg, c.linesTruncatedMetric)
 	}
 	return e
 }
 
 func (c *criStage) flushPartialLinesIfExceeded(buf []Entry) []Entry {
-	if len(c.partialLines) < c.cfg.MaxPartialLines {
+	before := len(buf)
+	buf = c.partialLines.DrainIfAtLeast(c.cfg.MaxPartialLines, buf)
+
+	flushed := len(buf) - before
+	if flushed == 0 {
 		return buf
 	}
 
-	buf = slices.Grow(buf, len(c.partialLines))
-
 	c.logger.Warn("partial lines upperbound exceeded, merging it to single line", "threshold", c.cfg.MaxPartialLines)
 	if c.partialLinesFlushedMetric != nil {
-		c.partialLinesFlushedMetric.Add(float64(len(c.partialLines)))
+		c.partialLinesFlushedMetric.Add(float64(flushed))
 	}
-
-	for _, v := range c.partialLines {
-		buf = append(buf, v)
-	}
-
-	c.partialLines = make(map[model.Fingerprint]Entry, c.cfg.MaxPartialLines)
 
 	return buf
 }
@@ -232,29 +211,21 @@ func (c *criStage) stop() {
 	ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
 	defer cancel()
 
-	c.mut.Lock()
-	defer c.mut.Unlock()
-
-	if len(c.partialLines) == 0 {
+	out := c.partialLines.DrainAll(nil)
+	if len(out) == 0 {
 		return
 	}
-
-	out := make([]Entry, 0, len(c.partialLines))
-	for _, e := range c.partialLines {
-		out = append(out, e)
-	}
-	c.partialLines = make(map[model.Fingerprint]Entry)
 
 	if err := c.next(ctx, out); err != nil {
 		c.logger.Error("failed to flush held partial lines on stop", "err", err)
 	}
 }
 
-func (c *criStage) ensureTruncateIfRequired(e *Entry) {
-	if c.cfg.MaxPartialLineSizeTruncate && len(e.Line) > int(c.cfg.MaxPartialLineSize) {
-		e.Line = e.Line[:c.cfg.MaxPartialLineSize]
-		if c.linesTruncatedMetric != nil {
-			c.linesTruncatedMetric.Inc()
+func truncatePartialLine(e *Entry, cfg CRIConfig, linesTruncated prometheus.Counter) {
+	if cfg.MaxPartialLineSizeTruncate && len(e.Line) > int(cfg.MaxPartialLineSize) {
+		e.Line = e.Line[:cfg.MaxPartialLineSize]
+		if linesTruncated != nil {
+			linesTruncated.Inc()
 		}
 	}
 }

--- a/internal/component/loki/process/stages/cri_bench_test.go
+++ b/internal/component/loki/process/stages/cri_bench_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/alloy/internal/runtime/logging"
 )
@@ -60,27 +60,23 @@ func generateCRIPartialsOnly(streams int) []criBenchLine {
 	return out
 }
 
-func generateCRIMixedWorkerBatch(worker, run, fullLines, partialLines int) []criBenchLine {
-	out := make([]criBenchLine, 0, fullLines+partialLines)
-	for i := range fullLines {
-		out = append(out, criBenchLine{
-			labels: model.LabelSet{
-				"namespace": "default",
-				"pod":       model.LabelValue(fmt.Sprintf("worker-%d-full-%d", worker, i)),
-				"container": "main",
-			},
-			line: fmt.Sprintf("%s stdout F full line %d of worker %d", criTestTS, i, worker),
-		})
-	}
-	for i := range partialLines {
-		out = append(out, criBenchLine{
-			labels: model.LabelSet{
-				"namespace": "default",
-				"pod":       model.LabelValue(fmt.Sprintf("worker-%d-run-%d-partial-%d", worker, run, i)),
-				"container": "main",
-			},
-			line: fmt.Sprintf("%s stdout P partial line %d of worker %d run %d ", criTestTS, i, worker, run),
-		})
+func generateCRIMergingWorkerBatch(worker, run, streams, partialsPerStream int) []criBenchLine {
+	out := make([]criBenchLine, 0, streams*(partialsPerStream+1))
+	for round := range partialsPerStream + 1 {
+		for st := range streams {
+			flag, content := "P", fmt.Sprintf("partial %d ", round)
+			if round == partialsPerStream {
+				flag, content = "F", "final line"
+			}
+			out = append(out, criBenchLine{
+				labels: model.LabelSet{
+					"namespace": "default",
+					"pod":       model.LabelValue(fmt.Sprintf("worker-%d-run-%d-stream-%d", worker, run, st)),
+					"container": "main",
+				},
+				line: fmt.Sprintf("%s stdout %s %s", criTestTS, flag, content),
+			})
+		}
 	}
 	return out
 }
@@ -91,18 +87,6 @@ func buildCRIBenchEntries(src []criBenchLine, ts time.Time) []Entry {
 		out[i] = newEntry(make(map[string]any, 4), s.labels.Clone(), s.line, ts)
 	}
 	return out
-}
-
-func resetCRIBenchEntries(entries []Entry, src []criBenchLine, ts time.Time) {
-	for i, s := range src {
-		clear(entries[i].Extracted)
-		clear(entries[i].Labels)
-		for k, v := range s.labels {
-			entries[i].Labels[k] = v
-		}
-		entries[i].Line = s.line
-		entries[i].Timestamp = ts
-	}
 }
 
 func newCRIBenchStage(b *testing.B, cfg CRIConfig, next nextFn) *criStage {
@@ -116,13 +100,13 @@ func newCRIBenchStage(b *testing.B, cfg CRIConfig, next nextFn) *criStage {
 
 func BenchmarkCRIStageProcessHappyPath(b *testing.B) {
 	const (
-		streams           = 50
+		streams           = 25
 		partialsPerStream = 9
 	)
 
 	src := generateCRIPartialThenFull(streams, partialsPerStream)
-	ts := time.Now()
-	entries := buildCRIBenchEntries(src, ts)
+	pristine := buildCRIBenchEntries(src, time.Now())
+	work := make([]Entry, len(pristine))
 
 	forwarded := 0
 	c := newCRIBenchStage(b, CRIConfig{MaxPartialLines: streams * 10},
@@ -137,28 +121,26 @@ func BenchmarkCRIStageProcessHappyPath(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		b.StopTimer()
-		resetCRIBenchEntries(entries, src, ts)
-		b.StartTimer()
-
-		if err := c.process(ctx, entries); err != nil {
+		copy(work, pristine)
+		if err := c.process(ctx, work); err != nil {
 			b.Fatal(err)
 		}
 	}
 
-	require.Empty(b, c.partialLines)
+	b.StopTimer()
+	require.Zero(b, c.partialLines.Size())
 	require.Equal(b, streams*b.N, forwarded)
 }
 
 func BenchmarkCRIStageProcessMaxPartialLinesFlush(b *testing.B) {
 	const (
-		streams         = 500
+		streams         = 250
 		maxPartialLines = 25
 	)
 
 	src := generateCRIPartialsOnly(streams)
-	ts := time.Now()
-	entries := buildCRIBenchEntries(src, ts)
+	pristine := buildCRIBenchEntries(src, time.Now())
+	work := make([]Entry, len(pristine))
 
 	flushedEntries := 0
 	c := newCRIBenchStage(b, CRIConfig{MaxPartialLines: maxPartialLines},
@@ -173,45 +155,40 @@ func BenchmarkCRIStageProcessMaxPartialLinesFlush(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		b.StopTimer()
-		resetCRIBenchEntries(entries, src, ts)
-		clear(c.partialLines)
-		b.StartTimer()
-
-		if err := c.process(ctx, entries); err != nil {
+		c.partialLines.Reset()
+		copy(work, pristine)
+		if err := c.process(ctx, work); err != nil {
 			b.Fatal(err)
 		}
 	}
 
+	b.StopTimer()
 	flushesPerIteration := (streams - 1) / maxPartialLines
-	wantEntries := flushesPerIteration * maxPartialLines * b.N
-	require.Equal(b, wantEntries, flushedEntries)
-	require.Len(b, c.partialLines, streams-flushesPerIteration*maxPartialLines)
+	require.Equal(b, flushesPerIteration*maxPartialLines*b.N, flushedEntries)
 }
 
 func BenchmarkCRIStageProcessConcurrent(b *testing.B) {
 	const (
-		numGoroutines   = 10
-		fullLinesPerRun = 20
-		partialsPerRun  = 20
-		maxPartialLines = 4
+		numGoroutines     = 10
+		streamsPerRun     = 5
+		partialsPerStream = 3
+		maxPartialLines   = 4
 	)
 
 	ts := time.Now()
 
-	batches := make([][][]Entry, numGoroutines)
+	pristine := make([][]Entry, numGoroutines)
+	work := make([][]Entry, numGoroutines)
 	for g := range numGoroutines {
-		batches[g] = make([][]Entry, b.N)
-		for i := range b.N {
-			src := generateCRIMixedWorkerBatch(g, i, fullLinesPerRun, partialsPerRun)
-			batches[g][i] = buildCRIBenchEntries(src, ts)
-		}
+		src := generateCRIMergingWorkerBatch(g, 0, streamsPerRun, partialsPerStream)
+		pristine[g] = buildCRIBenchEntries(src, ts)
+		work[g] = make([]Entry, len(pristine[g]))
 	}
 
-	var flushedEntries atomic.Int64
+	var forwarded atomic.Int64
 	c := newCRIBenchStage(b, CRIConfig{MaxPartialLines: maxPartialLines},
 		func(_ context.Context, entries []Entry) error {
-			flushedEntries.Add(int64(len(entries)))
+			forwarded.Add(int64(len(entries)))
 			return nil
 		})
 	ctx := context.Background()
@@ -222,16 +199,68 @@ func BenchmarkCRIStageProcessConcurrent(b *testing.B) {
 	var wg sync.WaitGroup
 	for g := range numGoroutines {
 		wg.Add(1)
-		go func(batches [][]Entry) {
+		go func(pristine, work []Entry) {
 			defer wg.Done()
-			for _, entries := range batches {
-				if err := c.process(ctx, entries); err != nil {
+			for range b.N {
+				copy(work, pristine)
+				if err := c.process(ctx, work); err != nil {
 					b.Error(err)
 				}
 			}
-		}(batches[g])
+		}(pristine[g], work[g])
 	}
 	wg.Wait()
 
-	require.Positive(b, flushedEntries.Load())
+	b.StopTimer()
+	require.Zero(b, c.partialLines.Size())
+	require.Greater(b, forwarded.Load(), int64(numGoroutines*streamsPerRun*b.N))
+}
+
+func BenchmarkCRIStageProcessConcurrentNoFlush(b *testing.B) {
+	const (
+		numGoroutines     = 10
+		streamsPerRun     = 5
+		partialsPerStream = 3
+		maxPartialLines   = 100
+	)
+
+	ts := time.Now()
+
+	pristine := make([][]Entry, numGoroutines)
+	work := make([][]Entry, numGoroutines)
+	for g := range numGoroutines {
+		src := generateCRIMergingWorkerBatch(g, 0, streamsPerRun, partialsPerStream)
+		pristine[g] = buildCRIBenchEntries(src, ts)
+		work[g] = make([]Entry, len(pristine[g]))
+	}
+
+	var forwarded atomic.Int64
+	c := newCRIBenchStage(b, CRIConfig{MaxPartialLines: maxPartialLines},
+		func(_ context.Context, entries []Entry) error {
+			forwarded.Add(int64(len(entries)))
+			return nil
+		})
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	for g := range numGoroutines {
+		wg.Add(1)
+		go func(pristine, work []Entry) {
+			defer wg.Done()
+			for range b.N {
+				copy(work, pristine)
+				if err := c.process(ctx, work); err != nil {
+					b.Error(err)
+				}
+			}
+		}(pristine[g], work[g])
+	}
+	wg.Wait()
+
+	b.StopTimer()
+	require.Zero(b, c.partialLines.Size())
+	require.Equal(b, int64(numGoroutines*streamsPerRun*b.N), forwarded.Load())
 }

--- a/internal/component/loki/process/stages/cri_bench_test.go
+++ b/internal/component/loki/process/stages/cri_bench_test.go
@@ -1,0 +1,237 @@
+package stages
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/runtime/logging"
+)
+
+const criTestTS = "2019-05-07T18:57:50.904275087+00:00"
+
+type criBenchLine struct {
+	labels model.LabelSet
+	line   string
+}
+
+var benchCRISink []Entry
+
+func criBenchLabels(stream int) model.LabelSet {
+	return model.LabelSet{
+		"namespace": "default",
+		"pod":       model.LabelValue(fmt.Sprintf("app-%d", stream)),
+		"container": "main",
+	}
+}
+
+func generateCRIPartialThenFull(streams, partialsPerStream int) []criBenchLine {
+	out := make([]criBenchLine, 0, streams*(partialsPerStream+1))
+	for round := range partialsPerStream + 1 {
+		for s := range streams {
+			flag, content := "P", fmt.Sprintf("partial %d of stream %d ", round, s)
+			if round == partialsPerStream {
+				flag, content = "F", fmt.Sprintf("final line of stream %d", s)
+			}
+			out = append(out, criBenchLine{
+				labels: criBenchLabels(s),
+				line:   fmt.Sprintf("%s stdout %s %s", criTestTS, flag, content),
+			})
+		}
+	}
+	return out
+}
+
+func generateCRIPartialsOnly(streams int) []criBenchLine {
+	out := make([]criBenchLine, 0, streams)
+	for s := range streams {
+		out = append(out, criBenchLine{
+			labels: criBenchLabels(s),
+			line:   fmt.Sprintf("%s stdout P partial line of stream %d ", criTestTS, s),
+		})
+	}
+	return out
+}
+
+func generateCRIMixedWorkerBatch(worker, run, fullLines, partialLines int) []criBenchLine {
+	out := make([]criBenchLine, 0, fullLines+partialLines)
+	for i := range fullLines {
+		out = append(out, criBenchLine{
+			labels: model.LabelSet{
+				"namespace": "default",
+				"pod":       model.LabelValue(fmt.Sprintf("worker-%d-full-%d", worker, i)),
+				"container": "main",
+			},
+			line: fmt.Sprintf("%s stdout F full line %d of worker %d", criTestTS, i, worker),
+		})
+	}
+	for i := range partialLines {
+		out = append(out, criBenchLine{
+			labels: model.LabelSet{
+				"namespace": "default",
+				"pod":       model.LabelValue(fmt.Sprintf("worker-%d-run-%d-partial-%d", worker, run, i)),
+				"container": "main",
+			},
+			line: fmt.Sprintf("%s stdout P partial line %d of worker %d run %d ", criTestTS, i, worker, run),
+		})
+	}
+	return out
+}
+
+func buildCRIBenchEntries(src []criBenchLine, ts time.Time) []Entry {
+	out := make([]Entry, len(src))
+	for i, s := range src {
+		out[i] = newEntry(make(map[string]any, 4), s.labels.Clone(), s.line, ts)
+	}
+	return out
+}
+
+func resetCRIBenchEntries(entries []Entry, src []criBenchLine, ts time.Time) {
+	for i, s := range src {
+		clear(entries[i].Extracted)
+		clear(entries[i].Labels)
+		for k, v := range s.labels {
+			entries[i].Labels[k] = v
+		}
+		entries[i].Line = s.line
+		entries[i].Timestamp = ts
+	}
+}
+
+func newCRIBenchStage(b *testing.B, cfg CRIConfig, next nextFn) *criStage {
+	b.Helper()
+	return newCRIStage(cfg, stageOpts{
+		slogger:    logging.NewSlogNop(),
+		registerer: prometheus.NewRegistry(),
+		next:       next,
+	})
+}
+
+func BenchmarkCRIStageProcessHappyPath(b *testing.B) {
+	const (
+		streams           = 50
+		partialsPerStream = 9
+	)
+
+	src := generateCRIPartialThenFull(streams, partialsPerStream)
+	ts := time.Now()
+	entries := buildCRIBenchEntries(src, ts)
+
+	forwarded := 0
+	c := newCRIBenchStage(b, CRIConfig{MaxPartialLines: streams * 10},
+		func(_ context.Context, entries []Entry) error {
+			benchCRISink = entries
+			forwarded += len(entries)
+			return nil
+		})
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		b.StopTimer()
+		resetCRIBenchEntries(entries, src, ts)
+		b.StartTimer()
+
+		if err := c.process(ctx, entries); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	require.Empty(b, c.partialLines)
+	require.Equal(b, streams*b.N, forwarded)
+}
+
+func BenchmarkCRIStageProcessMaxPartialLinesFlush(b *testing.B) {
+	const (
+		streams         = 500
+		maxPartialLines = 25
+	)
+
+	src := generateCRIPartialsOnly(streams)
+	ts := time.Now()
+	entries := buildCRIBenchEntries(src, ts)
+
+	flushedEntries := 0
+	c := newCRIBenchStage(b, CRIConfig{MaxPartialLines: maxPartialLines},
+		func(_ context.Context, entries []Entry) error {
+			benchCRISink = entries
+			flushedEntries += len(entries)
+			return nil
+		})
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		b.StopTimer()
+		resetCRIBenchEntries(entries, src, ts)
+		clear(c.partialLines)
+		b.StartTimer()
+
+		if err := c.process(ctx, entries); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	flushesPerIteration := (streams - 1) / maxPartialLines
+	wantEntries := flushesPerIteration * maxPartialLines * b.N
+	require.Equal(b, wantEntries, flushedEntries)
+	require.Len(b, c.partialLines, streams-flushesPerIteration*maxPartialLines)
+}
+
+func BenchmarkCRIStageProcessConcurrent(b *testing.B) {
+	const (
+		numGoroutines   = 10
+		fullLinesPerRun = 20
+		partialsPerRun  = 20
+		maxPartialLines = 4
+	)
+
+	ts := time.Now()
+
+	batches := make([][][]Entry, numGoroutines)
+	for g := range numGoroutines {
+		batches[g] = make([][]Entry, b.N)
+		for i := range b.N {
+			src := generateCRIMixedWorkerBatch(g, i, fullLinesPerRun, partialsPerRun)
+			batches[g][i] = buildCRIBenchEntries(src, ts)
+		}
+	}
+
+	var flushedEntries atomic.Int64
+	c := newCRIBenchStage(b, CRIConfig{MaxPartialLines: maxPartialLines},
+		func(_ context.Context, entries []Entry) error {
+			flushedEntries.Add(int64(len(entries)))
+			return nil
+		})
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	for g := range numGoroutines {
+		wg.Add(1)
+		go func(batches [][]Entry) {
+			defer wg.Done()
+			for _, entries := range batches {
+				if err := c.process(ctx, entries); err != nil {
+					b.Error(err)
+				}
+			}
+		}(batches[g])
+	}
+	wg.Wait()
+
+	require.Positive(b, flushedEntries.Load())
+}

--- a/internal/component/loki/process/stages/cri_bench_test.go
+++ b/internal/component/loki/process/stages/cri_bench_test.go
@@ -163,8 +163,7 @@ func BenchmarkCRIStageProcessMaxPartialLinesFlush(b *testing.B) {
 	}
 
 	b.StopTimer()
-	flushesPerIteration := (streams - 1) / maxPartialLines
-	require.Equal(b, flushesPerIteration*maxPartialLines*b.N, flushedEntries)
+	require.Equal(b, streams*b.N, flushedEntries)
 }
 
 func BenchmarkCRIStageProcessConcurrent(b *testing.B) {

--- a/internal/component/loki/process/stages/cri_partial_lines.go
+++ b/internal/component/loki/process/stages/cri_partial_lines.go
@@ -1,7 +1,6 @@
 package stages
 
 import (
-	"slices"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,21 +8,39 @@ import (
 	"go.uber.org/atomic"
 )
 
-type partialLineStore struct {
+const partialLineStripeCount = 16
+
+type partialLineStripe struct {
 	mut   sync.Mutex
 	lines map[model.Fingerprint]Entry
-	size  atomic.Int64
+}
+
+type partialLineStore struct {
+	// size is only exact while every stripe lock is held. Other readers treat it
+	// as a hint. flushing keeps concurrent callers from all queueing on lockAll.
+	size     atomic.Int64
+	flushing atomic.Bool
+
+	stripes [partialLineStripeCount]partialLineStripe
 
 	cfg            CRIConfig
 	linesTruncated prometheus.Counter
 }
 
 func newPartialLineStore(cfg CRIConfig, linesTruncated prometheus.Counter) *partialLineStore {
-	return &partialLineStore{
-		lines:          make(map[model.Fingerprint]Entry, cfg.MaxPartialLines),
+	s := &partialLineStore{
 		cfg:            cfg,
 		linesTruncated: linesTruncated,
 	}
+	perStripe := cfg.MaxPartialLines/partialLineStripeCount + 1
+	for i := range s.stripes {
+		s.stripes[i].lines = make(map[model.Fingerprint]Entry, perStripe)
+	}
+	return s
+}
+
+func (s *partialLineStore) stripe(fp model.Fingerprint) *partialLineStripe {
+	return &s.stripes[uint64(fp)&(partialLineStripeCount-1)]
 }
 
 func (s *partialLineStore) Size() int {
@@ -31,65 +48,91 @@ func (s *partialLineStore) Size() int {
 }
 
 func (s *partialLineStore) Append(fp model.Fingerprint, e Entry) {
-	s.mut.Lock()
-	defer s.mut.Unlock()
+	st := s.stripe(fp)
+	st.mut.Lock()
+	defer st.mut.Unlock()
 
-	if prev, ok := s.lines[fp]; ok {
+	prev, existed := st.lines[fp]
+	if existed {
 		e.Line = prev.Line + e.Line
 	}
 	truncatePartialLine(&e, s.cfg, s.linesTruncated)
-	s.lines[fp] = e
-	s.size.Store(int64(len(s.lines)))
+	st.lines[fp] = e
+	if !existed {
+		s.size.Add(1)
+	}
 }
 
 func (s *partialLineStore) Take(fp model.Fingerprint) (Entry, bool) {
-	s.mut.Lock()
-	defer s.mut.Unlock()
+	st := s.stripe(fp)
+	st.mut.Lock()
+	defer st.mut.Unlock()
 
-	e, ok := s.lines[fp]
+	e, ok := st.lines[fp]
 	if !ok {
 		return Entry{}, false
 	}
-	delete(s.lines, fp)
-	s.size.Store(int64(len(s.lines)))
+	delete(st.lines, fp)
+	s.size.Add(-1)
 	return e, true
 }
 
-func (s *partialLineStore) DrainIfAtLeast(n int, buf []Entry) []Entry {
+func (s *partialLineStore) DrainIfAtLeast(n int) []Entry {
 	if s.Size() < n {
-		return buf
+		return nil
 	}
-
-	s.mut.Lock()
-	defer s.mut.Unlock()
-
-	if len(s.lines) < n {
-		return buf
+	if !s.flushing.CompareAndSwap(false, true) {
+		return nil
 	}
-	return s.drainLocked(buf)
+	defer s.flushing.Store(false)
+
+	s.lockAll()
+	defer s.unlockAll()
+
+	// Another caller may already have drained the store while this one waited.
+	if int(s.size.Load()) < n {
+		return nil
+	}
+	return s.drainLocked()
 }
 
-func (s *partialLineStore) DrainAll(buf []Entry) []Entry {
-	s.mut.Lock()
-	defer s.mut.Unlock()
+func (s *partialLineStore) DrainAll() []Entry {
+	s.lockAll()
+	defer s.unlockAll()
 
-	return s.drainLocked(buf)
+	return s.drainLocked()
 }
 
 func (s *partialLineStore) Reset() {
-	s.mut.Lock()
-	defer s.mut.Unlock()
+	s.lockAll()
+	defer s.unlockAll()
 
-	clear(s.lines)
+	for i := range s.stripes {
+		clear(s.stripes[i].lines)
+	}
 	s.size.Store(0)
 }
 
-func (s *partialLineStore) drainLocked(buf []Entry) []Entry {
-	buf = slices.Grow(buf, len(s.lines))
-	for _, e := range s.lines {
-		buf = append(buf, e)
+func (s *partialLineStore) lockAll() {
+	for i := range s.stripes {
+		s.stripes[i].mut.Lock()
 	}
-	clear(s.lines)
+}
+
+func (s *partialLineStore) unlockAll() {
+	for i := len(s.stripes) - 1; i >= 0; i-- {
+		s.stripes[i].mut.Unlock()
+	}
+}
+
+func (s *partialLineStore) drainLocked() []Entry {
+	buf := make([]Entry, 0, s.size.Load())
+	for i := range s.stripes {
+		for _, e := range s.stripes[i].lines {
+			buf = append(buf, e)
+		}
+		clear(s.stripes[i].lines)
+	}
 	s.size.Store(0)
 	return buf
 }

--- a/internal/component/loki/process/stages/cri_partial_lines.go
+++ b/internal/component/loki/process/stages/cri_partial_lines.go
@@ -1,0 +1,95 @@
+package stages
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"go.uber.org/atomic"
+)
+
+type partialLineStore struct {
+	mut   sync.Mutex
+	lines map[model.Fingerprint]Entry
+	size  atomic.Int64
+
+	cfg            CRIConfig
+	linesTruncated prometheus.Counter
+}
+
+func newPartialLineStore(cfg CRIConfig, linesTruncated prometheus.Counter) *partialLineStore {
+	return &partialLineStore{
+		lines:          make(map[model.Fingerprint]Entry, cfg.MaxPartialLines),
+		cfg:            cfg,
+		linesTruncated: linesTruncated,
+	}
+}
+
+func (s *partialLineStore) Size() int {
+	return int(s.size.Load())
+}
+
+func (s *partialLineStore) Append(fp model.Fingerprint, e Entry) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	if prev, ok := s.lines[fp]; ok {
+		e.Line = prev.Line + e.Line
+	}
+	truncatePartialLine(&e, s.cfg, s.linesTruncated)
+	s.lines[fp] = e
+	s.size.Store(int64(len(s.lines)))
+}
+
+func (s *partialLineStore) Take(fp model.Fingerprint) (Entry, bool) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	e, ok := s.lines[fp]
+	if !ok {
+		return Entry{}, false
+	}
+	delete(s.lines, fp)
+	s.size.Store(int64(len(s.lines)))
+	return e, true
+}
+
+func (s *partialLineStore) DrainIfAtLeast(n int, buf []Entry) []Entry {
+	if s.Size() < n {
+		return buf
+	}
+
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	if len(s.lines) < n {
+		return buf
+	}
+	return s.drainLocked(buf)
+}
+
+func (s *partialLineStore) DrainAll(buf []Entry) []Entry {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	return s.drainLocked(buf)
+}
+
+func (s *partialLineStore) Reset() {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	clear(s.lines)
+	s.size.Store(0)
+}
+
+func (s *partialLineStore) drainLocked(buf []Entry) []Entry {
+	buf = slices.Grow(buf, len(s.lines))
+	for _, e := range s.lines {
+		buf = append(buf, e)
+	}
+	clear(s.lines)
+	s.size.Store(0)
+	return buf
+}

--- a/internal/component/loki/process/stages/cri_partial_lines_bench_test.go
+++ b/internal/component/loki/process/stages/cri_partial_lines_bench_test.go
@@ -1,0 +1,135 @@
+package stages
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+const (
+	plBenchGoroutines     = 10
+	plBenchStreams        = 5
+	plBenchPartialsPerRun = 3
+)
+
+var benchPLDrained atomic.Int64
+
+type plBenchOp struct {
+	fp model.Fingerprint
+	e  Entry
+}
+
+type plBenchWorker struct {
+	partials []plBenchOp
+	fulls    []plBenchOp
+}
+
+func newPLBenchWorker(worker int, ts time.Time) plBenchWorker {
+	labelsFor := func(stream int) model.LabelSet {
+		return model.LabelSet{
+			"namespace": "default",
+			"pod":       model.LabelValue(fmt.Sprintf("worker-%d-stream-%d", worker, stream)),
+			"container": "main",
+			criStream:   "stdout",
+		}
+	}
+
+	opFor := func(stream int, content string) plBenchOp {
+		labels := labelsFor(stream)
+		return plBenchOp{
+			fp: labels.Fingerprint(),
+			e:  newEntry(make(map[string]any, 4), labels, content, ts),
+		}
+	}
+
+	w := plBenchWorker{
+		partials: make([]plBenchOp, 0, plBenchStreams*plBenchPartialsPerRun),
+		fulls:    make([]plBenchOp, 0, plBenchStreams),
+	}
+	for round := range plBenchPartialsPerRun {
+		for stream := range plBenchStreams {
+			w.partials = append(w.partials, opFor(stream, fmt.Sprintf("partial %d ", round)))
+		}
+	}
+	for stream := range plBenchStreams {
+		w.fulls = append(w.fulls, opFor(stream, "final line"))
+	}
+	return w
+}
+
+func newPLBenchWorkers(n int, ts time.Time) []plBenchWorker {
+	out := make([]plBenchWorker, n)
+	for i := range out {
+		out[i] = newPLBenchWorker(i, ts)
+	}
+	return out
+}
+
+func newPLBenchStore(maxPartialLines int) *partialLineStore {
+	return newPartialLineStore(CRIConfig{MaxPartialLines: maxPartialLines}, nil)
+}
+
+func runPLBenchWorker(s *partialLineStore, w plBenchWorker, maxPartialLines int) {
+	var buf []Entry
+	for _, op := range w.partials {
+		buf = s.DrainIfAtLeast(maxPartialLines, buf)
+		s.Append(op.fp, op.e)
+	}
+	for _, op := range w.fulls {
+		s.Take(op.fp)
+	}
+	benchPLDrained.Add(int64(len(buf)))
+}
+
+func benchmarkPLStoreConcurrent(b *testing.B, maxPartialLines int) {
+	workers := newPLBenchWorkers(plBenchGoroutines, time.Now())
+	s := newPLBenchStore(maxPartialLines)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	for _, w := range workers {
+		wg.Add(1)
+		go func(w plBenchWorker) {
+			defer wg.Done()
+			for range b.N {
+				runPLBenchWorker(s, w, maxPartialLines)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	b.StopTimer()
+	require.Zero(b, s.Size())
+}
+
+func BenchmarkPartialLineStoreConcurrent(b *testing.B) {
+	benchmarkPLStoreConcurrent(b, 4)
+}
+
+func BenchmarkPartialLineStoreConcurrentNoFlush(b *testing.B) {
+	benchmarkPLStoreConcurrent(b, 100)
+}
+
+func BenchmarkPartialLineStoreSerial(b *testing.B) {
+	const maxPartialLines = 100
+
+	w := newPLBenchWorker(0, time.Now())
+	s := newPLBenchStore(maxPartialLines)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		runPLBenchWorker(s, w, maxPartialLines)
+	}
+
+	b.StopTimer()
+	require.Zero(b, s.Size())
+}

--- a/internal/component/loki/process/stages/cri_partial_lines_bench_test.go
+++ b/internal/component/loki/process/stages/cri_partial_lines_bench_test.go
@@ -75,15 +75,13 @@ func newPLBenchStore(maxPartialLines int) *partialLineStore {
 }
 
 func runPLBenchWorker(s *partialLineStore, w plBenchWorker, maxPartialLines int) {
-	var buf []Entry
 	for _, op := range w.partials {
-		buf = s.DrainIfAtLeast(maxPartialLines, buf)
 		s.Append(op.fp, op.e)
 	}
 	for _, op := range w.fulls {
 		s.Take(op.fp)
 	}
-	benchPLDrained.Add(int64(len(buf)))
+	benchPLDrained.Add(int64(len(s.DrainIfAtLeast(maxPartialLines))))
 }
 
 func benchmarkPLStoreConcurrent(b *testing.B, maxPartialLines int) {

--- a/internal/component/loki/process/stages/cri_partial_lines_test.go
+++ b/internal/component/loki/process/stages/cri_partial_lines_test.go
@@ -1,0 +1,154 @@
+package stages
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func partialLineStoreCount(s *partialLineStore) int {
+	s.lockAll()
+	defer s.unlockAll()
+
+	n := 0
+	for i := range s.stripes {
+		n += len(s.stripes[i].lines)
+	}
+	return n
+}
+
+func partialLineTestEntry(fp int, line string) (model.Fingerprint, Entry) {
+	labels := model.LabelSet{
+		"pod":     model.LabelValue(fmt.Sprintf("pod-%d", fp)),
+		criStream: "stdout",
+	}
+	return labels.Fingerprint(), newEntry(make(map[string]any, 4), labels, line, time.Now())
+}
+
+func TestPartialLineStore_SizeTracksContents(t *testing.T) {
+	s := newPartialLineStore(CRIConfig{MaxPartialLines: 100}, nil)
+
+	fpA, entryA := partialLineTestEntry(1, "a ")
+	fpB, entryB := partialLineTestEntry(2, "b ")
+
+	require.Zero(t, s.Size())
+
+	s.Append(fpA, entryA)
+	require.Equal(t, 1, s.Size())
+
+	s.Append(fpA, entryA)
+	require.Equal(t, 1, s.Size(), "merging into an existing stream must not grow the size")
+
+	s.Append(fpB, entryB)
+	require.Equal(t, 2, s.Size())
+
+	got, ok := s.Take(fpA)
+	require.True(t, ok)
+	require.Equal(t, "a a ", got.Line, "Take must return the merged line")
+	require.Equal(t, 1, s.Size())
+
+	_, ok = s.Take(fpA)
+	require.False(t, ok, "a second Take of the same stream must find nothing")
+	require.Equal(t, 1, s.Size())
+
+	drained := s.DrainAll()
+	require.Len(t, drained, 1)
+	require.Zero(t, s.Size())
+	require.Zero(t, partialLineStoreCount(s))
+}
+
+func TestPartialLineStore_SizeMatchesContentsUnderConcurrency(t *testing.T) {
+	const (
+		goroutines = 8
+		iterations = 3000
+		streams    = 6
+	)
+
+	s := newPartialLineStore(CRIConfig{MaxPartialLines: 4}, nil)
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+
+			ops := make([]struct {
+				fp model.Fingerprint
+				e  Entry
+			}, streams)
+			for i := range ops {
+				ops[i].fp, ops[i].e = partialLineTestEntry(g*streams+i, fmt.Sprintf("worker %d ", g))
+			}
+
+			for range iterations {
+				for _, op := range ops {
+					s.Append(op.fp, op.e)
+				}
+				for _, op := range ops {
+					s.Take(op.fp)
+				}
+				s.DrainIfAtLeast(4)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	require.Equal(t, partialLineStoreCount(s), s.Size(),
+		"size must still match the entries actually held after concurrent appends, takes and drains")
+}
+
+func TestPartialLineStore_DrainEmitsEachEntryOnce(t *testing.T) {
+	const (
+		goroutines = 8
+		streams    = 8
+	)
+
+	s := newPartialLineStore(CRIConfig{MaxPartialLines: 4}, nil)
+
+	var (
+		mut     sync.Mutex
+		emitted []Entry
+	)
+	collect := func(entries []Entry) {
+		mut.Lock()
+		defer mut.Unlock()
+		emitted = append(emitted, entries...)
+	}
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+
+			for i := range streams {
+				fp, e := partialLineTestEntry(g*streams+i, fmt.Sprintf("w%d-s%d ", g, i))
+				collect(s.DrainIfAtLeast(4))
+				s.Append(fp, e)
+			}
+			for i := range streams {
+				fp, _ := partialLineTestEntry(g*streams+i, "")
+				if taken, ok := s.Take(fp); ok {
+					collect([]Entry{taken})
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	collect(s.DrainAll())
+
+	seen := make(map[string]int, len(emitted))
+	for _, e := range emitted {
+		seen[e.Line]++
+	}
+	for line, count := range seen {
+		require.Equal(t, 1, count, "line %q was emitted %d times, every entry must leave the store exactly once", line, count)
+	}
+	require.Len(t, emitted, goroutines*streams, "every appended stream must be emitted")
+	require.Zero(t, s.Size())
+}

--- a/internal/component/loki/process/stages/cri_test.go
+++ b/internal/component/loki/process/stages/cri_test.go
@@ -1,13 +1,18 @@
 package stages
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/grafana/alloy/internal/runtime/logging"
 	"github.com/grafana/loki/pkg/push"
 )
 
@@ -271,6 +276,41 @@ loki_process_cri_partial_lines_flushed_total %d
 			runPipelineTest(t, []StageConfig{{CRIConfig: &tt.cfg}}, tt.entries, tt.expected, expectedMetrics)
 		})
 	}
+}
+
+// TestCRIStageFlushOnShutdown verifies that buffered entries are flushed when stop is called.
+// This is only implemented for the new pipeline.
+func TestCRIStageFlushOnShutdown(t *testing.T) {
+	var (
+		partialTimeStr = "2019-05-07T18:57:50.904275087+00:00"
+		partialTime, _ = time.Parse(time.RFC3339Nano, partialTimeStr)
+	)
+
+	var collected []Entry
+	next := func(_ context.Context, entries []Entry) error {
+		collected = append(collected, entries...)
+		return nil
+	}
+
+	p, err := NewPipeline2(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, []StageConfig{{CRIConfig: &defaultCRIConfig}}, next)
+	require.NoError(t, err)
+
+	require.NoError(t, p.process(context.Background(), []Entry{
+		newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, partialTimeStr+" stdout P partial line ", time.Now()),
+	}))
+	require.Empty(t, collected)
+
+	p.Stop()
+
+	expected := []Entry{
+		newEntry(
+			map[string]any{"foo": "bar", "flags": "P", "stream": "stdout", "content": "partial line ", "time": partialTimeStr},
+			model.LabelSet{"foo": "bar", "stream": "stdout"},
+			"partial line ",
+			partialTime,
+		),
+	}
+	assertEntriesUnordered(t, expected, collected)
 }
 
 func BenchmarkCRIStage(b *testing.B) {

--- a/internal/component/loki/process/stages/cri_test.go
+++ b/internal/component/loki/process/stages/cri_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,6 @@ import (
 	"github.com/grafana/alloy/internal/component/common/loki"
 	"github.com/grafana/alloy/internal/featuregate"
 	"github.com/grafana/alloy/internal/runtime/logging"
-	"github.com/grafana/loki/pkg/push"
 )
 
 func TestCRIStage(t *testing.T) {
@@ -292,7 +292,7 @@ func TestCRIStageFlushOnShutdown(t *testing.T) {
 		return nil
 	}
 
-	p, err := NewPipeline2(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, []StageConfig{{CRIConfig: &defaultCRIConfig}}, next)
+	p, err := newPipeline(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, []StageConfig{{CRIConfig: &defaultCRIConfig}}, next)
 	require.NoError(t, err)
 
 	require.NoError(t, p.process(context.Background(), []Entry{
@@ -300,7 +300,7 @@ func TestCRIStageFlushOnShutdown(t *testing.T) {
 	}))
 	require.Empty(t, collected)
 
-	p.Stop()
+	p.stop()
 
 	expected := []Entry{
 		newEntry(

--- a/internal/component/loki/process/stages/cri_test.go
+++ b/internal/component/loki/process/stages/cri_test.go
@@ -2,18 +2,13 @@ package stages
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alloy/internal/featuregate"
-	"github.com/grafana/alloy/internal/runtime/logging"
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/loki/pkg/push"
 )
 
 func TestCRIStage(t *testing.T) {
@@ -273,176 +268,11 @@ loki_process_cri_partial_lines_flushed_total %d
 	}
 }
 
-func TestCRI_tags(t *testing.T) {
-	type testEntry struct {
-		labels model.LabelSet
-		line   string
-	}
-
-	type testCase struct {
-		name                        string
-		expected                    []string
-		maxPartialLines             int
-		maxPartialLineSize          uint64
-		maxPartialLineSizeTruncate  bool
-		entries                     []testEntry
-		expectedPartialLinesFlushed int // expected value of the partial lines flushed metric
-		expectedLinesTruncated      int // expected value of the lines truncated metric
-	}
-
-	cases := []testCase{
-		{
-			name:            "tag F",
-			maxPartialLines: 100,
-			entries: []testEntry{
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout F some full line", labels: model.LabelSet{"foo": "bar"}},
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F log", labels: model.LabelSet{"foo": "bar"}},
-			},
-			expected:                    []string{"some full line", "log"},
-			expectedPartialLinesFlushed: 0,
-			expectedLinesTruncated:      0,
-		},
-		{
-			name:            "tag P multi-stream",
-			maxPartialLines: 100,
-			entries: []testEntry{
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1 ", labels: model.LabelSet{"foo": "bar"}},
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2 ", labels: model.LabelSet{"foo": "bar2"}},
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F log finished", labels: model.LabelSet{"foo": "bar"}},
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F another full log", labels: model.LabelSet{"foo": "bar2"}},
-			},
-			expected: []string{
-				"partial line 1 log finished",     // belongs to stream `{foo="bar"}`
-				"partial line 2 another full log", // belongs to stream `{foo="bar2"}
-			},
-			expectedPartialLinesFlushed: 0,
-			expectedLinesTruncated:      0,
-		},
-		{
-			name: "tag P multi-stream with maxPartialLines exceeded",
-			entries: []testEntry{
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1 ", labels: model.LabelSet{"label1": "val1", "label2": "val2"}},
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2 ", labels: model.LabelSet{"label1": "val1"}},
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 3 ", labels: model.LabelSet{"label1": "val1", "label2": "val2"}},
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 4 ", labels: model.LabelSet{"label1": "val3"}},
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 5 ", labels: model.LabelSet{"label1": "val4"}}, // exceeded maxPartialLines as already 3 streams in flight.
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F log finished", labels: model.LabelSet{"label1": "val1", "label2": "val2"}},
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F another full log", labels: model.LabelSet{"label1": "val3"}},
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F yet an another full log", labels: model.LabelSet{"label1": "val4"}},
-			},
-			maxPartialLines: 3,
-			expected: []string{
-				"partial line 1 partial line 3 ",
-				"partial line 2 ",
-				"partial line 4 ",
-				"log finished",
-				"another full log",
-				"partial line 5 yet an another full log",
-			},
-			expectedPartialLinesFlushed: 3, // 3 partial lines were flushed when limit was exceeded
-			expectedLinesTruncated:      0,
-		},
-		{
-			name: "tag P single stream",
-			entries: []testEntry{
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1 ", labels: model.LabelSet{"foo": "bar"}},
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2 ", labels: model.LabelSet{"foo": "bar"}},
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 3 ", labels: model.LabelSet{"foo": "bar"}},
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 4 ", labels: model.LabelSet{"foo": "bar"}}, // this exceeds the `MaxPartialLinesSize` of 3
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F log finished", labels: model.LabelSet{"foo": "bar"}},
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F another full log", labels: model.LabelSet{"foo": "bar"}},
-			},
-			maxPartialLines: 3,
-			expected: []string{
-				"partial line 1 partial line 2 partial line 3 partial line 4 log finished",
-				"another full log",
-			},
-			expectedPartialLinesFlushed: 0, // single stream, no flush due to limit (partial lines merge within same stream)
-			expectedLinesTruncated:      0,
-		},
-		{
-			name: "tag P multi-stream with truncation",
-			entries: []testEntry{
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1 ", labels: model.LabelSet{"foo": "bar"}},
-				{line: "2019-05-07T18:57:50.904275087+00:00 stdout P partial", labels: model.LabelSet{"foo": "bar2"}},
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F log finished", labels: model.LabelSet{"foo": "bar"}},
-				{line: "2019-05-07T18:57:55.904275087+00:00 stdout F full", labels: model.LabelSet{"foo": "bar2"}},
-			},
-			maxPartialLines:            100,
-			maxPartialLineSizeTruncate: true,
-			maxPartialLineSize:         11,
-			expected: []string{
-				"partial lin",
-				"partialfull",
-			},
-			expectedPartialLinesFlushed: 0,
-			expectedLinesTruncated:      2, // 2 lines were truncated due to max_partial_line_size
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			registry := prometheus.NewRegistry()
-			cfg := CRIConfig{
-				MaxPartialLines:            tt.maxPartialLines,
-				MaxPartialLineSize:         tt.maxPartialLineSize,
-				MaxPartialLineSizeTruncate: tt.maxPartialLineSizeTruncate,
-			}
-			p := newCRIStage(logging.NewSlogNop(), cfg, registry, featuregate.StabilityGenerallyAvailable, nil)
-			got := make([]string, 0)
-
-			for _, entry := range tt.entries {
-				out := processEntries(p, newEntry(nil, entry.labels, entry.line, time.Now()))
-				if len(out) > 0 {
-					for _, en := range out {
-						got = append(got, en.Line)
-					}
-				}
-			}
-
-			expectedMap := make(map[string]bool)
-			for _, v := range tt.expected {
-				expectedMap[v] = true
-			}
-
-			gotMap := make(map[string]bool)
-			for _, v := range got {
-				gotMap[v] = true
-			}
-
-			assert.Equal(t, expectedMap, gotMap)
-
-			// Verify the metrics
-			expectedMetrics := fmt.Sprintf(`
-# HELP loki_process_cri_lines_truncated_total A count of lines that were truncated due to the max_partial_line_size limit
-# TYPE loki_process_cri_lines_truncated_total counter
-loki_process_cri_lines_truncated_total %d
-# HELP loki_process_cri_partial_lines_flushed_total A count of partial lines that were flushed prematurely due to the max_partial_lines limit being exceeded
-# TYPE loki_process_cri_partial_lines_flushed_total counter
-loki_process_cri_partial_lines_flushed_total %d
-`, tt.expectedLinesTruncated, tt.expectedPartialLinesFlushed)
-			require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics)))
-		})
-	}
-}
-
-var (
-	benchCRITime  = time.Now()
-	benchCRIEntry Entry
-	benchCRILine  = "2019-01-01T01:00:00.000000001Z stderr F my cool message yay\n test"
-)
-
-func BenchmarkCRI(b *testing.B) {
-	p := newCRIStage(logging.NewSlogNop(), defaultCRIConfig, prometheus.DefaultRegisterer, featuregate.StabilityGenerallyAvailable, nil)
-	e := newEntry(nil, model.LabelSet{}, benchCRILine, benchCRITime)
-	in := make(chan Entry)
-	out := p.Run(in)
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for b.Loop() {
-		in <- e
-		benchCRIEntry = <-out
-	}
+func BenchmarkCRIStage(b *testing.B) {
+	batch := loki.NewBatch()
+	batch.Add(loki.NewStream(model.LabelSet{}, push.Entry{
+		Timestamp: time.Now(),
+		Line:      "2019-01-01T01:00:00.000000001Z stderr F my cool message yay\n test",
+	}))
+	runPipelineBenchmark(b, []StageConfig{{CRIConfig: &defaultCRIConfig}}, batch)
 }

--- a/internal/component/loki/process/stages/cri_test.go
+++ b/internal/component/loki/process/stages/cri_test.go
@@ -16,74 +16,259 @@ import (
 	"github.com/grafana/alloy/internal/runtime/logging"
 )
 
-var (
-	criTestTimeStr = "2019-01-01T01:00:00.000000001Z"
-	criTestTime, _ = time.Parse(time.RFC3339Nano, criTestTimeStr)
-	criTestTime2   = time.Now()
-)
+func TestCRIStage(t *testing.T) {
+	var (
+		criTestTimeStr = "2019-01-01T01:00:00.000000001Z"
+		criTestTime, _ = time.Parse(time.RFC3339Nano, criTestTimeStr)
+		criTestTime2   = time.Now()
 
-func TestCRI(t *testing.T) {
-	tests := map[string]struct {
-		entry          string
-		expectedLine   string
-		ts             time.Time
-		expectedTs     time.Time
-		expectedLabels model.LabelSet
-	}{
-		"happy path": {
-			criTestTimeStr + " stderr F message",
-			"message",
-			time.Now(),
-			criTestTime,
-			model.LabelSet{
-				"stream": "stderr",
+		tagFTime1Str = "2019-05-07T18:57:50.904275087+00:00"
+		tagFTime1, _ = time.Parse(time.RFC3339Nano, tagFTime1Str)
+		tagFTime2Str = "2019-05-07T18:57:55.904275087+00:00"
+		tagFTime2, _ = time.Parse(time.RFC3339Nano, tagFTime2Str)
+	)
+
+	type testCase struct {
+		name                        string
+		entries                     []Entry
+		expected                    []Entry
+		cfg                         CRIConfig
+		expectedPartialLinesFlushed int
+		expectedLinesTruncated      int
+	}
+
+	tests := []testCase{
+		{
+			name: "full line",
+			cfg:  defaultCRIConfig,
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{}, criTestTimeStr+" stderr F message", time.Now()),
+			},
+			expected: []Entry{
+				newEntry(
+					map[string]any{"flags": "F", "stream": "stderr", "content": "message", "time": criTestTimeStr},
+					model.LabelSet{"stream": "stderr"},
+					"message",
+					criTestTime,
+				),
 			},
 		},
-		"multi line pass": {
-			criTestTimeStr + " stderr F message\nmessage2",
-			"message\nmessage2",
-			time.Now(),
-			criTestTime,
-			model.LabelSet{
-				"stream": "stderr",
+		{
+			name: "full line multiline",
+			cfg:  defaultCRIConfig,
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{}, criTestTimeStr+" stderr F message\nmessage2", time.Now()),
+			},
+			expected: []Entry{
+				newEntry(
+					map[string]any{"flags": "F", "stream": "stderr", "content": "message\nmessage2", "time": criTestTimeStr},
+					model.LabelSet{"stream": "stderr"},
+					"message\nmessage2",
+					criTestTime,
+				),
 			},
 		},
-		"invalid timestamp": {
-			"3242 stderr F message",
-			"message",
-			criTestTime2,
-			criTestTime2,
-			model.LabelSet{
-				"stream": "stderr",
+		{
+			name: "with invalid timestamp",
+			cfg:  defaultCRIConfig,
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{}, "3242 stderr F message", criTestTime2),
+			},
+			expected: []Entry{
+				newEntry(
+					map[string]any{"flags": "F", "stream": "stderr", "content": "message", "time": "3242"},
+					model.LabelSet{"stream": "stderr"},
+					"message",
+					criTestTime2,
+				),
 			},
 		},
-		"invalid line": {
-			"i'm invalid!!!",
-			"i'm invalid!!!",
-			criTestTime2,
-			criTestTime2,
-			model.LabelSet{},
+		{
+			name: "with invalid line",
+			cfg:  defaultCRIConfig,
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{}, "i'm invalid!!!", criTestTime2),
+			},
+			expected: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{}, "i'm invalid!!!", criTestTime2),
+			},
 		},
-		"gracefully handle without flag": {
-			entry:          "something stderr looks like it could be cri",
-			expectedLine:   "looks like it could be cri",
-			ts:             criTestTime2,
-			expectedTs:     criTestTime2,
-			expectedLabels: model.LabelSet{"stream": "stderr"},
+		{
+			name: "with invalid line",
+			cfg:  defaultCRIConfig,
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{}, "i'm invalid!!!", criTestTime2),
+			},
+			expected: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{}, "i'm invalid!!!", criTestTime2),
+			},
+		},
+		{
+			name: "tag F",
+			cfg:  defaultCRIConfig,
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime1Str+" stdout F some full line", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime2Str+" stdout F log", time.Now()),
+			},
+			expected: []Entry{
+				newEntry(
+					map[string]any{"foo": "bar", "flags": "F", "stream": "stdout", "content": "some full line", "time": tagFTime1Str},
+					model.LabelSet{"foo": "bar", "stream": "stdout"},
+					"some full line",
+					tagFTime1,
+				),
+				newEntry(
+					map[string]any{"foo": "bar", "flags": "F", "stream": "stdout", "content": "log", "time": tagFTime2Str},
+					model.LabelSet{"foo": "bar", "stream": "stdout"},
+					"log",
+					tagFTime2,
+				),
+			},
+		},
+		{
+			name: "tag P multi-stream",
+			cfg:  defaultCRIConfig,
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime1Str+" stdout P partial line 1 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar2"}, tagFTime1Str+" stdout P partial line 2 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime2Str+" stdout F log finished", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar2"}, tagFTime2Str+" stdout F another full log", time.Now()),
+			},
+			expected: []Entry{
+				newEntry(
+					map[string]any{"foo": "bar", "flags": "F", "stream": "stdout", "content": "log finished", "time": tagFTime2Str},
+					model.LabelSet{"foo": "bar", "stream": "stdout"},
+					"partial line 1 log finished",
+					tagFTime2,
+				),
+				newEntry(
+					map[string]any{"foo": "bar2", "flags": "F", "stream": "stdout", "content": "another full log", "time": tagFTime2Str},
+					model.LabelSet{"foo": "bar2", "stream": "stdout"},
+					"partial line 2 another full log",
+					tagFTime2,
+				),
+			},
+		},
+		{
+			name: "tag P single stream",
+			cfg:  CRIConfig{MaxPartialLines: 3},
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime1Str+" stdout P partial line 1 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime1Str+" stdout P partial line 2 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime1Str+" stdout P partial line 3 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime1Str+" stdout P partial line 4 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime2Str+" stdout F log finished", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime2Str+" stdout F another full log", time.Now()),
+			},
+			expected: []Entry{
+				newEntry(
+					map[string]any{"foo": "bar", "flags": "F", "stream": "stdout", "content": "log finished", "time": tagFTime2Str},
+					model.LabelSet{"foo": "bar", "stream": "stdout"},
+					"partial line 1 partial line 2 partial line 3 partial line 4 log finished",
+					tagFTime2,
+				),
+				newEntry(
+					map[string]any{"foo": "bar", "flags": "F", "stream": "stdout", "content": "another full log", "time": tagFTime2Str},
+					model.LabelSet{"foo": "bar", "stream": "stdout"},
+					"another full log",
+					tagFTime2,
+				),
+			},
+		},
+		{
+			name: "tag P multi-stream with truncation",
+			cfg:  CRIConfig{MaxPartialLines: 100, MaxPartialLineSizeTruncate: true, MaxPartialLineSize: 11},
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime1Str+" stdout P partial line 1 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar2"}, tagFTime1Str+" stdout P partial", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar"}, tagFTime2Str+" stdout F log finished", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"foo": "bar2"}, tagFTime2Str+" stdout F full", time.Now()),
+			},
+			expected: []Entry{
+				newEntry(
+					map[string]any{"foo": "bar", "flags": "F", "stream": "stdout", "content": "log finished", "time": tagFTime2Str},
+					model.LabelSet{"foo": "bar", "stream": "stdout"},
+					"partial lin",
+					tagFTime2,
+				),
+				newEntry(
+					map[string]any{"foo": "bar2", "flags": "F", "stream": "stdout", "content": "full", "time": tagFTime2Str},
+					model.LabelSet{"foo": "bar2", "stream": "stdout"},
+					"partialfull",
+					tagFTime2,
+				),
+			},
+			expectedLinesTruncated: 2,
+		},
+		{
+			name: "tag P multi-stream with maxPartialLines exceeded",
+			cfg:  CRIConfig{MaxPartialLines: 3},
+			entries: []Entry{
+				newEntry(map[string]any{}, model.LabelSet{"label1": "val1", "label2": "val2"}, tagFTime1Str+" stdout P partial line 1 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"label1": "val1"}, tagFTime1Str+" stdout P partial line 2 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"label1": "val1", "label2": "val2"}, tagFTime1Str+" stdout P partial line 3 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"label1": "val3"}, tagFTime1Str+" stdout P partial line 4 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"label1": "val4"}, tagFTime1Str+" stdout P partial line 5 ", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"label1": "val1", "label2": "val2"}, tagFTime2Str+" stdout F log finished", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"label1": "val3"}, tagFTime2Str+" stdout F another full log", time.Now()),
+				newEntry(map[string]any{}, model.LabelSet{"label1": "val4"}, tagFTime2Str+" stdout F yet an another full log", time.Now()),
+			},
+			expected: []Entry{
+				newEntry(
+					map[string]any{"label1": "val1", "label2": "val2", "flags": "P", "stream": "stdout", "content": "partial line 3 ", "time": tagFTime1Str},
+					model.LabelSet{"label1": "val1", "label2": "val2", "stream": "stdout"},
+					"partial line 1 partial line 3 ",
+					tagFTime1,
+				),
+				newEntry(
+					map[string]any{"label1": "val1", "flags": "P", "stream": "stdout", "content": "partial line 2 ", "time": tagFTime1Str},
+					model.LabelSet{"label1": "val1", "stream": "stdout"},
+					"partial line 2 ",
+					tagFTime1,
+				),
+				newEntry(
+					map[string]any{"label1": "val3", "flags": "P", "stream": "stdout", "content": "partial line 4 ", "time": tagFTime1Str},
+					model.LabelSet{"label1": "val3", "stream": "stdout"},
+					"partial line 4 ",
+					tagFTime1,
+				),
+				newEntry(
+					map[string]any{"label1": "val1", "label2": "val2", "flags": "F", "stream": "stdout", "content": "log finished", "time": tagFTime2Str},
+					model.LabelSet{"label1": "val1", "label2": "val2", "stream": "stdout"},
+					"log finished",
+					tagFTime2,
+				),
+				newEntry(
+					map[string]any{"label1": "val3", "flags": "F", "stream": "stdout", "content": "another full log", "time": tagFTime2Str},
+					model.LabelSet{"label1": "val3", "stream": "stdout"},
+					"another full log",
+					tagFTime2,
+				),
+				newEntry(
+					map[string]any{"label1": "val4", "flags": "F", "stream": "stdout", "content": "yet an another full log", "time": tagFTime2Str},
+					model.LabelSet{"label1": "val4", "stream": "stdout"},
+					"partial line 5 yet an another full log",
+					tagFTime2,
+				),
+			},
+			expectedPartialLinesFlushed: 3,
 		},
 	}
 
-	for tName, tt := range tests {
-		t.Run(tName, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			p, err := NewCRI(logging.NewSlogNop(), DefaultCRIConfig, prometheus.DefaultRegisterer, featuregate.StabilityGenerallyAvailable)
-			require.NoError(t, err)
+			expectedMetrics := fmt.Sprintf(`
+# HELP loki_process_cri_lines_truncated_total A count of lines that were truncated due to the max_partial_line_size limit
+# TYPE loki_process_cri_lines_truncated_total counter
+loki_process_cri_lines_truncated_total %d
+# HELP loki_process_cri_partial_lines_flushed_total A count of partial lines that were flushed prematurely due to the max_partial_lines limit being exceeded
+# TYPE loki_process_cri_partial_lines_flushed_total counter
+loki_process_cri_partial_lines_flushed_total %d
+`, tt.expectedLinesTruncated, tt.expectedPartialLinesFlushed)
 
-			out := processEntries(p, newEntry(nil, model.LabelSet{}, tt.entry, tt.ts))[0]
-			assert.EqualValues(t, tt.expectedLabels, out.Labels)
-			assert.Equal(t, tt.expectedLine, out.Line, "did not receive expected log entry")
-			assert.Equal(t, tt.expectedTs.Unix(), out.Timestamp.Unix())
+			runPipelineTest(t, []StageConfig{{CRIConfig: &tt.cfg}}, tt.entries, tt.expected, expectedMetrics)
 		})
 	}
 }
@@ -203,9 +388,7 @@ func TestCRI_tags(t *testing.T) {
 				MaxPartialLineSize:         tt.maxPartialLineSize,
 				MaxPartialLineSizeTruncate: tt.maxPartialLineSizeTruncate,
 			}
-			p, err := NewCRI(logging.NewSlogNop(), cfg, registry, featuregate.StabilityGenerallyAvailable)
-			require.NoError(t, err)
-
+			p := newCRIStage(logging.NewSlogNop(), cfg, registry, featuregate.StabilityGenerallyAvailable, nil)
 			got := make([]string, 0)
 
 			for _, entry := range tt.entries {
@@ -250,7 +433,7 @@ var (
 )
 
 func BenchmarkCRI(b *testing.B) {
-	p, _ := NewCRI(logging.NewSlogNop(), DefaultCRIConfig, prometheus.DefaultRegisterer, featuregate.StabilityGenerallyAvailable)
+	p := newCRIStage(logging.NewSlogNop(), defaultCRIConfig, prometheus.DefaultRegisterer, featuregate.StabilityGenerallyAvailable, nil)
 	e := newEntry(nil, model.LabelSet{}, benchCRILine, benchCRITime)
 	in := make(chan Entry)
 	out := p.Run(in)

--- a/internal/component/loki/process/stages/cri_test.go
+++ b/internal/component/loki/process/stages/cri_test.go
@@ -304,7 +304,7 @@ func TestCRIStageFlushOnShutdown(t *testing.T) {
 
 	expected := []Entry{
 		newEntry(
-			map[string]any{"foo": "bar", "flags": "P", "stream": "stdout", "content": "partial line ", "time": partialTimeStr},
+			map[string]any{"flags": "P", "stream": "stdout", "content": "partial line ", "time": partialTimeStr},
 			model.LabelSet{"foo": "bar", "stream": "stdout"},
 			"partial line ",
 			partialTime,

--- a/internal/component/loki/process/stages/cri_test.go
+++ b/internal/component/loki/process/stages/cri_test.go
@@ -35,6 +35,11 @@ func TestCRIStage(t *testing.T) {
 		cfg                         CRIConfig
 		expectedPartialLinesFlushed int
 		expectedLinesTruncated      int
+
+		// Set these when the new pipeline is expected to differ, because it
+		// checks max_partial_lines once per batch rather than per entry.
+		expectedNew                    []Entry
+		expectedNewPartialLinesFlushed int
 	}
 
 	tests := []testCase{
@@ -257,6 +262,37 @@ func TestCRIStage(t *testing.T) {
 				),
 			},
 			expectedPartialLinesFlushed: 3,
+			// process appends every partial first and only then checks the
+			// limit, so the three streams that get a full line in this batch
+			// merge normally and nothing is flushed early. The one stream left
+			// buffered is emitted by stop.
+			expectedNew: []Entry{
+				newEntry(
+					map[string]any{"label1": "val1", "label2": "val2", "flags": "F", "stream": "stdout", "content": "log finished", "time": tagFTime2Str},
+					model.LabelSet{"label1": "val1", "label2": "val2", "stream": "stdout"},
+					"partial line 1 partial line 3 log finished",
+					tagFTime2,
+				),
+				newEntry(
+					map[string]any{"label1": "val3", "flags": "F", "stream": "stdout", "content": "another full log", "time": tagFTime2Str},
+					model.LabelSet{"label1": "val3", "stream": "stdout"},
+					"partial line 4 another full log",
+					tagFTime2,
+				),
+				newEntry(
+					map[string]any{"label1": "val4", "flags": "F", "stream": "stdout", "content": "yet an another full log", "time": tagFTime2Str},
+					model.LabelSet{"label1": "val4", "stream": "stdout"},
+					"partial line 5 yet an another full log",
+					tagFTime2,
+				),
+				newEntry(
+					map[string]any{"label1": "val1", "flags": "P", "stream": "stdout", "content": "partial line 2 ", "time": tagFTime1Str},
+					model.LabelSet{"label1": "val1", "stream": "stdout"},
+					"partial line 2 ",
+					tagFTime1,
+				),
+			},
+			expectedNewPartialLinesFlushed: 0,
 		},
 	}
 
@@ -264,16 +300,30 @@ func TestCRIStage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			expectedMetrics := fmt.Sprintf(`
+			metricsFor := func(flushed int) string {
+				return fmt.Sprintf(`
 # HELP loki_process_cri_lines_truncated_total A count of lines that were truncated due to the max_partial_line_size limit
 # TYPE loki_process_cri_lines_truncated_total counter
 loki_process_cri_lines_truncated_total %d
 # HELP loki_process_cri_partial_lines_flushed_total A count of partial lines that were flushed prematurely due to the max_partial_lines limit being exceeded
 # TYPE loki_process_cri_partial_lines_flushed_total counter
 loki_process_cri_partial_lines_flushed_total %d
-`, tt.expectedLinesTruncated, tt.expectedPartialLinesFlushed)
+`, tt.expectedLinesTruncated, flushed)
+			}
 
-			runPipelineTest(t, []StageConfig{{CRIConfig: &tt.cfg}}, tt.entries, tt.expected, expectedMetrics)
+			wantOld := pipelineExpectation{
+				entries: tt.expected,
+				metrics: metricsFor(tt.expectedPartialLinesFlushed),
+			}
+			wantNew := wantOld
+			if tt.expectedNew != nil {
+				wantNew = pipelineExpectation{
+					entries: tt.expectedNew,
+					metrics: metricsFor(tt.expectedNewPartialLinesFlushed),
+				}
+			}
+
+			runPipelineTest(t, []StageConfig{{CRIConfig: &tt.cfg}}, tt.entries, wantOld, wantNew)
 		})
 	}
 }

--- a/internal/component/loki/process/stages/cri_test.go
+++ b/internal/component/loki/process/stages/cri_test.go
@@ -89,13 +89,18 @@ func TestCRIStage(t *testing.T) {
 			},
 		},
 		{
-			name: "with invalid line",
+			name: "without flag",
 			cfg:  defaultCRIConfig,
 			entries: []Entry{
-				newEntry(map[string]any{}, model.LabelSet{}, "i'm invalid!!!", criTestTime2),
+				newEntry(map[string]any{}, model.LabelSet{}, "something stderr looks like it could be cri", criTestTime2),
 			},
 			expected: []Entry{
-				newEntry(map[string]any{}, model.LabelSet{}, "i'm invalid!!!", criTestTime2),
+				newEntry(
+					map[string]any{"flags": "F", "stream": "stderr", "content": "looks like it could be cri", "time": "something"},
+					model.LabelSet{"stream": "stderr"},
+					"looks like it could be cri",
+					criTestTime2,
+				),
 			},
 		},
 		{

--- a/internal/component/loki/process/stages/json_test.go
+++ b/internal/component/loki/process/stages/json_test.go
@@ -392,7 +392,7 @@ func TestJSONParser_Parse(t *testing.T) {
 		tt := tt
 		t.Run(tName, func(t *testing.T) {
 			t.Parallel()
-			p, err := New(logger.Slog(), tt.config, nil, featuregate.StabilityGenerallyAvailable)
+			p, err := newStage(logger.Slog(), tt.config, nil, featuregate.StabilityGenerallyAvailable)
 			assert.NoError(t, err, "failed to create json parser: %s", err)
 			out := processEntries(p, newEntry(tt.extracted, nil, tt.entry, time.Now()))[0]
 

--- a/internal/component/loki/process/stages/logfmt_test.go
+++ b/internal/component/loki/process/stages/logfmt_test.go
@@ -284,7 +284,7 @@ func TestLogfmtParser_Parse(t *testing.T) {
 		tt := tt
 		t.Run(tName, func(t *testing.T) {
 			t.Parallel()
-			p, err := New(logger.Slog(), StageConfig{LogfmtConfig: &tt.config}, nil, featuregate.StabilityGenerallyAvailable)
+			p, err := newStage(logger.Slog(), StageConfig{LogfmtConfig: &tt.config}, nil, featuregate.StabilityGenerallyAvailable)
 			assert.NoError(t, err)
 			out := processEntries(p, newEntry(tt.extracted, nil, tt.entry, time.Now()))[0]
 

--- a/internal/component/loki/process/stages/match_test.go
+++ b/internal/component/loki/process/stages/match_test.go
@@ -241,7 +241,7 @@ func TestMatchStage_NewPipelineErrorIsWrapped(t *testing.T) {
 	}
 
 	logger := util.TestAlloyLogger(t)
-	_, err := New(logger.Slog(), cfg, prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
+	_, err := newStage(logger.Slog(), cfg, prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
 	require.ErrorContains(t, err, "match stage failed to create pipeline")
 	require.ErrorContains(t, errors.Unwrap(err), "invalid stage config")
 }

--- a/internal/component/loki/process/stages/metric_test.go
+++ b/internal/component/loki/process/stages/metric_test.go
@@ -447,15 +447,15 @@ func TestMetricStage_Process(t *testing.T) {
 		}}}
 
 	registry := prometheus.NewRegistry()
-	jsonStage, err := New(logging.NewSlogNop(), jsonStageConfig, registry, featuregate.StabilityGenerallyAvailable)
+	jsonStage, err := newStage(logging.NewSlogNop(), jsonStageConfig, registry, featuregate.StabilityGenerallyAvailable)
 	if err != nil {
 		t.Fatalf("failed to create stage with metrics: %v", err)
 	}
-	regexStage, err := New(logging.NewSlogNop(), regexStageConfig, registry, featuregate.StabilityGenerallyAvailable)
+	regexStage, err := newStage(logging.NewSlogNop(), regexStageConfig, registry, featuregate.StabilityGenerallyAvailable)
 	if err != nil {
 		t.Fatalf("failed to create stage with metrics: %v", err)
 	}
-	metricStage, err := New(logging.NewSlogNop(), metricsStageConfig, registry, featuregate.StabilityGenerallyAvailable)
+	metricStage, err := newStage(logging.NewSlogNop(), metricsStageConfig, registry, featuregate.StabilityGenerallyAvailable)
 	if err != nil {
 		t.Fatalf("failed to create stage with metrics: %v", err)
 	}

--- a/internal/component/loki/process/stages/pattern_test.go
+++ b/internal/component/loki/process/stages/pattern_test.go
@@ -447,7 +447,7 @@ func TestPatternParser_Parse(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			t.Parallel()
 			logger := util.TestAlloyLogger(t)
-			p, err := New(logger.Slog(), StageConfig{PatternConfig: &tt.config}, nil, featuregate.StabilityGenerallyAvailable)
+			p, err := newStage(logger.Slog(), StageConfig{PatternConfig: &tt.config}, nil, featuregate.StabilityGenerallyAvailable)
 			if err != nil {
 				t.Fatalf("failed to create pattern parser: %s", err)
 			}
@@ -474,7 +474,7 @@ func BenchmarkPatternStage(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			logger := util.TestAlloyLogger(b)
-			stage, err := New(logger.Slog(), StageConfig{PatternConfig: &bm.config}, nil, featuregate.StabilityGenerallyAvailable)
+			stage, err := newStage(logger.Slog(), StageConfig{PatternConfig: &bm.config}, nil, featuregate.StabilityGenerallyAvailable)
 			if err != nil {
 				panic(err)
 			}

--- a/internal/component/loki/process/stages/pipeline.go
+++ b/internal/component/loki/process/stages/pipeline.go
@@ -59,7 +59,7 @@ type Pipeline struct {
 func NewPipeline(slogger *slog.Logger, stages []StageConfig, registerer prometheus.Registerer, minStability featuregate.Stability) (*Pipeline, error) {
 	st := []Stage{}
 	for _, stage := range stages {
-		newStage, err := New(slogger, stage, registerer, minStability)
+		newStage, err := newStage(slogger, stage, registerer, minStability)
 		if err != nil {
 			return nil, fmt.Errorf("invalid stage config %w", err)
 		}

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -74,7 +74,7 @@ func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) error {
 	_ = batch.ConsumeStreams(func(stream loki.Stream, created int64) error {
 		extracted := make(map[string]any, len(stream.Labels))
 		for k, v := range stream.Labels {
-			extracted[string(k)] = v
+			extracted[string(k)] = string(v)
 		}
 
 		for i, e := range stream.Entries {
@@ -100,7 +100,7 @@ func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) error {
 func (p *Pipeline2) ProcessEntry(ctx context.Context, entry loki.Entry) error {
 	extracted := make(map[string]any, len(entry.Labels))
 	for k, v := range entry.Labels {
-		extracted[string(k)] = v
+		extracted[string(k)] = string(v)
 	}
 
 	return p.process(ctx, []Entry{

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -91,6 +91,7 @@ func (p *PipelineConsumer) Stop() {
 }
 
 func (p *PipelineConsumer) collect(ctx context.Context, entries []Entry) error {
+	// FIXME(kallep): Currently this would set time.Now as creation time for a batch.
 	batch := loki.NewBatch()
 	for _, e := range entries {
 		batch.AddEntry(e.Labels, e.Entry.Entry)

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -13,8 +13,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// NextFn forwards a batch of entries to whatever comes next in a pipeline.
-type NextFn func(ctx context.Context, entries []Entry) error
+// nextFn forwards a batch of entries to whatever comes next in a pipeline.
+type nextFn func(ctx context.Context, entries []Entry) error
 
 // entryProcessor is a single step in a pipeline.
 type entryProcessor interface {
@@ -28,52 +28,41 @@ type stopper interface {
 	stop()
 }
 
-var _ entryProcessor = (*Pipeline2)(nil)
+var _ loki.Consumer = (*PipelineConsumer)(nil)
 
-// Pipeline2 runs a batch of entries through a configured chain of stages,
-// passing each batch from one stage to the next via direct function calls.
-type Pipeline2 struct {
-	next   NextFn
-	stages []entryProcessor
-}
-
-func NewPipeline2(
+func NewPipelineConsumer(
 	slogger *slog.Logger,
 	registerer prometheus.Registerer,
 	minStability featuregate.Stability,
 	cfgs []StageConfig,
-	next NextFn,
-) (*Pipeline2, error) {
+	consumer loki.Consumer,
+) (*PipelineConsumer, error) {
 
-	var stages []entryProcessor
+	var (
+		err error
+		pc  = &PipelineConsumer{consumer: consumer}
+	)
 
-	// We build stages from the back so we can pass the correct next function
-	// to the constructor.
-	for _, cfg := range slices.Backward(cfgs) {
-		s, err := newStageWithNextFn(slogger, cfg, registerer, minStability, next)
-		if err != nil {
-			return nil, fmt.Errorf("invalid stage config %w", err)
-		}
-
-		newStage, ok := s.(entryProcessor)
-		if !ok {
-			return nil, errors.New("stage has not been migrated to new interface")
-		}
-
-		stages = append(stages, newStage)
-		next = newStage.process
+	pc.inner, err = newPipeline(slogger, registerer, minStability, cfgs, pc.collect)
+	if err != nil {
+		return nil, err
 	}
 
-	return &Pipeline2{
-		next:   next,
-		stages: stages,
-	}, nil
+	return pc, nil
 }
 
-// ProcessBatch runs every entry in batch through the pipeline.
-func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) error {
+type PipelineConsumer struct {
+	inner    *pipeline
+	consumer loki.Consumer
+}
+
+// Consume implements loki.Consumer.
+func (p *PipelineConsumer) Consume(ctx context.Context, batch loki.Batch) error {
+	// FIXME(kalleep): pool of entry slices?
 	entries := make([]Entry, 0, batch.EntryLen())
-	_ = batch.ConsumeStreams(func(stream loki.Stream, created int64) error {
+	return batch.ConsumeStreams(func(stream loki.Stream, created int64) error {
+		entries = slices.Grow(entries[:0], len(stream.Entries))
+
 		extracted := make(map[string]any, len(stream.Labels))
 		for k, v := range stream.Labels {
 			extracted[string(k)] = string(v)
@@ -92,32 +81,73 @@ func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) error {
 				})
 			}
 		}
-		return nil
-	})
 
-	return p.process(ctx, entries)
+		return p.inner.process(ctx, entries)
+	})
 }
 
-// ProcessEntry runs a single entry through the pipeline.
-func (p *Pipeline2) ProcessEntry(ctx context.Context, entry loki.Entry) error {
-	extracted := make(map[string]any, len(entry.Labels))
-	for k, v := range entry.Labels {
-		extracted[string(k)] = string(v)
+func (p *PipelineConsumer) Stop() {
+	p.inner.stop()
+}
+
+func (p *PipelineConsumer) collect(ctx context.Context, entries []Entry) error {
+	// FIXME(kalleep): restore batch creation time?
+	batch := loki.NewBatch()
+	for _, e := range entries {
+		batch.AddEntry(e.Labels, e.Entry.Entry)
+	}
+	return p.consumer.Consume(ctx, batch)
+}
+
+var _ entryProcessor = (*pipeline)(nil)
+
+// pipeline runs a batch of entries through a configured chain of stages,
+// passing each batch from one stage to the next via direct function calls.
+type pipeline struct {
+	next   nextFn
+	stages []entryProcessor
+}
+
+func newPipeline(
+	slogger *slog.Logger,
+	registerer prometheus.Registerer,
+	minStability featuregate.Stability,
+	cfgs []StageConfig,
+	next nextFn,
+) (*pipeline, error) {
+
+	var stages []entryProcessor
+
+	// We build stages from the back so we can pass the correct next function
+	// to the constructor.
+	for _, cfg := range slices.Backward(cfgs) {
+		s, err := newStageWithOpts(cfg, stageOpts{
+			slogger:      slogger,
+			registerer:   registerer,
+			minStability: minStability,
+			next:         next,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("invalid stage config %w", err)
+		}
+
+		newStage, ok := s.(entryProcessor)
+		if !ok {
+			return nil, errors.New("stage has not been migrated to new interface")
+		}
+
+		stages = append(stages, newStage)
+		next = newStage.process
 	}
 
-	return p.process(ctx, []Entry{
-		{
-			Extracted: extracted,
-			Entry:     entry,
-		},
-	})
+	return &pipeline{next: next, stages: stages}, nil
 }
 
-func (p *Pipeline2) process(ctx context.Context, entries []Entry) error {
+func (p *pipeline) process(ctx context.Context, entries []Entry) error {
 	return p.next(ctx, entries)
 }
 
-func (p *Pipeline2) Stop() {
+func (p *pipeline) stop() {
 	// stages is stored in the reverse of its config order, so iterate
 	// backwards to stop in the original, upstream-first order.
 	for _, s := range slices.Backward(p.stages) {

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -16,9 +16,11 @@ import (
 // NextFn forwards a batch of entries to whatever comes next in a pipeline.
 type NextFn func(ctx context.Context, entries []Entry) error
 
-// stage is a single step in a pipeline.
-type stage interface {
-	// process performs work on entries. The result is not returned. Typically the implementations call a `NextFn` configured at construction time. Errors are propagated.
+// entryProcessor is a single step in a pipeline.
+type entryProcessor interface {
+	// process performs work on entries. The result is not returned.
+	// Typically the implementations call a `NextFn` configured at construction time.
+	// Errors are propagated.
 	process(ctx context.Context, entries []Entry) error
 }
 
@@ -26,13 +28,13 @@ type stopper interface {
 	stop()
 }
 
-var _ stage = (*Pipeline2)(nil)
+var _ entryProcessor = (*Pipeline2)(nil)
 
 // Pipeline2 runs a batch of entries through a configured chain of stages,
 // passing each batch from one stage to the next via direct function calls.
 type Pipeline2 struct {
 	next   NextFn
-	stages []stage
+	stages []entryProcessor
 }
 
 func NewPipeline2(
@@ -43,7 +45,7 @@ func NewPipeline2(
 	next NextFn,
 ) (*Pipeline2, error) {
 
-	var stages []stage
+	var stages []entryProcessor
 
 	// We build stages from the back so we can pass the correct next function
 	// to the constructor.
@@ -53,7 +55,7 @@ func NewPipeline2(
 			return nil, fmt.Errorf("invalid stage config %w", err)
 		}
 
-		newStage, ok := s.(stage)
+		newStage, ok := s.(entryProcessor)
 		if !ok {
 			return nil, errors.New("stage has not been migrated to new interface")
 		}

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -42,6 +42,7 @@ func NewPipeline2(
 	cfgs []StageConfig,
 	next NextFn,
 ) (*Pipeline2, error) {
+
 	var stages []stage
 
 	// We build stages from the back so we can pass the correct next function

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -1,0 +1,119 @@
+package stages
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"slices"
+
+	"github.com/grafana/alloy/internal/component/common/loki"
+	"github.com/grafana/alloy/internal/featuregate"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// NextFn forwards a batch of entries to whatever comes next in a pipeline.
+type NextFn func(ctx context.Context, entries []Entry) error
+
+// stage is a single step in a pipeline.
+type stage interface {
+	// process runs the stage's work on entries and forwards the result.
+	process(ctx context.Context, entries []Entry) error
+}
+
+type cleaner interface {
+	cleanup()
+}
+
+var _ stage = (*Pipeline2)(nil)
+
+// Pipeline2 runs a batch of entries through a configured chain of stages,
+// passing each batch from one stage to the next via direct function calls.
+type Pipeline2 struct {
+	next   NextFn
+	stages []stage
+}
+
+func NewPipeline2(
+	slogger *slog.Logger,
+	registerer prometheus.Registerer,
+	minStability featuregate.Stability,
+	cfgs []StageConfig,
+	next NextFn,
+) (*Pipeline2, error) {
+	var stages []stage
+
+	// We build stages from the back so we can pass the correct next function
+	// to the constructor.
+	for _, cfg := range slices.Backward(cfgs) {
+		s, err := newStageWithNextFn(slogger, cfg, registerer, minStability, next)
+		if err != nil {
+			return nil, fmt.Errorf("invalid stage config %w", err)
+		}
+
+		newStage, ok := s.(stage)
+		if !ok {
+			return nil, errors.New("stage has not been migrated to new interface")
+		}
+
+		stages = append(stages, newStage)
+		next = newStage.process
+	}
+
+	return &Pipeline2{
+		next:   next,
+		stages: stages,
+	}, nil
+}
+
+// ProcessBatch runs every entry in batch through the pipeline.
+func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) error {
+	entries := make([]Entry, 0, batch.EntryLen())
+	_ = batch.ConsumeStreams(func(stream loki.Stream, created int64) error {
+		extracted := make(map[string]any, len(stream.Labels))
+		for k, v := range stream.Labels {
+			extracted[string(k)] = v
+		}
+
+		for _, e := range stream.Entries {
+			entries = append(entries, Entry{
+				Extracted: maps.Clone(extracted),
+				Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e),
+			})
+		}
+		return nil
+	})
+
+	return p.process(ctx, entries)
+}
+
+// ProcessEntry runs a single entry through the pipeline.
+func (p *Pipeline2) ProcessEntry(ctx context.Context, entry loki.Entry) error {
+	extracted := make(map[string]any, len(entry.Labels))
+	for k, v := range entry.Labels {
+		extracted[string(k)] = v
+	}
+
+	return p.process(ctx, []Entry{
+		{
+			Extracted: extracted,
+			Entry:     entry,
+		},
+	})
+}
+
+func (p *Pipeline2) process(ctx context.Context, entries []Entry) error {
+	return p.next(ctx, entries)
+}
+
+func (p *Pipeline2) Cleanup() {
+	// stages is stored in the reverse of its config order, so iterate
+	// backwards to clean up in the original, upstream-first order.
+	for _, s := range slices.Backward(p.stages) {
+		c, ok := s.(cleaner)
+		if ok {
+			c.cleanup()
+		}
+	}
+}

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -18,7 +18,7 @@ type NextFn func(ctx context.Context, entries []Entry) error
 
 // stage is a single step in a pipeline.
 type stage interface {
-	// process runs the stage's work on entries and forwards the result.
+	// process performs work on entries. The result is not returned. Typically the implementations call a `NextFn` configured at construction time. Errors are propagated.
 	process(ctx context.Context, entries []Entry) error
 }
 

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -22,8 +22,8 @@ type stage interface {
 	process(ctx context.Context, entries []Entry) error
 }
 
-type cleaner interface {
-	cleanup()
+type stopper interface {
+	stop()
 }
 
 var _ stage = (*Pipeline2)(nil)
@@ -115,13 +115,13 @@ func (p *Pipeline2) process(ctx context.Context, entries []Entry) error {
 	return p.next(ctx, entries)
 }
 
-func (p *Pipeline2) Cleanup() {
+func (p *Pipeline2) Stop() {
 	// stages is stored in the reverse of its config order, so iterate
-	// backwards to clean up in the original, upstream-first order.
+	// backwards to stop in the original, upstream-first order.
 	for _, s := range slices.Backward(p.stages) {
-		c, ok := s.(cleaner)
+		c, ok := s.(stopper)
 		if ok {
-			c.cleanup()
+			c.stop()
 		}
 	}
 }

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -58,7 +58,6 @@ type PipelineConsumer struct {
 
 // Consume implements loki.Consumer.
 func (p *PipelineConsumer) Consume(ctx context.Context, batch loki.Batch) error {
-	// FIXME(kalleep): pool of entry slices?
 	entries := make([]Entry, 0, batch.EntryLen())
 	return batch.ConsumeStreams(func(stream loki.Stream, created int64) error {
 		entries = slices.Grow(entries[:0], len(stream.Entries))
@@ -77,7 +76,8 @@ func (p *PipelineConsumer) Consume(ctx context.Context, batch loki.Batch) error 
 			} else {
 				entries = append(entries, Entry{
 					Extracted: maps.Clone(extracted),
-					Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e),
+					//FIXME(kalleep): this clone will be removed when https://github.com/grafana/alloy/issues/6835 is implemented.
+					Entry: loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e),
 				})
 			}
 		}
@@ -91,7 +91,6 @@ func (p *PipelineConsumer) Stop() {
 }
 
 func (p *PipelineConsumer) collect(ctx context.Context, entries []Entry) error {
-	// FIXME(kalleep): restore batch creation time?
 	batch := loki.NewBatch()
 	for _, e := range entries {
 		batch.AddEntry(e.Labels, e.Entry.Entry)

--- a/internal/component/loki/process/stages/pipeline2.go
+++ b/internal/component/loki/process/stages/pipeline2.go
@@ -76,11 +76,18 @@ func (p *Pipeline2) ProcessBatch(ctx context.Context, batch loki.Batch) error {
 			extracted[string(k)] = v
 		}
 
-		for _, e := range stream.Entries {
-			entries = append(entries, Entry{
-				Extracted: maps.Clone(extracted),
-				Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e),
-			})
+		for i, e := range stream.Entries {
+			if i == len(stream.Entries)-1 {
+				entries = append(entries, Entry{
+					Extracted: extracted,
+					Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels, created, e),
+				})
+			} else {
+				entries = append(entries, Entry{
+					Extracted: maps.Clone(extracted),
+					Entry:     loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e),
+				})
+			}
 		}
 		return nil
 	})

--- a/internal/component/loki/process/stages/pipeline_test.go
+++ b/internal/component/loki/process/stages/pipeline_test.go
@@ -119,7 +119,7 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 		require.NoError(t, err)
 
 		p.process(context.Background(), entries)
-		p.Cleanup()
+		p.Stop()
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assertEntriesUnordered(c, expected, collected)
@@ -176,7 +176,7 @@ func runPipelineBenchmark(b *testing.B, cfgs []StageConfig, batch loki.Batch) {
 
 		p, err := NewPipeline2(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, cfgs, next)
 		require.NoError(b, err)
-		defer p.Cleanup()
+		defer p.Stop()
 
 		b.ResetTimer()
 		b.ReportAllocs()

--- a/internal/component/loki/process/stages/pipeline_test.go
+++ b/internal/component/loki/process/stages/pipeline_test.go
@@ -166,8 +166,8 @@ func runPipelineBenchmark(b *testing.B, cfgs []StageConfig, batch loki.Batch) {
 	})
 
 	b.Run("New Pipeline", func(b *testing.B) {
-		collcetor := loki.NewCollectingConsumer()
-		pc, err := NewPipelineConsumer(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, cfgs, collcetor)
+		consumer := loki.NewNopConsumer()
+		pc, err := NewPipelineConsumer(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, cfgs, consumer)
 		require.NoError(b, err)
 		defer pc.Stop()
 

--- a/internal/component/loki/process/stages/pipeline_test.go
+++ b/internal/component/loki/process/stages/pipeline_test.go
@@ -1,15 +1,21 @@
 package stages
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,6 +60,129 @@ func loadConfig(yml string) []StageConfig {
 
 func newPipelineFromConfig(cfg string) (*Pipeline, error) {
 	return NewPipeline(logging.NewSlogNop(), loadConfig(cfg), prometheus.DefaultRegisterer, featuregate.StabilityGenerallyAvailable)
+}
+
+// runPipelineTest builds a pipeline for cfgs using both the old and new
+// pipeline implementations, runs entries through each, and asserts the
+// result matches expected. expectedMetrics is optional: pass "" to skip
+// checking metrics, or a Prometheus exposition-format string (as consumed
+// by testutil.GatherAndCompare) to assert against each run's own registry.
+func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected []Entry, expectedMetrics string) {
+	// Pipeline.Run seeds the extracted map with each entry's initial labels
+	// before running any stage. process (called directly below, bypassing
+	// ProcessBatch/ProcessEntry) does not. Seed it here once so both
+	// pipeline implementations start from the same state.
+	for i := range entries {
+		for labelName, labelValue := range entries[i].Labels {
+			entries[i].Extracted[string(labelName)] = string(labelValue)
+		}
+	}
+
+	t.Run("Stage", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		p, err := NewPipeline(logging.NewSlogNop(), cfgs, registry, featuregate.StabilityGenerallyAvailable)
+		require.NoError(t, err)
+		out := p.Run(withInboundEntries(cloneEntries(entries)...))
+		var collected []Entry
+		for e := range out {
+			collected = append(collected, e)
+		}
+
+		assertEntriesUnordered(t, expected, collected)
+		if expectedMetrics != "" {
+			require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics)))
+		}
+	})
+
+	t.Run("New Stage", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		var collected []Entry
+		next := func(_ context.Context, entries []Entry) error {
+			collected = append(collected, entries...)
+			return nil
+		}
+
+		p, err := NewPipeline2(logging.NewSlogNop(), registry, featuregate.StabilityGenerallyAvailable, cfgs, next)
+		require.NoError(t, err)
+
+		p.process(context.Background(), entries)
+		p.Cleanup()
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assertEntriesUnordered(c, expected, collected)
+			if expectedMetrics != "" {
+				assert.NoError(c, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics)))
+			}
+		}, 2*time.Second, 100*time.Millisecond)
+	})
+
+}
+
+// cloneEntries returns a deep copy of entries so a pipeline run mutating
+// them (Labels/Extracted are maps, mutated in place) doesn't affect a caller
+// still holding the original slice.
+func cloneEntries(entries []Entry) []Entry {
+	out := make([]Entry, len(entries))
+	for i, e := range entries {
+		out[i] = Entry{
+			Extracted: maps.Clone(e.Extracted),
+			Entry:     e.Entry.Clone(),
+		}
+	}
+	return out
+}
+
+// assertEntriesUnordered asserts that actual contains exactly the entries in
+// expected, ignoring order.
+func assertEntriesUnordered(t require.TestingT, expected, actual []Entry) {
+	require.Len(t, actual, len(expected))
+
+	entriesEqual := func(expected, actual Entry) bool {
+		if expected.Line != actual.Line {
+			return false
+		}
+		if expected.Timestamp.Unix() != actual.Timestamp.Unix() {
+			return false
+		}
+		if !reflect.DeepEqual(expected.Labels, actual.Labels) {
+			return false
+		}
+		if !reflect.DeepEqual(expected.Extracted, actual.Extracted) {
+			return false
+		}
+
+		var (
+			expectedStructured = slices.Clone(expected.StructuredMetadata)
+			actualStructured   = slices.Clone(actual.StructuredMetadata)
+		)
+
+		sortLabelAdapters := func(s []push.LabelAdapter) {
+			slices.SortFunc(s, func(a, b push.LabelAdapter) int {
+				if a.Name != b.Name {
+					return strings.Compare(a.Name, b.Name)
+				}
+				return strings.Compare(a.Value, b.Value)
+			})
+		}
+		sortLabelAdapters(expectedStructured)
+		sortLabelAdapters(actualStructured)
+
+		return reflect.DeepEqual(expectedStructured, actualStructured)
+	}
+
+	remaining := append([]Entry(nil), actual...)
+	for _, exp := range expected {
+		found := -1
+		for i, got := range remaining {
+			if entriesEqual(exp, got) {
+				found = i
+				break
+			}
+		}
+
+		require.NotEqual(t, -1, found)
+		remaining = append(remaining[:found], remaining[found+1:]...)
+	}
 }
 
 // TODO(@tpaschalis) Comment these out until we port over the remaining

--- a/internal/component/loki/process/stages/pipeline_test.go
+++ b/internal/component/loki/process/stages/pipeline_test.go
@@ -132,10 +132,7 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 
 // benchResultLokiEntry and benchResultEntries sink runPipelineBenchmark's
 // results so the compiler can't optimize the calls being measured away.
-var (
-	benchResultEntries   []Entry
-	benchResultLokiEntry loki.Entry
-)
+var benchResultLokiEntry loki.Entry
 
 // runPipelineBenchmark benchmarks a pipeline built for cfgs against batch.
 // It will run one benchmark for new stage implementation and one for old implementation.

--- a/internal/component/loki/process/stages/pipeline_test.go
+++ b/internal/component/loki/process/stages/pipeline_test.go
@@ -91,7 +91,7 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 
 	cloned := cloneEntries(entries)
 
-	t.Run("Stage", func(t *testing.T) {
+	t.Run("Pipeline", func(t *testing.T) {
 		registry := prometheus.NewRegistry()
 		p, err := NewPipeline(logging.NewSlogNop(), cfgs, registry, featuregate.StabilityGenerallyAvailable)
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 		}
 	})
 
-	t.Run("New Stage", func(t *testing.T) {
+	t.Run("New Pipeline", func(t *testing.T) {
 		registry := prometheus.NewRegistry()
 		var collected []Entry
 		next := func(_ context.Context, entries []Entry) error {
@@ -140,7 +140,7 @@ var (
 // runPipelineBenchmark benchmarks a pipeline built for cfgs against batch.
 // It will run one benchmark for new stage implementation and one for old implementation.
 func runPipelineBenchmark(b *testing.B, cfgs []StageConfig, batch loki.Batch) {
-	b.Run("Stage", func(b *testing.B) {
+	b.Run("Pipeline", func(b *testing.B) {
 		p, err := NewPipeline(logging.NewSlogNop(), cfgs, prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
 		require.NoError(b, err)
 
@@ -168,7 +168,7 @@ func runPipelineBenchmark(b *testing.B, cfgs []StageConfig, batch loki.Batch) {
 		}
 	})
 
-	b.Run("New Stage", func(b *testing.B) {
+	b.Run("New Pipeline", func(b *testing.B) {
 		collcetor := loki.NewCollectingConsumer()
 		pc, err := NewPipelineConsumer(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, cfgs, collcetor)
 		require.NoError(b, err)

--- a/internal/component/loki/process/stages/pipeline_test.go
+++ b/internal/component/loki/process/stages/pipeline_test.go
@@ -115,11 +115,11 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 			return nil
 		}
 
-		p, err := NewPipeline2(logging.NewSlogNop(), registry, featuregate.StabilityGenerallyAvailable, cfgs, next)
+		p, err := newPipeline(logging.NewSlogNop(), registry, featuregate.StabilityGenerallyAvailable, cfgs, next)
 		require.NoError(t, err)
 
 		p.process(context.Background(), entries)
-		p.Stop()
+		p.stop()
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assertEntriesUnordered(c, expected, collected)
@@ -169,20 +169,16 @@ func runPipelineBenchmark(b *testing.B, cfgs []StageConfig, batch loki.Batch) {
 	})
 
 	b.Run("New Stage", func(b *testing.B) {
-		next := func(_ context.Context, e []Entry) error {
-			benchResultEntries = e
-			return nil
-		}
-
-		p, err := NewPipeline2(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, cfgs, next)
+		collcetor := loki.NewCollectingConsumer()
+		pc, err := NewPipelineConsumer(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, cfgs, collcetor)
 		require.NoError(b, err)
-		defer p.Stop()
+		defer pc.Stop()
 
 		b.ResetTimer()
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = p.ProcessBatch(context.Background(), batch.Clone())
+			_ = pc.Consume(context.Background(), batch.Clone())
 		}
 	})
 }

--- a/internal/component/loki/process/stages/pipeline_test.go
+++ b/internal/component/loki/process/stages/pipeline_test.go
@@ -78,11 +78,24 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 		}
 	}
 
+	cloneEntries := func(entries []Entry) []Entry {
+		out := make([]Entry, len(entries))
+		for i, e := range entries {
+			out[i] = Entry{
+				Extracted: maps.Clone(e.Extracted),
+				Entry:     e.Entry.Clone(),
+			}
+		}
+		return out
+	}
+
+	cloned := cloneEntries(entries)
+
 	t.Run("Stage", func(t *testing.T) {
 		registry := prometheus.NewRegistry()
 		p, err := NewPipeline(logging.NewSlogNop(), cfgs, registry, featuregate.StabilityGenerallyAvailable)
 		require.NoError(t, err)
-		out := p.Run(withInboundEntries(cloneEntries(entries)...))
+		out := p.Run(withInboundEntries(cloned...))
 		var collected []Entry
 		for e := range out {
 			collected = append(collected, e)
@@ -118,18 +131,61 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 
 }
 
-// cloneEntries returns a deep copy of entries so a pipeline run mutating
-// them (Labels/Extracted are maps, mutated in place) doesn't affect a caller
-// still holding the original slice.
-func cloneEntries(entries []Entry) []Entry {
-	out := make([]Entry, len(entries))
-	for i, e := range entries {
-		out[i] = Entry{
-			Extracted: maps.Clone(e.Extracted),
-			Entry:     e.Entry.Clone(),
+// benchResultLokiEntry and benchResultEntries sink runPipelineBenchmark's
+// results so the compiler can't optimize the calls being measured away.
+var (
+	benchResultEntries   []Entry
+	benchResultLokiEntry loki.Entry
+)
+
+// runPipelineBenchmark benchmarks a pipeline built for cfgs against batch.
+// It will run one benchmark for new stage implementation and one for old implementation.
+func runPipelineBenchmark(b *testing.B, cfgs []StageConfig, batch loki.Batch) {
+	b.Run("Stage", func(b *testing.B) {
+		p, err := NewPipeline(logging.NewSlogNop(), cfgs, prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable)
+		require.NoError(b, err)
+
+		in := make(chan loki.Entry)
+		out := make(chan loki.Entry)
+		handler := p.Start(in, out)
+		defer handler.Stop()
+
+		clone := batch.Clone()
+		entries := make([]loki.Entry, 0, clone.EntryLen())
+		_ = clone.ConsumeStreams(func(stream loki.Stream, created int64) error {
+			for _, e := range stream.Entries {
+				entries = append(entries, loki.NewEntryWithCreatedUnixMicro(stream.Labels.Clone(), created, e))
+			}
+			return nil
+		})
+
+		b.ResetTimer()
+		b.ReportAllocs()
+		for b.Loop() {
+			for _, e := range entries {
+				handler.Chan() <- e.Clone()
+				benchResultLokiEntry = <-out
+			}
 		}
-	}
-	return out
+	})
+
+	b.Run("New Stage", func(b *testing.B) {
+		next := func(_ context.Context, e []Entry) error {
+			benchResultEntries = e
+			return nil
+		}
+
+		p, err := NewPipeline2(logging.NewSlogNop(), prometheus.NewRegistry(), featuregate.StabilityGenerallyAvailable, cfgs, next)
+		require.NoError(b, err)
+		defer p.Cleanup()
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_ = p.ProcessBatch(context.Background(), batch.Clone())
+		}
+	})
 }
 
 // assertEntriesUnordered asserts that actual contains exactly the entries in

--- a/internal/component/loki/process/stages/pipeline_test.go
+++ b/internal/component/loki/process/stages/pipeline_test.go
@@ -62,12 +62,21 @@ func newPipelineFromConfig(cfg string) (*Pipeline, error) {
 	return NewPipeline(logging.NewSlogNop(), loadConfig(cfg), prometheus.DefaultRegisterer, featuregate.StabilityGenerallyAvailable)
 }
 
+// pipelineExpectation is what one pipeline implementation should produce.
+// metrics is optional: pass "" to skip checking metrics, or a Prometheus
+// exposition-format string (as consumed by testutil.GatherAndCompare) to assert
+// against that run's own registry.
+type pipelineExpectation struct {
+	entries []Entry
+	metrics string
+}
+
 // runPipelineTest builds a pipeline for cfgs using both the old and new
-// pipeline implementations, runs entries through each, and asserts the
-// result matches expected. expectedMetrics is optional: pass "" to skip
-// checking metrics, or a Prometheus exposition-format string (as consumed
-// by testutil.GatherAndCompare) to assert against each run's own registry.
-func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected []Entry, expectedMetrics string) {
+// pipeline implementations, runs entries through each, and asserts each result
+// matches its own expectation. The two differ when a stage batches work, for
+// example the cri stage checks max_partial_lines per entry in Run but once per
+// batch in process.
+func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, wantOld, wantNew pipelineExpectation) {
 	// Pipeline.Run seeds the extracted map with each entry's initial labels
 	// before running any stage. process (called directly below, bypassing
 	// ProcessBatch/ProcessEntry) does not. Seed it here once so both
@@ -101,9 +110,9 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 			collected = append(collected, e)
 		}
 
-		assertEntriesUnordered(t, expected, collected)
-		if expectedMetrics != "" {
-			require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics)))
+		assertEntriesUnordered(t, wantOld.entries, collected)
+		if wantOld.metrics != "" {
+			require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(wantOld.metrics)))
 		}
 	})
 
@@ -122,9 +131,9 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 		p.stop()
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assertEntriesUnordered(c, expected, collected)
-			if expectedMetrics != "" {
-				assert.NoError(c, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics)))
+			assertEntriesUnordered(c, wantNew.entries, collected)
+			if wantNew.metrics != "" {
+				assert.NoError(c, testutil.GatherAndCompare(registry, strings.NewReader(wantNew.metrics)))
 			}
 		}, 2*time.Second, 100*time.Millisecond)
 	})

--- a/internal/component/loki/process/stages/pipeline_test.go
+++ b/internal/component/loki/process/stages/pipeline_test.go
@@ -128,7 +128,6 @@ func runPipelineTest(t *testing.T, cfgs []StageConfig, entries []Entry, expected
 			}
 		}, 2*time.Second, 100*time.Millisecond)
 	})
-
 }
 
 // benchResultLokiEntry and benchResultEntries sink runPipelineBenchmark's

--- a/internal/component/loki/process/stages/regex_test.go
+++ b/internal/component/loki/process/stages/regex_test.go
@@ -455,7 +455,7 @@ func TestRegexParser_Parse(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			t.Parallel()
 			logger := util.TestAlloyLogger(t)
-			p, err := New(logger.Slog(), StageConfig{RegexConfig: &tt.config}, nil, featuregate.StabilityGenerallyAvailable)
+			p, err := newStage(logger.Slog(), StageConfig{RegexConfig: &tt.config}, nil, featuregate.StabilityGenerallyAvailable)
 			if err != nil {
 				t.Fatalf("failed to create regex parser: %s", err)
 			}
@@ -481,7 +481,7 @@ func BenchmarkRegexStage(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			logger := util.TestAlloyLogger(b)
-			stage, err := New(logger.Slog(), StageConfig{RegexConfig: &bm.config}, nil, featuregate.StabilityGenerallyAvailable)
+			stage, err := newStage(logger.Slog(), StageConfig{RegexConfig: &bm.config}, nil, featuregate.StabilityGenerallyAvailable)
 			if err != nil {
 				panic(err)
 			}

--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -65,7 +65,7 @@ func newStageWithNextFn(
 	cfg StageConfig,
 	registerer prometheus.Registerer,
 	minStability featuregate.Stability,
-	_ NextFn,
+	next NextFn,
 ) (Stage, error) {
 
 	var (
@@ -79,10 +79,7 @@ func newStageWithNextFn(
 			return nil, err
 		}
 	case cfg.CRIConfig != nil:
-		s, err = NewCRI(slogger, *cfg.CRIConfig, registerer, minStability)
-		if err != nil {
-			return nil, err
-		}
+		s = newCRIStage(slogger, *cfg.CRIConfig, registerer, minStability, next)
 	case cfg.JSONConfig != nil:
 		s, err = newJSONStage(slogger, *cfg.JSONConfig)
 		if err != nil {

--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -53,8 +53,8 @@ func toStage(p Processor) Stage {
 	}
 }
 
-// New creates a new stage for the given type and configuration.
-func New(slogger *slog.Logger, cfg StageConfig, registerer prometheus.Registerer, minStability featuregate.Stability) (Stage, error) {
+// newStage creates a new stage for the given type and configuration.
+func newStage(slogger *slog.Logger, cfg StageConfig, registerer prometheus.Registerer, minStability featuregate.Stability) (Stage, error) {
 	var (
 		s   Stage
 		err error

--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -53,8 +53,21 @@ func toStage(p Processor) Stage {
 	}
 }
 
+func (*stageProcessor) Cleanup() {}
+
 // newStage creates a new stage for the given type and configuration.
 func newStage(slogger *slog.Logger, cfg StageConfig, registerer prometheus.Registerer, minStability featuregate.Stability) (Stage, error) {
+	return newStageWithNextFn(slogger, cfg, registerer, minStability, nil)
+}
+
+func newStageWithNextFn(
+	slogger *slog.Logger,
+	cfg StageConfig,
+	registerer prometheus.Registerer,
+	minStability featuregate.Stability,
+	_ NextFn,
+) (Stage, error) {
+
 	var (
 		s   Stage
 		err error
@@ -208,9 +221,4 @@ func newStage(slogger *slog.Logger, cfg StageConfig, registerer prometheus.Regis
 	}
 
 	return s, nil
-}
-
-// Cleanup implements Stage.
-func (*stageProcessor) Cleanup() {
-	// no-op
 }

--- a/internal/component/loki/process/stages/stage.go
+++ b/internal/component/loki/process/stages/stage.go
@@ -57,15 +57,24 @@ func (*stageProcessor) Cleanup() {}
 
 // newStage creates a new stage for the given type and configuration.
 func newStage(slogger *slog.Logger, cfg StageConfig, registerer prometheus.Registerer, minStability featuregate.Stability) (Stage, error) {
-	return newStageWithNextFn(slogger, cfg, registerer, minStability, nil)
+	return newStageWithOpts(cfg, stageOpts{
+		slogger:      slogger,
+		registerer:   registerer,
+		minStability: minStability,
+	})
 }
 
-func newStageWithNextFn(
-	slogger *slog.Logger,
+type stageOpts struct {
+	slogger      *slog.Logger
+	registerer   prometheus.Registerer
+	minStability featuregate.Stability
+
+	next nextFn
+}
+
+func newStageWithOpts(
 	cfg StageConfig,
-	registerer prometheus.Registerer,
-	minStability featuregate.Stability,
-	next NextFn,
+	opts stageOpts,
 ) (Stage, error) {
 
 	var (
@@ -74,19 +83,19 @@ func newStageWithNextFn(
 	)
 	switch {
 	case cfg.DockerConfig != nil:
-		s, err = NewDocker(slogger, registerer, minStability)
+		s, err = NewDocker(opts.slogger, opts.registerer, opts.minStability)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.CRIConfig != nil:
-		s = newCRIStage(slogger, *cfg.CRIConfig, registerer, minStability, next)
+		s = newCRIStage(*cfg.CRIConfig, opts)
 	case cfg.JSONConfig != nil:
-		s, err = newJSONStage(slogger, *cfg.JSONConfig)
+		s, err = newJSONStage(opts.slogger, *cfg.JSONConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.LogfmtConfig != nil:
-		s, err = newLogfmtStage(slogger, *cfg.LogfmtConfig)
+		s, err = newLogfmtStage(opts.slogger, *cfg.LogfmtConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -96,77 +105,77 @@ func newStageWithNextFn(
 			return nil, err
 		}
 	case cfg.MetricsConfig != nil:
-		s, err = newMetricStage(slogger, *cfg.MetricsConfig, registerer)
+		s, err = newMetricStage(opts.slogger, *cfg.MetricsConfig, opts.registerer)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.LabelsConfig != nil:
-		s, err = newLabelStage(slogger, *cfg.LabelsConfig)
+		s, err = newLabelStage(opts.slogger, *cfg.LabelsConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.StructuredMetadata != nil:
-		s, err = newStructuredMetadataStage(slogger, *cfg.StructuredMetadata)
+		s, err = newStructuredMetadataStage(opts.slogger, *cfg.StructuredMetadata)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.StructuredMetadataDropConfig != nil:
-		s, err = newStructuredMetadataDropStage(slogger, *cfg.StructuredMetadataDropConfig)
+		s, err = newStructuredMetadataDropStage(opts.slogger, *cfg.StructuredMetadataDropConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.RegexConfig != nil:
-		s, err = newRegexStage(slogger, *cfg.RegexConfig)
+		s, err = newRegexStage(opts.slogger, *cfg.RegexConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.TimestampConfig != nil:
-		s, err = newTimestampStage(slogger, *cfg.TimestampConfig)
+		s, err = newTimestampStage(opts.slogger, *cfg.TimestampConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.OutputConfig != nil:
-		s, err = newOutputStage(slogger, *cfg.OutputConfig)
+		s, err = newOutputStage(opts.slogger, *cfg.OutputConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.MatchConfig != nil:
-		s, err = newMatcherStage(slogger, *cfg.MatchConfig, registerer, minStability)
+		s, err = newMatcherStage(opts.slogger, *cfg.MatchConfig, opts.registerer, opts.minStability)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.TemplateConfig != nil:
-		s, err = newTemplateStage(slogger, *cfg.TemplateConfig)
+		s, err = newTemplateStage(opts.slogger, *cfg.TemplateConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.TenantConfig != nil:
-		s, err = newTenantStage(slogger, *cfg.TenantConfig)
+		s, err = newTenantStage(opts.slogger, *cfg.TenantConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.ReplaceConfig != nil:
-		s, err = newReplaceStage(slogger, *cfg.ReplaceConfig)
+		s, err = newReplaceStage(opts.slogger, *cfg.ReplaceConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.LimitConfig != nil:
-		s, err = newLimitStage(slogger, *cfg.LimitConfig, registerer)
+		s, err = newLimitStage(opts.slogger, *cfg.LimitConfig, opts.registerer)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.DropConfig != nil:
-		s, err = newDropStage(slogger, *cfg.DropConfig, registerer)
+		s, err = newDropStage(opts.slogger, *cfg.DropConfig, opts.registerer)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.MultilineConfig != nil:
-		s, err = newMultilineStage(slogger, *cfg.MultilineConfig)
+		s, err = newMultilineStage(opts.slogger, *cfg.MultilineConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.PackConfig != nil:
-		s, err = newPackStage(slogger, *cfg.PackConfig, registerer)
+		s, err = newPackStage(opts.slogger, *cfg.PackConfig, opts.registerer)
 		if err != nil {
 			return nil, err
 		}
@@ -186,7 +195,7 @@ func newStageWithNextFn(
 			return nil, err
 		}
 	case cfg.GeoIPConfig != nil:
-		s, err = newGeoIPStage(slogger, *cfg.GeoIPConfig)
+		s, err = newGeoIPStage(opts.slogger, *cfg.GeoIPConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -196,23 +205,23 @@ func newStageWithNextFn(
 			return nil, err
 		}
 	case cfg.SamplingConfig != nil:
-		s, err = newSamplingStage(slogger, *cfg.SamplingConfig, registerer)
+		s, err = newSamplingStage(opts.slogger, *cfg.SamplingConfig, opts.registerer)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.EventLogMessageConfig != nil:
-		s = newEventLogMessageStage(slogger, cfg.EventLogMessageConfig)
+		s = newEventLogMessageStage(opts.slogger, cfg.EventLogMessageConfig)
 	case cfg.WindowsEventConfig != nil:
-		s = newWindowsEventStage(slogger, cfg.WindowsEventConfig)
+		s = newWindowsEventStage(opts.slogger, cfg.WindowsEventConfig)
 	case cfg.PatternConfig != nil:
-		s, err = newPatternStage(slogger, *cfg.PatternConfig)
+		s, err = newPatternStage(opts.slogger, *cfg.PatternConfig)
 		if err != nil {
 			return nil, err
 		}
 	case cfg.TruncateConfig != nil:
-		s = newTruncateStage(slogger, *cfg.TruncateConfig, registerer)
+		s = newTruncateStage(opts.slogger, *cfg.TruncateConfig, opts.registerer)
 	case cfg.SplitJSONConfig != nil:
-		s = newSplitJSONStage(slogger, *cfg.SplitJSONConfig)
+		s = newSplitJSONStage(opts.slogger, *cfg.SplitJSONConfig)
 	default:
 		panic(fmt.Sprintf("unreachable; should have decoded into one of the StageConfig fields: %+v", cfg))
 	}


### PR DESCRIPTION
### Brief description of Pull Request

Builds on #6913. Four commits, one line each:

- [`daf510e1`](https://github.com/grafana/alloy/pull/7025/commits/daf510e19) Add benchmarks for the cri stage `process` path.
- [`7573d408`](https://github.com/grafana/alloy/pull/7025/commits/7573d408b) Move the cri partial line map behind a `partialLineStore` type that owns its own locking.
- [`e2a77856`](https://github.com/grafana/alloy/pull/7025/commits/e2a77856c) Replace the store's single mutex with 16 lock stripes and check the flush limit once per batch instead of once per entry.
- [`51564585`](https://github.com/grafana/alloy/pull/7025/commits/515645856) Update the cri stage tests for the new flush timing.

#### Benchmarks

`benchstat` of this branch against the base in #6913, 10 runs each. Apple M2, `darwin/arm64`, `GOMAXPROCS=8`.

The `Concurrent` benchmarks run 10 goroutines calling `process` in parallel on
disjoint stream fingerprints. `NoFlush` uses the default `max_partial_lines` of
100 and never trips the limit.

```
                                      │  base  │            this branch             │
                                      │ sec/op │   sec/op     vs base               │
CRIStageProcessHappyPath-8              157.2µ ± 6%   157.7µ ±  6%       ~ (p=0.579)
CRIStageProcessMaxPartialLinesFlush-8   171.8µ ± 4%   154.2µ ±  4%  -10.21% (p=0.000)
CRIStageProcessConcurrent-8            166.51µ ± 3%   98.61µ ±  3%  -40.78% (p=0.000)
CRIStageProcessConcurrentNoFlush-8     156.29µ ± 6%   46.50µ ± 24%  -70.25% (p=0.000)
geomean                                 162.8µ        102.8µ        -36.88%

                                      │  B/op  │
CRIStageProcessHappyPath-8             68.56Ki ± 0%   68.56Ki ± 0%       ~ (p=0.875)
CRIStageProcessMaxPartialLinesFlush-8 166.92Ki ± 0%   65.19Ki ± 0%  -60.94% (p=0.000)
CRIStageProcessConcurrent-8            96.22Ki ± 0%   50.38Ki ± 2%  -47.64% (p=0.000)
CRIStageProcessConcurrentNoFlush-8     34.80Ki ± 0%   34.80Ki ± 0%   +0.01% (p=0.018)
geomean                                78.68Ki        52.91Ki       -32.75%

                                      │ allocs/op │
CRIStageProcessHappyPath-8               1.725k ± 0%  1.725k ± 0%       ~ (p=1.000)
CRIStageProcessMaxPartialLinesFlush-8    1.541k ± 0%  1.501k ± 0%  -2.60% (p=0.000)
CRIStageProcessConcurrent-8              1.320k ± 0%  1.311k ± 0%  -0.68% (p=0.001)
CRIStageProcessConcurrentNoFlush-8       1.350k ± 0%  1.350k ± 0%       ~ (p=1.000)
geomean                                  1.475k       1.463k       -0.83%
```

Striping measured on its own, same `cri.go` on both sides so only the store
implementation differs:

```
                                    │ single mutex │            16 stripes            │
                                    │    sec/op    │    sec/op     vs base            │
PartialLineStoreConcurrent-8           33.01µ ± 2%   17.21µ ±  7%  -47.86% (p=0.000)
PartialLineStoreConcurrentNoFlush-8    31.56µ ± 2%   14.83µ ± 14%  -53.02% (p=0.000)
PartialLineStoreSerial-8               849.2n ± 3%   744.8n ±  2%  -12.30% (p=0.000)
geomean                                9.599µ        5.749µ        -40.11%
```

### Pull Request Details

<!-- HUMAN ONLY: Motivations, trade-offs, and decisions. Write in your own words. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Write in your own words. -->


### PR Checklist

<!-- HUMAN ONLY: Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
