### PR TITLE
feat(otelcol.exporter.clickhouse): Add native ClickHouse exporter component

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -151,8 +151,8 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/BobuSumisu/aho-corasick v1.0.3 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
-	github.com/ClickHouse/ch-go v0.71.0 // indirect
-	github.com/ClickHouse/clickhouse-go/v2 v2.43.0 // indirect
+	github.com/ClickHouse/ch-go v0.73.0 // indirect
+	github.com/ClickHouse/clickhouse-go/v2 v2.47.0 // indirect
 	github.com/Code-Hex/go-generics-cache v1.5.1 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.205 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.80.2 // indirect
@@ -703,6 +703,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/oliver006/redis_exporter v1.86.0 // indirect
 	github.com/open-telemetry/opamp-go v0.23.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.158.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.158.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.158.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.158.0 // indirect
@@ -773,7 +774,7 @@ require (
 	github.com/ovh/go-ovh v1.9.0 // indirect
 	github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
-	github.com/paulmach/orb v0.12.0 // indirect
+	github.com/paulmach/orb v0.13.0 // indirect
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/libopenapi v0.37.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
@@ -885,8 +886,8 @@ require (
 	github.com/tilinna/clock v1.1.0 // indirect
 	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/tjhop/slog-gokit v0.1.6 // indirect
-	github.com/tklauser/go-sysconf v0.3.16 // indirect
-	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/tklauser/go-sysconf v0.4.0 // indirect
+	github.com/tklauser/numcpus v0.12.0 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/twmb/franz-go v1.21.5 // indirect
 	github.com/twmb/franz-go/pkg/kadm v1.18.0 // indirect

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -151,8 +151,8 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/BobuSumisu/aho-corasick v1.0.3 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
-	github.com/ClickHouse/ch-go v0.73.0 // indirect
-	github.com/ClickHouse/clickhouse-go/v2 v2.47.0 // indirect
+	github.com/ClickHouse/ch-go v0.74.0 // indirect
+	github.com/ClickHouse/clickhouse-go/v2 v2.48.0 // indirect
 	github.com/Code-Hex/go-generics-cache v1.5.1 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.205 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.80.2 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -155,10 +155,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoyRM=
-github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
-github.com/ClickHouse/clickhouse-go/v2 v2.43.0 h1:fUR05TrF1GyvLDa/mAQjkx7KbgwdLRffs2n9O3WobtE=
-github.com/ClickHouse/clickhouse-go/v2 v2.43.0/go.mod h1:o6jf7JM/zveWC/PP277BLxjHy5KjnGX/jfljhM4s34g=
+github.com/ClickHouse/ch-go v0.73.0 h1:jsHiGRbQ3sz+gekvDFJF29LWDo5dzbJm5s1h8TWVP2M=
+github.com/ClickHouse/ch-go v0.73.0/go.mod h1:wkFIxrqlXeRJ9cn3r5Fz5Qen9jl5aTMPuGZeuJpANNY=
+github.com/ClickHouse/clickhouse-go/v2 v2.47.0 h1:ZDAzrnKSOPTIsm4tdUNfrii2yc8dk4SVRLC77BR7Z5Q=
+github.com/ClickHouse/clickhouse-go/v2 v2.47.0/go.mod h1:sPj7C7UYQ2MWHcfX+4eGN6nwnCqwUKfgO6PcwKpd6K8=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
@@ -1090,7 +1090,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -1502,7 +1501,6 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
@@ -1700,7 +1698,6 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/mongodb/mongo-tools v0.0.0-20250715155915-887641268977 h1:J9wFLko0N7sbovyHahuRw1NyfMUsNhaauLK87wQ3ruc=
 github.com/mongodb/mongo-tools v0.0.0-20250715155915-887641268977/go.mod h1:LnygXPEsw45G6DSmJmA9pLaNBXL8GblrFlKiSY3YNyY=
-github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.1.0 h1:vBBl0pUnvi/Je71dsRrhMBtreIqNMYErSAbEeb8jrXQ=
@@ -1766,6 +1763,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsc
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.158.0/go.mod h1:jU+ZE6ds9ZMoHwy9lHmEQyHurq14JS03rb2IaJftIVI=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.158.0 h1:Xf3lCHxj7EFp63t9vcP9Vz6iBdntvQKCJKo1hpv25P4=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.158.0/go.mod h1:+8xkle4PgBgQC2BCzgjot9cOsdH7ieE54Bd/e1vLFZY=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.158.0 h1:Y8SBHs0drTB9uVYKa0i/YaGQjqfodbriixJCiEbYWzo=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.158.0/go.mod h1:uc/Yf15lW0EH21bpsiL/5R/RItylTLdsK6rtoRtF9F8=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.158.0 h1:BnL1TvGDZoccD6IpOLxc7VyWV4JIDRvVI7P6i8RrUaY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.158.0/go.mod h1:WIYmZB+ywAh+ao1rFNiGyovQ3BKDfNtNiO1bKNmjnHo=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter v0.158.0 h1:SLJrMQ0KOW+7YiUTFIg6XZVvgdwmKEnJ2vM1cXQw6CI=
@@ -2044,9 +2043,8 @@ github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0Mw
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
-github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
-github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
-github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=
+github.com/paulmach/orb v0.13.0 h1:r7n7mQGGF+cj/CbcivEj9J3HGK+XR+yXnvzRdq9saIw=
+github.com/paulmach/orb v0.13.0/go.mod h1:6scRWINywA2Jf05dcjOfLfxrUIMECvTSG2MVbRLxu/k=
 github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=
 github.com/pb33f/jsonpath v0.8.2/go.mod h1:zBV5LJW4OQOPatmQE2QdKpGQJvhDTlE5IEj6ASaRNTo=
 github.com/pb33f/libopenapi v0.37.2 h1:4Kb4w/h2BVKb099oYIZqeDxEBhUioWA+z6WJhBOk2r8=
@@ -2382,7 +2380,6 @@ github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4s
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/match v1.2.0 h1:0pt8FlkOwjN2fPt4bIl4BoNxb98gGHN2ObFEDkrfZnM=
 github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
@@ -2399,11 +2396,11 @@ github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77ro
 github.com/tjhop/slog-gokit v0.1.6 h1:aRNB5omFUPs/5k40Ao1s7aBZHaKhNNu1JLc9ukF0qBg=
 github.com/tjhop/slog-gokit v0.1.6/go.mod h1:yA48zAHvV+Sg4z4VRyeFyFUNNXd3JY5Zg84u3USICq0=
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
-github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
-github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
+github.com/tklauser/go-sysconf v0.4.0 h1:7H0uAN+7RkwWRaxhYXDLqa5V3LPrJeV8wmD9dRUgPQU=
+github.com/tklauser/go-sysconf v0.4.0/go.mod h1:8mTNWyog7H+MpKijp4VmKJAd2bbYQ2zuUwkYRbUArPI=
 github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
-github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
-github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/tklauser/numcpus v0.12.0 h1:NR85qdvHA9pFse3x3weVZ0r0ST8R6l5RHbZrlRaqob4=
+github.com/tklauser/numcpus v0.12.0/go.mod h1:ABHeXzJnr/qqwguhClkZKT1/8VABcYrsyUiUGobwWJg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
@@ -2471,10 +2468,8 @@ github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
-github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/scram v1.2.0 h1:bYKF2AEwG5rqd1BumT4gAnvwU/M9nBp2pTSxeZw7Wvs=
 github.com/xdg-go/scram v1.2.0/go.mod h1:3dlrS0iBaWKYVt2ZfA4cj48umJZ+cAEbR6/SjLA88I8=
-github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/xdg/scram v1.0.5 h1:TuS0RFmt5Is5qm9Tm2SoD89OPqe4IRiFtyFY4iwWXsw=
@@ -2497,7 +2492,6 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
-github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -2528,7 +2522,6 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.12 h1:36zzB+pQOdHbhN+kH2iJz/K8bJn0ZLtLfPPO7jo
 go.etcd.io/etcd/client/pkg/v3 v3.6.12/go.mod h1:hh2+ZXtfLzs3o6mn92ntgNPBrTJJOvXqICM5g3L3DMY=
 go.etcd.io/etcd/client/v3 v3.6.12 h1:kMSP6JcPZMqSJiX+TXdUIBU/4eXEZWBAaui4VihMbIc=
 go.etcd.io/etcd/client/v3 v3.6.12/go.mod h1:CMs6fJWYiZQk4ytFjd4lE1diOvvRMmtbbn/alZXd3dQ=
-go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
 go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -3291,7 +3284,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -155,10 +155,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ClickHouse/ch-go v0.73.0 h1:jsHiGRbQ3sz+gekvDFJF29LWDo5dzbJm5s1h8TWVP2M=
-github.com/ClickHouse/ch-go v0.73.0/go.mod h1:wkFIxrqlXeRJ9cn3r5Fz5Qen9jl5aTMPuGZeuJpANNY=
-github.com/ClickHouse/clickhouse-go/v2 v2.47.0 h1:ZDAzrnKSOPTIsm4tdUNfrii2yc8dk4SVRLC77BR7Z5Q=
-github.com/ClickHouse/clickhouse-go/v2 v2.47.0/go.mod h1:sPj7C7UYQ2MWHcfX+4eGN6nwnCqwUKfgO6PcwKpd6K8=
+github.com/ClickHouse/ch-go v0.74.0 h1:uYs2m4wIt0ZHSM1E72rg0maCfzhR2V3xWb/vZEgpeWE=
+github.com/ClickHouse/ch-go v0.74.0/go.mod h1:sZ/r+8ttZMjyrP9PuFbgoVbth1ywIu2LIQNA2vgko6M=
+github.com/ClickHouse/clickhouse-go/v2 v2.48.0 h1:auzd4VkapQYhQF8F2Gog7s3x78Bi1JZmByxGbrw3C+4=
+github.com/ClickHouse/clickhouse-go/v2 v2.48.0/go.mod h1:lBjUCPRG6RpRQdMbkXq+JV8rY0/O5lw+Z7jShgReFjM=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.clickhouse.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.clickhouse.md
@@ -1,0 +1,203 @@
+---
+canonical: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.clickhouse/
+description: Learn about otelcol.exporter.clickhouse
+aliases:
+  - ../otelcol.exporter.clickhouse/ # /docs/alloy/latest/reference/components/otelcol.exporter.clickhouse/
+labels:
+  products:
+    - oss
+  tags:
+    - text: Community
+      tooltip: This component is developed, maintained, and supported by the Alloy user community.
+title: otelcol.exporter.clickhouse
+---
+
+# `otelcol.exporter.clickhouse`
+
+{{< docs/shared lookup="stability/community.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+`otelcol.exporter.clickhouse` accepts metrics, logs, and traces telemetry data from other `otelcol` components and writes them to a [ClickHouse](https://clickhouse.com/) database over its native TCP protocol.
+
+{{< admonition type="note" >}}
+`otelcol.exporter.clickhouse` is a wrapper over the upstream OpenTelemetry Collector [`clickhouse`][] exporter.
+Bug reports or feature requests will be redirected to the upstream repository, if necessary.
+
+[`clickhouse`]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/{{< param "OTEL_VERSION" >}}/exporter/clickhouseexporter
+{{< /admonition >}}
+
+You can specify multiple `otelcol.exporter.clickhouse` components by giving them different labels.
+
+## Usage
+
+```alloy
+otelcol.exporter.clickhouse "<LABEL>" {
+    endpoint = "tcp://<CLICKHOUSE_HOST>:9000"
+}
+```
+
+## Arguments
+
+You can use the following arguments with `otelcol.exporter.clickhouse`:
+
+| Name                  | Type          | Description                                                                                     | Default            | Required |
+|-----------------------|---------------|---------------------------------------------------------------------------------------------------|---------------------|----------|
+| `endpoint`            | `string`      | The ClickHouse server DSN, for example `tcp://localhost:9000` or `clickhouse://localhost:9000`. |                     | yes      |
+| `async_insert`        | `bool`        | Enable asynchronous inserts. Ignored if async inserts are already configured in `endpoint` or `connection_params`. | `true`              | no       |
+| `cluster_name`        | `string`      | If set, appends `ON CLUSTER` with the given name when creating tables.                          | `""`                | no       |
+| `compress`            | `string`      | Compression algorithm to use. Valid values are `none`, `zstd`, `lz4`, `gzip`, `deflate`, and `br`. | `"lz4"`             | no       |
+| `connection_params`   | `map(string)` | Extra connection parameters, for example `compression` or `dial_timeout`.                       | `{}`                | no       |
+| `create_schema`       | `bool`        | Run the DDL to create the database and tables if they don't already exist.                      | `true`              | no       |
+| `database`            | `string`      | The database to export to.                                                                       | `"default"`         | no       |
+| `logs_table_name`     | `string`      | The table name used for logs.                                                                    | `"otel_logs"`       | no       |
+| `metrics_table_name`  | `string`      | The base table name used for metrics, before the per-metric-type suffix.                        | `"otel_metrics"`    | no       |
+| `password`            | `secret`      | The password used to authenticate to ClickHouse.                                                | `""`                | no       |
+| `timeout`             | `duration`    | The timeout for every attempt to send data to ClickHouse. `0` means no timeout.                 | `"0s"`              | no       |
+| `traces_table_name`   | `string`      | The table name used for traces.                                                                 | `"otel_traces"`     | no       |
+| `ttl`                 | `duration`    | The time-to-live for inserted data, for example `48h`. `0` means no TTL.                        | `"0s"`              | no       |
+| `username`            | `string`      | The username used to authenticate to ClickHouse.                                                | `""`                | no       |
+
+If `username` is set, it overrides any username in `endpoint`.
+If `password` is set, it overrides any password in `endpoint`.
+
+## Blocks
+
+You can use the following blocks with `otelcol.exporter.clickhouse`:
+
+{{< docs/alloy-config >}}
+
+| Block                                   | Description                                                                    | Required |
+|------------------------------------------|--------------------------------------------------------------------------------|----------|
+| [`debug_metrics`][debug_metrics]         | Configures the metrics that this component generates to monitor its state.     | no       |
+| [`metrics_tables`][metrics_tables]       | Configures per-metric-type table name overrides.                              | no       |
+| metrics_tables > [`gauge`][metric_type]  | Table name override for gauge metrics.                                        | no       |
+| metrics_tables > [`sum`][metric_type]    | Table name override for sum metrics.                                          | no       |
+| metrics_tables > [`summary`][metric_type]| Table name override for summary metrics.                                      | no       |
+| metrics_tables > [`histogram`][metric_type] | Table name override for histogram metrics.                                 | no       |
+| metrics_tables > [`exponential_histogram`][metric_type] | Table name override for exponential histogram metrics.         | no       |
+| [`retry_on_failure`][retry_on_failure]   | Configures retry mechanism for failed requests.                               | no       |
+| [`sending_queue`][queue]                 | Configures batching of data before sending.                                   | no       |
+| `sending_queue` > [`batch`][batch]       | Configures batching requests based on a timeout and a minimum number of items.| no       |
+| [`table_engine`][table_engine]           | Configures the ClickHouse table `ENGINE` clause used when creating tables.     | no       |
+| [`tls`][tls]                             | Configures TLS for the connection to ClickHouse.                              | no       |
+
+[batch]: #batch
+[debug_metrics]: #debug_metrics
+[metric_type]: #gauge-sum-summary-histogram-and-exponential_histogram
+[metrics_tables]: #metrics_tables
+[queue]: #sending_queue
+[retry_on_failure]: #retry_on_failure
+[table_engine]: #table_engine
+[tls]: #tls
+
+{{< /docs/alloy-config >}}
+
+### `debug_metrics`
+
+{{< docs/shared lookup="reference/components/otelcol-debug-metrics-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `metrics_tables`
+
+The `metrics_tables` block configures table name overrides for each metric type.
+If a sub-block is omitted, its table name defaults to `metrics_table_name` plus a type-specific suffix, for example `otel_metrics_gauge`.
+
+### `gauge`, `sum`, `summary`, `histogram`, and `exponential_histogram`
+
+Each of these blocks accepts a single argument:
+
+| Name   | Type     | Description                          | Default | Required |
+|--------|----------|---------------------------------------|---------|----------|
+| `name` | `string` | The table name for this metric type. |         | no       |
+
+### `retry_on_failure`
+
+The `retry_on_failure` block configures how failed requests to ClickHouse are retried.
+
+{{< docs/shared lookup="reference/components/otelcol-retry-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `sending_queue`
+
+The `sending_queue` block configures queueing and batching for the exporter.
+
+{{< docs/shared lookup="reference/components/otelcol-queue-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `batch`
+
+The `batch` block configures batching requests based on a timeout and a minimum number of items.
+
+{{< docs/shared lookup="reference/components/otelcol-queue-batch-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+### `table_engine`
+
+The `table_engine` block configures the `ENGINE` clause used when `create_schema` creates ClickHouse tables.
+
+| Name     | Type     | Description                                     | Default       | Required |
+|----------|----------|--------------------------------------------------|---------------|----------|
+| `name`   | `string` | The table engine name, for example `MergeTree` or `ReplicatedMergeTree`. | `"MergeTree"` | no       |
+| `params` | `string` | Raw parameters passed to the engine, for example replication path and replica name arguments. | `""`          | no       |
+
+### `tls`
+
+The `tls` block configures TLS for the connection to ClickHouse.
+
+{{< docs/shared lookup="reference/components/otelcol-tls-client-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
+
+## Exported fields
+
+The following fields are exported and can be referenced by other components:
+
+| Name    | Type               | Description                                                 |
+|---------|--------------------|-------------------------------------------------------------|
+| `input` | `otelcol.Consumer` | A value other components can use to send telemetry data to. |
+
+`input` accepts `otelcol.Consumer` data for any telemetry signal (metrics, logs, or traces).
+
+## Component health
+
+`otelcol.exporter.clickhouse` is only reported as unhealthy if given an invalid configuration.
+
+## Debug information
+
+`otelcol.exporter.clickhouse` doesn't expose any component-specific debug information.
+
+## Example
+
+This example scrapes Prometheus metrics and exports them to ClickHouse, using a non-default database and a one-week TTL:
+
+```alloy
+prometheus.exporter.self "default" {
+}
+
+prometheus.scrape "metamonitoring" {
+  targets    = prometheus.exporter.self.default.targets
+  forward_to = [otelcol.receiver.prometheus.default.receiver]
+}
+
+otelcol.receiver.prometheus "default" {
+  output {
+    metrics = [otelcol.exporter.clickhouse.default.input]
+  }
+}
+
+otelcol.exporter.clickhouse "default" {
+    endpoint = "tcp://clickhouse.clickhouse.svc.cluster.local:9000"
+    username = "default"
+    password = "<CLICKHOUSE_PASSWORD>"
+    database = "metrics"
+    ttl      = "168h"
+}
+```
+
+<!-- START GENERATED COMPATIBLE COMPONENTS -->
+
+## Compatible components
+
+`otelcol.exporter.clickhouse` has exports that can be consumed by the following components:
+
+- Components that consume [OpenTelemetry `otelcol.Consumer`](../../../compatibility/#opentelemetry-otelcolconsumer-consumers)
+
+{{< admonition type="note" >}}
+Connecting some components may not be sensible or components may require further configuration to make the connection work correctly.
+Refer to the linked documentation for more details.
+{{< /admonition >}}
+
+<!-- END GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/reference/components/otelcol/otelcol.exporter.clickhouse.md
+++ b/docs/sources/reference/components/otelcol/otelcol.exporter.clickhouse.md
@@ -59,6 +59,17 @@ You can use the following arguments with `otelcol.exporter.clickhouse`:
 If `username` is set, it overrides any username in `endpoint`.
 If `password` is set, it overrides any password in `endpoint`.
 
+{{< admonition type="note" >}}
+Combining `create_schema = true` with `cluster_name` runs a `CREATE TABLE
+... ON CLUSTER` DDL statement. As of `clickhouse-go/v2` v2.47.0, the driver
+can fail to parse ClickHouse's multi-host status response to this kind of
+distributed DDL, causing schema creation to fail with an `unexpected EOF`
+error even though the tables are actually created successfully. If you hit
+this, create the schema once manually (for example with `clickhouse-client`)
+and set `create_schema = false` — the exporter only runs `INSERT`s at
+runtime, which aren't affected.
+{{< /admonition >}}
+
 ## Blocks
 
 You can use the following blocks with `otelcol.exporter.clickhouse`:

--- a/go.mod
+++ b/go.mod
@@ -825,8 +825,8 @@ require (
 	github.com/tidwall/wal v1.2.1 // indirect
 	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/tjhop/slog-gokit v0.1.6 // indirect
-	github.com/tklauser/go-sysconf v0.3.16 // indirect
-	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/tklauser/go-sysconf v0.4.0 // indirect
+	github.com/tklauser/numcpus v0.12.0 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/twmb/franz-go v1.21.5 // indirect
 	github.com/twmb/franz-go/pkg/kadm v1.18.0 // indirect
@@ -867,7 +867,7 @@ require (
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.158.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.158.0 // indirect
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.158.0 // indirect
-	go.opentelemetry.io/collector/exporter/exportertest v0.158.0 // indirect
+	go.opentelemetry.io/collector/exporter/exportertest v0.158.0
 	go.opentelemetry.io/collector/exporter/xexporter v0.158.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.158.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.158.0 // indirect
@@ -956,6 +956,7 @@ require (
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector v0.158.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/splunk v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.158.0
@@ -967,14 +968,14 @@ require (
 
 require (
 	cloud.google.com/go/secretmanager v1.20.0 // indirect
-	github.com/ClickHouse/ch-go v0.71.0 // indirect
-	github.com/ClickHouse/clickhouse-go/v2 v2.43.0 // indirect
+	github.com/ClickHouse/ch-go v0.73.0 // indirect
+	github.com/ClickHouse/clickhouse-go/v2 v2.47.0
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/nginx/nginx-prometheus-exporter v1.5.1 // indirect
-	github.com/paulmach/orb v0.12.0 // indirect
+	github.com/paulmach/orb v0.13.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sethvargo/go-envconfig v1.3.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -968,8 +968,8 @@ require (
 
 require (
 	cloud.google.com/go/secretmanager v1.20.0 // indirect
-	github.com/ClickHouse/ch-go v0.73.0 // indirect
-	github.com/ClickHouse/clickhouse-go/v2 v2.47.0
+	github.com/ClickHouse/ch-go v0.74.0 // indirect
+	github.com/ClickHouse/clickhouse-go/v2 v2.48.0
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/jackc/pgx/v5 v5.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -157,10 +157,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoyRM=
-github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
-github.com/ClickHouse/clickhouse-go/v2 v2.43.0 h1:fUR05TrF1GyvLDa/mAQjkx7KbgwdLRffs2n9O3WobtE=
-github.com/ClickHouse/clickhouse-go/v2 v2.43.0/go.mod h1:o6jf7JM/zveWC/PP277BLxjHy5KjnGX/jfljhM4s34g=
+github.com/ClickHouse/ch-go v0.73.0 h1:jsHiGRbQ3sz+gekvDFJF29LWDo5dzbJm5s1h8TWVP2M=
+github.com/ClickHouse/ch-go v0.73.0/go.mod h1:wkFIxrqlXeRJ9cn3r5Fz5Qen9jl5aTMPuGZeuJpANNY=
+github.com/ClickHouse/clickhouse-go/v2 v2.47.0 h1:ZDAzrnKSOPTIsm4tdUNfrii2yc8dk4SVRLC77BR7Z5Q=
+github.com/ClickHouse/clickhouse-go/v2 v2.47.0/go.mod h1:sPj7C7UYQ2MWHcfX+4eGN6nwnCqwUKfgO6PcwKpd6K8=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
@@ -1560,7 +1560,6 @@ github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCy
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
@@ -1755,7 +1754,6 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/mongodb/mongo-tools v0.0.0-20250715155915-887641268977 h1:J9wFLko0N7sbovyHahuRw1NyfMUsNhaauLK87wQ3ruc=
 github.com/mongodb/mongo-tools v0.0.0-20250715155915-887641268977/go.mod h1:LnygXPEsw45G6DSmJmA9pLaNBXL8GblrFlKiSY3YNyY=
-github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.1.0 h1:vBBl0pUnvi/Je71dsRrhMBtreIqNMYErSAbEeb8jrXQ=
@@ -1822,6 +1820,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsc
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.158.0/go.mod h1:jU+ZE6ds9ZMoHwy9lHmEQyHurq14JS03rb2IaJftIVI=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.158.0 h1:Xf3lCHxj7EFp63t9vcP9Vz6iBdntvQKCJKo1hpv25P4=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.158.0/go.mod h1:+8xkle4PgBgQC2BCzgjot9cOsdH7ieE54Bd/e1vLFZY=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.158.0 h1:Y8SBHs0drTB9uVYKa0i/YaGQjqfodbriixJCiEbYWzo=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.158.0/go.mod h1:uc/Yf15lW0EH21bpsiL/5R/RItylTLdsK6rtoRtF9F8=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.158.0 h1:BnL1TvGDZoccD6IpOLxc7VyWV4JIDRvVI7P6i8RrUaY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.158.0/go.mod h1:WIYmZB+ywAh+ao1rFNiGyovQ3BKDfNtNiO1bKNmjnHo=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter v0.158.0 h1:SLJrMQ0KOW+7YiUTFIg6XZVvgdwmKEnJ2vM1cXQw6CI=
@@ -2059,9 +2059,8 @@ github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0Mw
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
-github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
-github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
-github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=
+github.com/paulmach/orb v0.13.0 h1:r7n7mQGGF+cj/CbcivEj9J3HGK+XR+yXnvzRdq9saIw=
+github.com/paulmach/orb v0.13.0/go.mod h1:6scRWINywA2Jf05dcjOfLfxrUIMECvTSG2MVbRLxu/k=
 github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=
 github.com/pb33f/jsonpath v0.8.2/go.mod h1:zBV5LJW4OQOPatmQE2QdKpGQJvhDTlE5IEj6ASaRNTo=
 github.com/pb33f/libopenapi v0.37.2 h1:4Kb4w/h2BVKb099oYIZqeDxEBhUioWA+z6WJhBOk2r8=
@@ -2397,7 +2396,6 @@ github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4s
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/match v1.2.0 h1:0pt8FlkOwjN2fPt4bIl4BoNxb98gGHN2ObFEDkrfZnM=
 github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
@@ -2414,11 +2412,11 @@ github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77ro
 github.com/tjhop/slog-gokit v0.1.6 h1:aRNB5omFUPs/5k40Ao1s7aBZHaKhNNu1JLc9ukF0qBg=
 github.com/tjhop/slog-gokit v0.1.6/go.mod h1:yA48zAHvV+Sg4z4VRyeFyFUNNXd3JY5Zg84u3USICq0=
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
-github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
-github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
+github.com/tklauser/go-sysconf v0.4.0 h1:7H0uAN+7RkwWRaxhYXDLqa5V3LPrJeV8wmD9dRUgPQU=
+github.com/tklauser/go-sysconf v0.4.0/go.mod h1:8mTNWyog7H+MpKijp4VmKJAd2bbYQ2zuUwkYRbUArPI=
 github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
-github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
-github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/tklauser/numcpus v0.12.0 h1:NR85qdvHA9pFse3x3weVZ0r0ST8R6l5RHbZrlRaqob4=
+github.com/tklauser/numcpus v0.12.0/go.mod h1:ABHeXzJnr/qqwguhClkZKT1/8VABcYrsyUiUGobwWJg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
@@ -2488,10 +2486,8 @@ github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
-github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/scram v1.2.0 h1:bYKF2AEwG5rqd1BumT4gAnvwU/M9nBp2pTSxeZw7Wvs=
 github.com/xdg-go/scram v1.2.0/go.mod h1:3dlrS0iBaWKYVt2ZfA4cj48umJZ+cAEbR6/SjLA88I8=
-github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/xdg/scram v1.0.5 h1:TuS0RFmt5Is5qm9Tm2SoD89OPqe4IRiFtyFY4iwWXsw=
@@ -2515,7 +2511,6 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
-github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -2549,7 +2544,6 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.12/go.mod h1:hh2+ZXtfLzs3o6mn92ntgNPBrTJJOvXq
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
 go.etcd.io/etcd/client/v3 v3.6.12 h1:kMSP6JcPZMqSJiX+TXdUIBU/4eXEZWBAaui4VihMbIc=
 go.etcd.io/etcd/client/v3 v3.6.12/go.mod h1:CMs6fJWYiZQk4ytFjd4lE1diOvvRMmtbbn/alZXd3dQ=
-go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
 go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -3314,7 +3308,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/go.sum
+++ b/go.sum
@@ -157,10 +157,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ClickHouse/ch-go v0.73.0 h1:jsHiGRbQ3sz+gekvDFJF29LWDo5dzbJm5s1h8TWVP2M=
-github.com/ClickHouse/ch-go v0.73.0/go.mod h1:wkFIxrqlXeRJ9cn3r5Fz5Qen9jl5aTMPuGZeuJpANNY=
-github.com/ClickHouse/clickhouse-go/v2 v2.47.0 h1:ZDAzrnKSOPTIsm4tdUNfrii2yc8dk4SVRLC77BR7Z5Q=
-github.com/ClickHouse/clickhouse-go/v2 v2.47.0/go.mod h1:sPj7C7UYQ2MWHcfX+4eGN6nwnCqwUKfgO6PcwKpd6K8=
+github.com/ClickHouse/ch-go v0.74.0 h1:uYs2m4wIt0ZHSM1E72rg0maCfzhR2V3xWb/vZEgpeWE=
+github.com/ClickHouse/ch-go v0.74.0/go.mod h1:sZ/r+8ttZMjyrP9PuFbgoVbth1ywIu2LIQNA2vgko6M=
+github.com/ClickHouse/clickhouse-go/v2 v2.48.0 h1:auzd4VkapQYhQF8F2Gog7s3x78Bi1JZmByxGbrw3C+4=
+github.com/ClickHouse/clickhouse-go/v2 v2.48.0/go.mod h1:lBjUCPRG6RpRQdMbkXq+JV8rY0/O5lw+Z7jShgReFjM=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=

--- a/internal/component/all/all.go
+++ b/internal/component/all/all.go
@@ -77,6 +77,7 @@ import (
 	_ "github.com/grafana/alloy/internal/component/otelcol/connector/spanlogs"               // Import otelcol.connector.spanlogs
 	_ "github.com/grafana/alloy/internal/component/otelcol/connector/spanmetrics"            // Import otelcol.connector.spanmetrics
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/awss3"                   // Import otelcol.exporter.awss3exporter
+	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/clickhouse"              // Import otelcol.exporter.clickhouse
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/datadog"                 // Import otelcol.exporter.datadog
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/debug"                   // Import otelcol.exporter.debug
 	_ "github.com/grafana/alloy/internal/component/otelcol/exporter/faro"                    // Import otelcol.exporter.faro

--- a/internal/component/otelcol/exporter/clickhouse/clickhouse.go
+++ b/internal/component/otelcol/exporter/clickhouse/clickhouse.go
@@ -1,0 +1,168 @@
+// Package clickhouse provides an otelcol.exporter.clickhouse component.
+package clickhouse
+
+import (
+	"errors"
+	"time"
+
+	"github.com/grafana/alloy/internal/component"
+	"github.com/grafana/alloy/internal/component/otelcol"
+	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
+	"github.com/grafana/alloy/internal/component/otelcol/exporter"
+	"github.com/grafana/alloy/syntax/alloytypes"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter"
+	otelcomponent "go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/pipeline"
+)
+
+func init() {
+	component.Register(component.Registration{
+		Name:      "otelcol.exporter.clickhouse",
+		Community: true,
+		Args:      Arguments{},
+		Exports:   otelcol.ConsumerExports{},
+
+		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
+			fact := clickhouseexporter.NewFactory()
+			return exporter.New(opts, fact, args.(Arguments), exporter.TypeSignalConstFunc(exporter.TypeAll))
+		},
+	})
+}
+
+// Arguments configures the otelcol.exporter.clickhouse component.
+type Arguments struct {
+	// Endpoint is the ClickHouse DSN, e.g. "tcp://localhost:9000" or "clickhouse://localhost:9000".
+	Endpoint         string            `alloy:"endpoint,attr"`
+	Username         string            `alloy:"username,attr,optional"`
+	Password         alloytypes.Secret `alloy:"password,attr,optional"`
+	Database         string            `alloy:"database,attr,optional"`
+	ConnectionParams map[string]string `alloy:"connection_params,attr,optional"`
+
+	TLS otelcol.TLSClientArguments `alloy:"tls,block,optional"`
+
+	LogsTableName    string `alloy:"logs_table_name,attr,optional"`
+	TracesTableName  string `alloy:"traces_table_name,attr,optional"`
+	MetricsTableName string `alloy:"metrics_table_name,attr,optional"`
+
+	TTL          time.Duration        `alloy:"ttl,attr,optional"`
+	TableEngine  TableEngineArguments `alloy:"table_engine,block,optional"`
+	ClusterName  string               `alloy:"cluster_name,attr,optional"`
+	CreateSchema bool                 `alloy:"create_schema,attr,optional"`
+	Compress     string               `alloy:"compress,attr,optional"`
+	AsyncInsert  bool                 `alloy:"async_insert,attr,optional"`
+
+	MetricsTables MetricsTablesArguments `alloy:"metrics_tables,block,optional"`
+
+	Timeout time.Duration          `alloy:"timeout,attr,optional"`
+	Retry   otelcol.RetryArguments `alloy:"retry_on_failure,block,optional"`
+	Queue   otelcol.QueueArguments `alloy:"sending_queue,block,optional"`
+
+	// DebugMetrics configures component internal metrics. Optional.
+	DebugMetrics otelcolCfg.DebugMetricsArguments `alloy:"debug_metrics,block,optional"`
+}
+
+// TableEngineArguments configures the ClickHouse table ENGINE clause.
+type TableEngineArguments struct {
+	Name   string `alloy:"name,attr,optional"`
+	Params string `alloy:"params,attr,optional"`
+}
+
+// MetricsTablesArguments configures per-metric-type table names.
+type MetricsTablesArguments struct {
+	Gauge                MetricTypeArguments `alloy:"gauge,block,optional"`
+	Sum                  MetricTypeArguments `alloy:"sum,block,optional"`
+	Summary              MetricTypeArguments `alloy:"summary,block,optional"`
+	Histogram            MetricTypeArguments `alloy:"histogram,block,optional"`
+	ExponentialHistogram MetricTypeArguments `alloy:"exponential_histogram,block,optional"`
+}
+
+// MetricTypeArguments configures the table name override for one metric type.
+type MetricTypeArguments struct {
+	Name string `alloy:"name,attr,optional"`
+}
+
+var _ exporter.Arguments = Arguments{}
+
+// SetToDefault implements syntax.Defaulter.
+func (args *Arguments) SetToDefault() {
+	*args = Arguments{
+		Database:         "default",
+		ConnectionParams: map[string]string{},
+		LogsTableName:    "otel_logs",
+		TracesTableName:  "otel_traces",
+		MetricsTableName: "otel_metrics",
+		TableEngine:      TableEngineArguments{Name: "MergeTree"},
+		CreateSchema:     true,
+		Compress:         "lz4",
+		AsyncInsert:      true,
+	}
+	args.Retry.SetToDefault()
+	args.Queue.SetToDefault()
+	args.DebugMetrics.SetToDefault()
+}
+
+// Validate implements syntax.Validator.
+func (args *Arguments) Validate() error {
+	if args.Endpoint == "" {
+		return errors.New("endpoint must be specified")
+	}
+	return nil
+}
+
+// Convert implements exporter.Arguments.
+func (args Arguments) Convert() (otelcomponent.Config, error) {
+	q, err := args.Queue.Convert()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &clickhouseexporter.Config{
+		TimeoutSettings:  exporterhelper.TimeoutConfig{Timeout: args.Timeout},
+		BackOffConfig:    *args.Retry.Convert(),
+		QueueSettings:    q,
+		Endpoint:         args.Endpoint,
+		Username:         args.Username,
+		Password:         configopaque.String(args.Password),
+		Database:         args.Database,
+		TLS:              *args.TLS.Convert(),
+		ConnectionParams: args.ConnectionParams,
+		LogsTableName:    args.LogsTableName,
+		TracesTableName:  args.TracesTableName,
+		MetricsTableName: args.MetricsTableName,
+		TTL:              args.TTL,
+		TableEngine: clickhouseexporter.TableEngine{
+			Name:   args.TableEngine.Name,
+			Params: args.TableEngine.Params,
+		},
+		ClusterName:  args.ClusterName,
+		CreateSchema: args.CreateSchema,
+		Compress:     args.Compress,
+		AsyncInsert:  args.AsyncInsert,
+	}
+	// MetricTypeConfig lives in clickhouseexporter's internal/metrics package, so it
+	// can't be named here (Go forbids importing another module's internal packages).
+	// Set the nested fields through selectors instead of a composite literal.
+	cfg.MetricsTables.Gauge.Name = args.MetricsTables.Gauge.Name
+	cfg.MetricsTables.Sum.Name = args.MetricsTables.Sum.Name
+	cfg.MetricsTables.Summary.Name = args.MetricsTables.Summary.Name
+	cfg.MetricsTables.Histogram.Name = args.MetricsTables.Histogram.Name
+	cfg.MetricsTables.ExponentialHistogram.Name = args.MetricsTables.ExponentialHistogram.Name
+	return cfg, nil
+}
+
+// Extensions implements exporter.Arguments.
+func (args Arguments) Extensions() map[otelcomponent.ID]otelcomponent.Component {
+	return args.Queue.Extensions()
+}
+
+// Exporters implements exporter.Arguments.
+func (args Arguments) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelcomponent.Component {
+	return nil
+}
+
+// DebugMetricsConfig implements exporter.Arguments.
+func (args Arguments) DebugMetricsConfig() otelcolCfg.DebugMetricsArguments {
+	return args.DebugMetrics
+}

--- a/internal/component/otelcol/exporter/clickhouse/clickhouse.go
+++ b/internal/component/otelcol/exporter/clickhouse/clickhouse.go
@@ -149,6 +149,15 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 	cfg.MetricsTables.Summary.Name = args.MetricsTables.Summary.Name
 	cfg.MetricsTables.Histogram.Name = args.MetricsTables.Histogram.Name
 	cfg.MetricsTables.ExponentialHistogram.Name = args.MetricsTables.ExponentialHistogram.Name
+
+	// cfg.Validate() backfills any per-metric-type table name left empty
+	// (e.g. "gauge") with clickhouseexporter's own defaults (e.g.
+	// "otel_metrics_gauge") via its internal buildMetricTableNames(). Without
+	// this call, an Arguments value that never set metrics_tables explicitly
+	// would reach the exporter with empty table names and fail at runtime.
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	return cfg, nil
 }
 

--- a/internal/component/otelcol/exporter/clickhouse/clickhouse_integration_test.go
+++ b/internal/component/otelcol/exporter/clickhouse/clickhouse_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package clickhouse_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	chcomponent "github.com/grafana/alloy/internal/component/otelcol/exporter/clickhouse"
+)
+
+// TestIntegration_LogsRoundTrip starts a real ClickHouse container, builds the
+// exporter the same way otelcol.exporter.clickhouse does (Arguments -> Convert
+// -> upstream factory), pushes one log record through it, and confirms the row
+// actually landed in ClickHouse. This is the check that would catch a
+// regression in Convert()'s field mapping that a mocked/absent-ClickHouse unit
+// test can't catch.
+func TestIntegration_LogsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "clickhouse/clickhouse-server:latest",
+			ExposedPorts: []string{"9000/tcp"},
+			// The official image requires CLICKHOUSE_PASSWORD to provision the
+			// default user with a password; without it, native-protocol auth fails.
+			Env:        map[string]string{"CLICKHOUSE_PASSWORD": "otel"},
+			WaitingFor: wait.ForListeningPort("9000/tcp").WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+
+	host, err := ctr.Host(ctx)
+	require.NoError(t, err)
+	port, err := ctr.MappedPort(ctx, "9000")
+	require.NoError(t, err)
+	addr := host + ":" + port.Port()
+
+	var args chcomponent.Arguments
+	args.SetToDefault()
+	args.Endpoint = "tcp://" + addr
+	args.Username = "default"
+	args.Password = "otel"
+	// Disable async_insert so the row is guaranteed visible as soon as
+	// ConsumeLogs returns, instead of depending on the server's flush timing.
+	args.AsyncInsert = false
+	// Disable the sending queue so ConsumeLogs pushes synchronously instead of
+	// enqueueing for a background consumer goroutine to deliver later.
+	args.Queue.Enabled = false
+
+	cfg, err := args.Convert()
+	require.NoError(t, err)
+
+	fact := clickhouseexporter.NewFactory()
+	exp, err := fact.CreateLogs(ctx, exportertest.NewNopSettings(fact.Type()), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exp.Start(ctx, nil))
+	t.Cleanup(func() { _ = exp.Shutdown(ctx) })
+
+	require.NoError(t, exp.ConsumeLogs(ctx, oneLogRecord("hello from otelcol.exporter.clickhouse")))
+
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{addr},
+		Auth: clickhouse.Auth{Username: "default", Password: "otel"},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	var (
+		count uint64
+		body  string
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT count(), any(Body) FROM otel_logs").Scan(&count, &body))
+	require.Equal(t, uint64(1), count)
+	require.Equal(t, "hello from otelcol.exporter.clickhouse", body)
+}
+
+func oneLogRecord(body string) plog.Logs {
+	logs := plog.NewLogs()
+	record := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	record.Body().SetStr(body)
+	record.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	return logs
+}

--- a/internal/component/otelcol/exporter/clickhouse/clickhouse_test.go
+++ b/internal/component/otelcol/exporter/clickhouse/clickhouse_test.go
@@ -1,0 +1,75 @@
+package clickhouse_test
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/component/otelcol/exporter/clickhouse"
+	"github.com/grafana/alloy/syntax"
+)
+
+func TestUnmarshalDefaults(t *testing.T) {
+	var args clickhouse.Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(`endpoint = "tcp://localhost:9000"`), &args))
+
+	require.Equal(t, "tcp://localhost:9000", args.Endpoint)
+	require.Equal(t, "default", args.Database)
+	require.Equal(t, "otel_logs", args.LogsTableName)
+	require.Equal(t, "otel_traces", args.TracesTableName)
+	require.Equal(t, "MergeTree", args.TableEngine.Name)
+	require.True(t, args.CreateSchema)
+	require.Equal(t, "lz4", args.Compress)
+	require.True(t, args.AsyncInsert)
+	require.True(t, args.Queue.Enabled)
+	require.True(t, args.Retry.Enabled)
+}
+
+func TestValidate(t *testing.T) {
+	var args clickhouse.Arguments
+	args.SetToDefault()
+	require.EqualError(t, args.Validate(), "endpoint must be specified")
+
+	args.Endpoint = "tcp://localhost:9000"
+	require.NoError(t, args.Validate())
+}
+
+func TestConvert(t *testing.T) {
+	cfgStr := `
+		endpoint = "tcp://localhost:9000"
+		username = "default"
+		password = "secret"
+		database = "otel"
+		cluster_name = "my_cluster"
+		ttl = "48h"
+
+		table_engine {
+			name   = "ReplicatedMergeTree"
+			params = "'/clickhouse/tables/{shard}/otel_logs', '{replica}'"
+		}
+
+		metrics_tables {
+			gauge {
+				name = "custom_gauge"
+			}
+		}
+	`
+	var args clickhouse.Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(cfgStr), &args))
+
+	converted, err := args.Convert()
+	require.NoError(t, err)
+
+	cfg, ok := converted.(*clickhouseexporter.Config)
+	require.True(t, ok)
+
+	require.Equal(t, "tcp://localhost:9000", cfg.Endpoint)
+	require.Equal(t, "default", cfg.Username)
+	require.Equal(t, "secret", string(cfg.Password))
+	require.Equal(t, "otel", cfg.Database)
+	require.Equal(t, "my_cluster", cfg.ClusterName)
+	require.Equal(t, "ReplicatedMergeTree", cfg.TableEngine.Name)
+	require.Equal(t, "custom_gauge", cfg.MetricsTables.Gauge.Name)
+	require.NoError(t, cfg.Validate())
+}

--- a/internal/component/otelcol/exporter/clickhouse/clickhouse_test.go
+++ b/internal/component/otelcol/exporter/clickhouse/clickhouse_test.go
@@ -35,6 +35,29 @@ func TestValidate(t *testing.T) {
 	require.NoError(t, args.Validate())
 }
 
+// TestConvert_MetricsTableNamesDefaulted guards against a regression where
+// Convert() never backfilled per-metric-type table names: without an
+// explicit metrics_tables block, they used to reach the exporter as empty
+// strings and fail at runtime (found via a real ClickHouse deployment,
+// see bugs.md Bug 3).
+func TestConvert_MetricsTableNamesDefaulted(t *testing.T) {
+	var args clickhouse.Arguments
+	args.SetToDefault()
+	args.Endpoint = "tcp://localhost:9000"
+
+	converted, err := args.Convert()
+	require.NoError(t, err)
+
+	cfg, ok := converted.(*clickhouseexporter.Config)
+	require.True(t, ok)
+
+	require.Equal(t, "otel_metrics_gauge", cfg.MetricsTables.Gauge.Name)
+	require.Equal(t, "otel_metrics_sum", cfg.MetricsTables.Sum.Name)
+	require.Equal(t, "otel_metrics_summary", cfg.MetricsTables.Summary.Name)
+	require.Equal(t, "otel_metrics_histogram", cfg.MetricsTables.Histogram.Name)
+	require.Equal(t, "otel_metrics_exponential_histogram", cfg.MetricsTables.ExponentialHistogram.Name)
+}
+
 func TestConvert(t *testing.T) {
 	cfgStr := `
 		endpoint = "tcp://localhost:9000"

--- a/internal/converter/internal/otelcolconvert/converter_clickhouseexporter.go
+++ b/internal/converter/internal/otelcolconvert/converter_clickhouseexporter.go
@@ -1,0 +1,80 @@
+package otelcolconvert
+
+import (
+	"fmt"
+
+	"github.com/grafana/alloy/internal/component/otelcol/exporter/clickhouse"
+	"github.com/grafana/alloy/internal/converter/diag"
+	"github.com/grafana/alloy/internal/converter/internal/common"
+	"github.com/grafana/alloy/syntax/alloytypes"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componentstatus"
+)
+
+func init() {
+	converters = append(converters, clickhouseExporterConverter{})
+}
+
+type clickhouseExporterConverter struct{}
+
+func (clickhouseExporterConverter) Factory() component.Factory {
+	return clickhouseexporter.NewFactory()
+}
+
+func (clickhouseExporterConverter) InputComponentName() string {
+	return "otelcol.exporter.clickhouse"
+}
+
+func (clickhouseExporterConverter) ConvertAndAppend(state *State, id componentstatus.InstanceID, cfg component.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	label := state.AlloyComponentLabel()
+
+	args := toOtelcolExporterClickhouse(cfg.(*clickhouseexporter.Config))
+	block := common.NewBlockWithOverride([]string{"otelcol", "exporter", "clickhouse"}, label, args)
+
+	diags.Add(
+		diag.SeverityLevelInfo,
+		fmt.Sprintf("Converted %s into %s", StringifyInstanceID(id), StringifyBlock(block)),
+	)
+
+	state.Body().AppendBlock(block)
+	return diags
+}
+
+func toOtelcolExporterClickhouse(cfg *clickhouseexporter.Config) *clickhouse.Arguments {
+	return &clickhouse.Arguments{
+		Endpoint:         cfg.Endpoint,
+		Username:         cfg.Username,
+		Password:         alloytypes.Secret(cfg.Password),
+		Database:         cfg.Database,
+		ConnectionParams: cfg.ConnectionParams,
+		TLS:              toTLSClientArguments(cfg.TLS),
+		LogsTableName:    cfg.LogsTableName,
+		TracesTableName:  cfg.TracesTableName,
+		// MetricsTableName is deprecated upstream in favor of MetricsTables
+		// (converted below), which is what cfg actually resolves to by the
+		// time Convert() runs on a validated config.
+		TTL: cfg.TTL,
+		TableEngine: clickhouse.TableEngineArguments{
+			Name:   cfg.TableEngine.Name,
+			Params: cfg.TableEngine.Params,
+		},
+		ClusterName:  cfg.ClusterName,
+		CreateSchema: cfg.CreateSchema,
+		Compress:     cfg.Compress,
+		AsyncInsert:  cfg.AsyncInsert,
+		MetricsTables: clickhouse.MetricsTablesArguments{
+			Gauge:                clickhouse.MetricTypeArguments{Name: cfg.MetricsTables.Gauge.Name},
+			Sum:                  clickhouse.MetricTypeArguments{Name: cfg.MetricsTables.Sum.Name},
+			Summary:              clickhouse.MetricTypeArguments{Name: cfg.MetricsTables.Summary.Name},
+			Histogram:            clickhouse.MetricTypeArguments{Name: cfg.MetricsTables.Histogram.Name},
+			ExponentialHistogram: clickhouse.MetricTypeArguments{Name: cfg.MetricsTables.ExponentialHistogram.Name},
+		},
+		Timeout:      cfg.TimeoutSettings.Timeout,
+		Retry:        toRetryArguments(cfg.BackOffConfig),
+		Queue:        toQueueArguments(cfg.QueueSettings),
+		DebugMetrics: common.DefaultValue[clickhouse.Arguments]().DebugMetrics,
+	}
+}

--- a/internal/converter/internal/otelcolconvert/testdata/clickhouse.alloy
+++ b/internal/converter/internal/otelcolconvert/testdata/clickhouse.alloy
@@ -1,0 +1,47 @@
+otelcol.receiver.otlp "default" {
+	grpc {
+		endpoint = "localhost:4317"
+	}
+
+	output {
+		metrics = [otelcol.exporter.clickhouse.default.input]
+		logs    = [otelcol.exporter.clickhouse.default.input]
+		traces  = [otelcol.exporter.clickhouse.default.input]
+	}
+}
+
+otelcol.exporter.clickhouse "default" {
+	endpoint           = "tcp://localhost:9000"
+	database           = "otel"
+	metrics_table_name = ""
+	ttl                = "48h0m0s"
+
+	table_engine {
+		name = "ReplicatedMergeTree"
+	}
+	cluster_name = "my_cluster"
+	compress     = ""
+
+	metrics_tables {
+		gauge {
+			name = "otel_metrics_gauge"
+		}
+
+		sum {
+			name = "otel_metrics_sum"
+		}
+
+		summary {
+			name = "otel_metrics_summary"
+		}
+
+		histogram {
+			name = "otel_metrics_histogram"
+		}
+
+		exponential_histogram {
+			name = "otel_metrics_exponential_histogram"
+		}
+	}
+	timeout = "5s"
+}

--- a/internal/converter/internal/otelcolconvert/testdata/clickhouse.yaml
+++ b/internal/converter/internal/otelcolconvert/testdata/clickhouse.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  clickhouse:
+    endpoint: tcp://localhost:9000
+    database: otel
+    ttl: 48h
+    table_engine:
+      name: ReplicatedMergeTree
+    cluster_name: my_cluster
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [clickhouse]
+    metrics:
+      receivers: [otlp]
+      exporters: [clickhouse]
+    logs:
+      receivers: [otlp]
+      exporters: [clickhouse]


### PR DESCRIPTION
### Brief description of Pull Request

Adds a new `otelcol.exporter.clickhouse` component that wraps the upstream OpenTelemetry Collector Contrib `clickhouseexporter`, which writes metrics, logs, and traces to ClickHouse over its native TCP protocol. Registered as a community component (`Community: true`), following the same pattern as `otelcol.exporter.datadog` and `otelcol.exporter.splunkhec`. Also adds an OTel-YAML-to-Alloy config converter for the new component.


### Pull Request Details

The contrib `clickhouseexporter` already speaks ClickHouse's native protocol via `clickhouse-go/v2` (HTTP is just an alternate DSN scheme, not the default), but Alloy had never wrapped it as a component. This PR add a thin `Arguments`/`Convert()` wrapper mirroring `otelcol.exporter.otlphttp`'s structure, covering the exporter's endpoint, auth, per-signal table names, TTL, table engine, cluster name, schema creation, compression, and per-metric-type table overrides, plus the standard retry_on_failure` / `sending_queue` / `debug_metrics` blocks.

`clickhouseexporter` is added as a direct dependency (`go.mod`/`go.sum`), promoting `clickhouse-go/v2` from indirect to direct. `make generate-otel-collector-distro` was run; the resulting `collector/go.mod`/`go.sum` changes are the expected propagation of these root dependency bumps and are included. It ships as a community component and isn't added to the OTel Engine's OCB manifest (`collector/builder-config.yaml`).

Also includes:
- A converter (`internal/converter/internal/otelcolconvert/converter_clickhouseexporter.go`) so `alloy convert --source-format=otelcol` can translate an existing `clickhouse` exporter YAML config into Alloy syntax.
- A `//go:build integration` test using testcontainers-go against a real ClickHouse container, verifying a log record actually round-trips through the exporter and lands in `otel_logs`.

Verified: unit tests for config conversion and validation; the testcontainers-based integration test against a real ClickHouse container; `go build ./...` and `golangci-lint` clean across all modules (root,`collector/`, `syntax/`, `tools/`); a Docker image build of Alloy with this component; and a live round-trip against a real Kubernetes deployment (Alloy → ClickHouse over the native protocol) both before and after this round of changes, confirming metrics keep landing in ClickHouse with fresh, ongoing writes and no regression.


### Issue(s) fixed by this Pull Request

Fixes #3492


### Notes to the Reviewer



### PR Checklist


- [x] Documentation added
- [x] Tests updated
- [x] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
