### PR TITLE
feat(helm): Add service.trafficDistribution to values.yaml

### DIFF
--- a/operations/helm/charts/alloy/CHANGELOG.md
+++ b/operations/helm/charts/alloy/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased
 ### Enhancements
 
 - Add `controller.dnsConfig` to configure the pod's DNS settings (`nameservers`, `searches`, `options`). (@younsl)
+- Allow setting `trafficDistribution` in the service spec. (@agermel)
 
 1.12.1 (2026-08-26)
 ----------

--- a/operations/helm/charts/alloy/README.md
+++ b/operations/helm/charts/alloy/README.md
@@ -188,6 +188,7 @@ useful if just using the default DaemonSet isn't sufficient.
 | service.externalTrafficPolicy | string | `"Cluster"` | Value for external traffic policy. 'Cluster' or 'Local' |
 | service.internalTrafficPolicy | string | `"Cluster"` | Value for internal traffic policy. 'Cluster' or 'Local' |
 | service.nodePort | int | `31128` | NodePort port. Only takes effect when `service.type: NodePort` |
+| service.trafficDistribution | string | `""` | Value for traffic distribution. 'PreferSameNode' or 'PreferSameZone' (k8s >= 1.34) |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.additionalLabels | object | `{}` | Additional labels to add to the created service account. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the created service account. |

--- a/operations/helm/charts/alloy/templates/service.yaml
+++ b/operations/helm/charts/alloy/templates/service.yaml
@@ -25,6 +25,11 @@ spec:
   externalTrafficPolicy: {{.Values.service.externalTrafficPolicy}}
   {{- end }}
   {{- end }}
+  {{- if semverCompare ">=1.34-0" .Capabilities.KubeVersion.Version }}
+  {{- with .Values.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
+  {{- end }}
   ports:
     - name: http-metrics
       {{- if eq .Values.service.type "NodePort" }}

--- a/operations/helm/charts/alloy/values.yaml
+++ b/operations/helm/charts/alloy/values.yaml
@@ -522,6 +522,8 @@ service:
   internalTrafficPolicy: Cluster
   # -- Value for external traffic policy. 'Cluster' or 'Local'
   externalTrafficPolicy: Cluster
+  # -- Value for traffic distribution. 'PreferSameNode' or 'PreferSameZone' (k8s >= 1.34)
+  trafficDistribution: ""
   annotations: {}
     # cloud.google.com/load-balancer-type: Internal
 


### PR DESCRIPTION
### Brief description of Pull Request

Adds a `service.trafficDistribution` value to the Alloy Helm chart. When set, it renders `spec.trafficDistribution` on the Service, guarded to Kubernetes 1.34+.

### Issue(s) fixed by this Pull Request

Fixes #7017

### Notes to the Reviewer

This is my first contribution to this project, and I’m really excited to be involved. I’ve enjoyed working on this change and hope to continue contributing to the project in the future.

Thank you for taking the time to review my PR!

### PR Checklist

- [x] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
