### PR TITLE
fix: Only log cluster warning for host-specific exporters when clustering is enabled

### DIFF
--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -1003,6 +1003,8 @@ func (f *fakeCluster) Peers() []peer.Peer { return nil }
 
 func (f *fakeCluster) Ready() bool { return f.ready }
 
+func (f *fakeCluster) Enabled() bool { return true }
+
 var (
 	clusterKeyDB1 = shard.StringKey("tcp(127.0.0.1:3306)/db1")
 	clusterKeyDB2 = shard.StringKey("tcp(127.0.0.1:3306)/db2")

--- a/internal/component/discovery/distributed_targets.go
+++ b/internal/component/discovery/distributed_targets.go
@@ -132,3 +132,7 @@ func (l disabledCluster) Peers() []peer.Peer {
 func (l disabledCluster) Ready() bool {
 	return true
 }
+
+func (l disabledCluster) Enabled() bool {
+	return false
+}

--- a/internal/component/discovery/distributed_targets_test.go
+++ b/internal/component/discovery/distributed_targets_test.go
@@ -318,3 +318,7 @@ func (f *fakeCluster) Peers() []peer.Peer {
 func (f *fakeCluster) Ready() bool {
 	return true
 }
+
+func (f *fakeCluster) Enabled() bool {
+	return true
+}

--- a/internal/component/discovery/target_test.go
+++ b/internal/component/discovery/target_test.go
@@ -1166,6 +1166,10 @@ func (f *randomCluster) Ready() bool {
 	return true
 }
 
+func (f *randomCluster) Enabled() bool {
+	return true
+}
+
 func mapToLabelSet(m map[string]string) model.LabelSet {
 	r := make(model.LabelSet, len(m))
 	for k, v := range m {

--- a/internal/component/mimir/rules/kubernetes/rules_test.go
+++ b/internal/component/mimir/rules/kubernetes/rules_test.go
@@ -120,6 +120,10 @@ func (f fakeCluster) Ready() bool {
 	return true
 }
 
+func (f fakeCluster) Enabled() bool {
+	return true
+}
+
 type fakeLeadership struct {
 	leader    bool
 	changed   bool

--- a/internal/component/prometheus/exporter/common/cluster_warning.go
+++ b/internal/component/prometheus/exporter/common/cluster_warning.go
@@ -18,7 +18,7 @@ func WarningIfUsedInCluster(o component.Options) {
 		return
 	}
 
-	if !clusterData.Ready() || len(clusterData.Peers()) > 0 {
+	if clusterData.Enabled() && len(clusterData.Peers()) > 1 {
 		o.Logger.Warn(
 			"detected clustering is configured while using a host-specific exporter - please make sure your configuration is correct",
 			"exporter",

--- a/internal/component/prometheus/exporter/common/cluster_warning.go
+++ b/internal/component/prometheus/exporter/common/cluster_warning.go
@@ -18,7 +18,7 @@ func WarningIfUsedInCluster(o component.Options) {
 		return
 	}
 
-	if clusterData.Enabled() && len(clusterData.Peers()) > 1 {
+	if clusterData.Enabled() {
 		o.Logger.Warn(
 			"detected clustering is configured while using a host-specific exporter - please make sure your configuration is correct",
 			"exporter",

--- a/internal/component/prometheus/scrape/scrape_clustering_test.go
+++ b/internal/component/prometheus/scrape/scrape_clustering_test.go
@@ -383,3 +383,7 @@ func (f *fakeCluster) Peers() []peer.Peer {
 func (f *fakeCluster) Ready() bool {
 	return true
 }
+
+func (f *fakeCluster) Enabled() bool {
+	return true
+}

--- a/internal/service/cluster/cluster_readonly.go
+++ b/internal/service/cluster/cluster_readonly.go
@@ -50,6 +50,10 @@ type Cluster interface {
 	// - there is a minimum size requirement and the cluster size is >= that size
 	// - there is a minimum size requirement and cluster size is too small, but the configured wait deadline has passed.
 	Ready() bool
+
+	// Enabled returns true if clustering is enabled for this instance of Alloy as a whole, as set
+	// by the --cluster.enabled flag.
+	Enabled() bool
 }
 
 // alloyCluster implements the Cluster interface and manages the admission control logic.
@@ -129,6 +133,10 @@ func (c *alloyCluster) Lookup(key shard.Key, replicationFactor int, op shard.Op)
 
 func (c *alloyCluster) Peers() []peer.Peer {
 	return c.sharder.Peers()
+}
+
+func (c *alloyCluster) Enabled() bool {
+	return c.opts.EnableClustering
 }
 
 func (c *alloyCluster) Ready() bool {

--- a/internal/service/cluster/mock.go
+++ b/internal/service/cluster/mock.go
@@ -35,6 +35,10 @@ func (mockCluster) Ready() bool {
 	return true
 }
 
+func (mockCluster) Enabled() bool {
+	return true
+}
+
 func (mockCluster) Observe(ckit.Observer) {
 	// no-op
 }


### PR DESCRIPTION
### Brief description of Pull Request
Currently, regardless of whether clustering is enabled or not, we see the following logs when host-specific exporters are configured within alloy:

```
detected clustering is configured while using a host-specific exporter - please make sure your configuration is correct
```

Although the warning is valid, we only want to print this when clustering is actually enabled _and_ there are multiple peers that targets can be sharded through. This PR ensures that.

### Pull Request Details
The current condition for whether or not to log the warning is 

```
!clusterData.Ready() || len(clusterData.Peers()) > 0
```

[clusterData.Ready()](https://github.com/grafana/alloy/blob/0dffb9f2829cf6ee5e527568e22a5ba82cb5dd5f/internal/service/cluster/cluster_readonly.go#L134-L143) is doing a calculation involving whether clustering is enabled (which we do care about) alongside if that cluster is ready to receive traffic (which we don't care about). We would still get `true` returned from that method if clustering was enabled but the `MinimumClusterSize` hasn't been met yet - which is unrelated to warning. Additionally, Peers() will return 1 even with clustering disabled, so this mistakenly always fires. 

In order to get around that I introduced a new method called `Enabled()` which _only_ checks the global clustering state. Now that we have a method that does a proper check for clustering, I don't think we need to check the peer count. I'm not sure why one would enable clustering with only a single node - but to reduce complexity overall I think we can safely remove that condition.

### PR Checklist
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
