### PR TITLE
fix: Ensure Windows exporter uses correct text file defaults when not specified

### DIFF
--- a/internal/static/integrations/windows_exporter/config_windows.go
+++ b/internal/static/integrations/windows_exporter/config_windows.go
@@ -80,7 +80,9 @@ func (c *Config) ToWindowsExporterConfig() (collector.Config, error) {
 	cfg.SMTP.ServerExclude, err = regexp.Compile(coalesceString(c.SMTP.Exclude, c.SMTP.BlackList))
 	errs = append(errs, err)
 
-	cfg.Textfile.TextFileDirectories = strings.Split(c.TextFile.TextFileDirectory, ",")
+	if c.TextFile.TextFileDirectory != "" {
+		cfg.Textfile.TextFileDirectories = strings.Split(c.TextFile.TextFileDirectory, ",")
+	}
 
 	cfg.PhysicalDisk.DiskInclude, err = regexp.Compile(c.PhysicalDisk.Include)
 	errs = append(errs, err)

--- a/internal/static/integrations/windows_exporter/config_windows_test.go
+++ b/internal/static/integrations/windows_exporter/config_windows_test.go
@@ -1,0 +1,26 @@
+package windows_exporter
+
+import (
+	"testing"
+
+	"github.com/prometheus-community/windows_exporter/pkg/collector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_TextFileDefaultsWhenUnset(t *testing.T) {
+	c := &Config{}
+
+	cfg, err := c.ToWindowsExporterConfig()
+	require.NoError(t, err)
+	require.Equal(t, collector.ConfigDefaults.Textfile.TextFileDirectories, cfg.Textfile.TextFileDirectories)
+}
+
+func TestConfig_TextFileExplicitDirectoryOverridesDefault(t *testing.T) {
+	c := &Config{
+		TextFile: TextFileConfig{TextFileDirectory: `C:\custom\path`},
+	}
+
+	cfg, err := c.ToWindowsExporterConfig()
+	require.NoError(t, err)
+	require.Equal(t, []string{`C:\custom\path`}, cfg.Textfile.TextFileDirectories)
+}


### PR DESCRIPTION
### Pull Request Details
We're currently falling back to incorrect text file defaults in the windows prometheus exporter. This PR ensures that we're correctly following the defaults we describe in our [docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.windows/#textfile). This has been broken since Alloy v1.11.0.

This is a breaking change as the defaults will be updated for users, but since it's a fix to match our docs I think that is acceptable 

### Note to reviewer
Also windows tests [are failing](https://github.com/grafana/alloy/actions/runs/34120368055/job/102032357523?pr=7047) for reasons unrelated to this PR, but I ran then just to check that the test added in this PR passes (it does). Happy to investigate those other windows failures outside of this PR

BREAKING CHANGE: `prometheus.exporter.windows` now applies the documented default `textfile` directory (`<install dir>\textfile_inputs`) when neither `textfile.directories` nor the deprecated `text_file.text_file_directory` is set, restoring behavior that was lost in v1.11.0. Deployments that were relying on the collector silently returning nothing will start receiving any .prom files found there, or an error if that directory doesn't exist, either of which can be avoided by setting directories explicitly or removing textfile from enabled_collectors.

### PR Checklist
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
