### PR TITLE
fix(prometheus.exporter.kafka): Start even when Kafka is unreachable

### DIFF
--- a/docs/sources/reference/components/prometheus/prometheus.exporter.kafka.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.kafka.md
@@ -77,9 +77,9 @@ The `prometheus.exporter.kafka` component doesn't support any blocks. You can co
 In those cases, exported fields retain their last healthy values.
 
 The component doesn't connect to Kafka when it starts.
-The first scrape opens the connection.
-Until a connection succeeds, every scrape retries the connection and reports `kafka_up 0`.
-After a connection succeeds, later scrapes reuse it.
+Each scrape attempts to connect.
+If the attempt fails, the scrape reports `kafka_up 0`, and the next scrape tries again.
+Once a scrape connects successfully, later scrapes reuse that connection instead of reconnecting.
 
 ## Debug information
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.kafka.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.kafka.md
@@ -76,8 +76,10 @@ The `prometheus.exporter.kafka` component doesn't support any blocks. You can co
 `prometheus.exporter.kafka` is only reported as unhealthy if given an invalid configuration.
 In those cases, exported fields retain their last healthy values.
 
-The component doesn't connect to Kafka until the first scrape.
-If Kafka is unreachable, the scrape exposes `kafka_up 0` and the connection is retried on the next scrape.
+The component doesn't connect to Kafka when it starts.
+The first scrape opens the connection.
+Until a connection succeeds, every scrape retries the connection and reports `kafka_up 0`.
+After a connection succeeds, later scrapes reuse it.
 
 ## Debug information
 

--- a/docs/sources/reference/components/prometheus/prometheus.exporter.kafka.md
+++ b/docs/sources/reference/components/prometheus/prometheus.exporter.kafka.md
@@ -76,6 +76,9 @@ The `prometheus.exporter.kafka` component doesn't support any blocks. You can co
 `prometheus.exporter.kafka` is only reported as unhealthy if given an invalid configuration.
 In those cases, exported fields retain their last healthy values.
 
+The component doesn't connect to Kafka until the first scrape.
+If Kafka is unreachable, the scrape exposes `kafka_up 0` and the connection is retried on the next scrape.
+
 ## Debug information
 
 `prometheus.exporter.kafka` doesn't expose any component-specific debug information.

--- a/internal/static/integrations/kafka_exporter/kafka_exporter.go
+++ b/internal/static/integrations/kafka_exporter/kafka_exporter.go
@@ -3,9 +3,13 @@ package kafka_exporter
 import (
 	"fmt"
 	"log/slog"
+	"regexp"
+	"sync"
+	"time"
 
 	"github.com/IBM/sarama"
 	kafka_exporter "github.com/grafana/kafka_exporter/exporter"
+	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 
 	"github.com/grafana/alloy/internal/slogadapter"
@@ -184,6 +188,22 @@ func New(logger *slog.Logger, c *Config) (integrations.Integration, error) {
 	if c.UseZooKeeperLag && (len(c.ZookeeperURIs) == 0 || c.ZookeeperURIs[0] == "") {
 		return nil, fmt.Errorf("zookeeper lag is enabled but no zookeeper uri was provided")
 	}
+	if _, err := sarama.ParseKafkaVersion(c.KafkaVersion); err != nil {
+		return nil, fmt.Errorf("invalid kafka_version: %w", err)
+	}
+	if _, err := time.ParseDuration(c.MetadataRefreshInterval); err != nil {
+		return nil, fmt.Errorf("invalid metadata_refresh_interval: %w", err)
+	}
+	for _, f := range []struct{ name, expr string }{
+		{"topics_filter_regex", c.TopicsFilter},
+		{"topics_exclude_regex", c.TopicsExclude},
+		{"groups_filter_regex", c.GroupFilter},
+		{"groups_exclude_regex", c.GroupExclude},
+	} {
+		if _, err := regexp.Compile(f.expr); err != nil {
+			return nil, fmt.Errorf("invalid %s: %w", f.name, err)
+		}
+	}
 
 	// 30 is the default value
 	if c.PruneIntervalSeconds != 30 {
@@ -221,13 +241,65 @@ func New(logger *slog.Logger, c *Config) (integrations.Integration, error) {
 		MaxOffsets:               c.MaxOffsets,
 	}
 
-	newExporter, err := kafka_exporter.New(slogadapter.GoKit(logger.Handler()), options, c.TopicsFilter, c.TopicsExclude, c.GroupFilter, c.GroupExclude)
-	if err != nil {
-		return nil, fmt.Errorf("could not instantiate kafka lag exporter: %w", err)
+	// kafka_exporter.New connects to Kafka (and ZooKeeper) as part of
+	// construction. Defer it to the first scrape so that an unreachable
+	// broker at startup does not fail the whole component and retries
+	// happen on every scrape until the connection succeeds.
+	collector := &lazyCollector{
+		logger: logger,
+		create: func() (*kafka_exporter.Exporter, error) {
+			return kafka_exporter.New(slogadapter.GoKit(logger.Handler()), options, c.TopicsFilter, c.TopicsExclude, c.GroupFilter, c.GroupExclude)
+		},
 	}
 
 	return integrations.NewCollectorIntegration(
 		c.Name(),
-		integrations.WithCollectors(newExporter),
+		integrations.WithCollectors(collector),
 	), nil
+}
+
+var kafkaUp = prometheus.NewDesc(
+	"kafka_up",
+	"Whether the exporter could connect to Kafka. 0 until the Kafka client is initialized.",
+	nil, nil,
+)
+
+// lazyCollector creates the wrapped kafka_exporter.Exporter on the first
+// Collect call and retries on subsequent calls until it succeeds.
+type lazyCollector struct {
+	logger *slog.Logger
+	create func() (*kafka_exporter.Exporter, error)
+
+	mut      sync.Mutex
+	exporter *kafka_exporter.Exporter
+}
+
+// Describe implements prometheus.Collector. It intentionally sends no
+// descriptors, which makes this an unchecked collector: the wrapped exporter
+// only initializes its descriptors once it has been created.
+func (l *lazyCollector) Describe(chan<- *prometheus.Desc) {}
+
+// Collect implements prometheus.Collector.
+func (l *lazyCollector) Collect(ch chan<- prometheus.Metric) {
+	exporter, err := l.get()
+	if err != nil {
+		l.logger.Error("could not instantiate kafka lag exporter, will retry on next scrape", "err", err)
+		ch <- prometheus.MustNewConstMetric(kafkaUp, prometheus.GaugeValue, 0)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(kafkaUp, prometheus.GaugeValue, 1)
+	exporter.Collect(ch)
+}
+
+func (l *lazyCollector) get() (*kafka_exporter.Exporter, error) {
+	l.mut.Lock()
+	defer l.mut.Unlock()
+	if l.exporter == nil {
+		exporter, err := l.create()
+		if err != nil {
+			return nil, err
+		}
+		l.exporter = exporter
+	}
+	return l.exporter, nil
 }

--- a/internal/static/integrations/kafka_exporter/kafka_test.go
+++ b/internal/static/integrations/kafka_exporter/kafka_test.go
@@ -1,7 +1,14 @@
 package kafka_exporter
 
 import (
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alloy/internal/static/config"
 )
@@ -16,4 +23,95 @@ integrations:
     sasl_password: secret_password
 `
 	config.CheckSecret(t, stringCfg, "secret_password")
+}
+
+func TestNew_KafkaUnreachableAtStartup(t *testing.T) {
+	// Reserve a local port and close it again so the dial is refused.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+	require.NoError(t, lis.Close())
+
+	cfg := DefaultConfig
+	cfg.KafkaURIs = []string{addr}
+
+	integration, err := New(slog.New(slog.DiscardHandler), &cfg)
+	require.NoError(t, err, "an unreachable broker must not fail integration construction")
+
+	handler, err := integration.MetricsHandler()
+	require.NoError(t, err)
+
+	body := scrape(t, handler)
+	require.Contains(t, body, "kafka_up 0")
+	require.NotContains(t, body, "kafka_brokers")
+
+	// Once a broker becomes reachable the next scrape connects and exports metrics.
+	broker := sarama.NewMockBrokerAddr(t, 1, addr)
+	defer broker.Close()
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"MetadataRequest":       sarama.NewMockMetadataResponse(t).SetBroker(addr, broker.BrokerID()).SetController(broker.BrokerID()),
+		"ListGroupsRequest":     sarama.NewMockListGroupsResponse(t),
+		"DescribeGroupsRequest": sarama.NewMockDescribeGroupsResponse(t),
+	})
+
+	body = scrape(t, handler)
+	require.Contains(t, body, "kafka_up 1")
+	require.Contains(t, body, "kafka_brokers 1")
+}
+
+func TestNew_InvalidConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(c *Config)
+		err    string
+	}{
+		{
+			name:   "empty kafka_uris",
+			mutate: func(c *Config) { c.KafkaURIs = nil },
+			err:    "empty kafka_uris provided",
+		},
+		{
+			name:   "sasl without credentials",
+			mutate: func(c *Config) { c.UseSASL = true },
+			err:    "SASL is enabled but username or password was not provided",
+		},
+		{
+			name:   "zookeeper lag without uris",
+			mutate: func(c *Config) { c.UseZooKeeperLag = true },
+			err:    "zookeeper lag is enabled but no zookeeper uri was provided",
+		},
+		{
+			name:   "invalid kafka_version",
+			mutate: func(c *Config) { c.KafkaVersion = "not-a-version" },
+			err:    "invalid kafka_version",
+		},
+		{
+			name:   "invalid metadata_refresh_interval",
+			mutate: func(c *Config) { c.MetadataRefreshInterval = "soon" },
+			err:    "invalid metadata_refresh_interval",
+		},
+		{
+			name:   "invalid topics_filter_regex",
+			mutate: func(c *Config) { c.TopicsFilter = "(" },
+			err:    "invalid topics_filter_regex",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig
+			cfg.KafkaURIs = []string{"127.0.0.1:9092"}
+			tc.mutate(&cfg)
+
+			_, err := New(slog.New(slog.DiscardHandler), &cfg)
+			require.ErrorContains(t, err, tc.err)
+		})
+	}
+}
+
+func scrape(t *testing.T, handler http.Handler) string {
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	return rec.Body.String()
 }


### PR DESCRIPTION
### Brief description of Pull Request

`prometheus.exporter.kafka` no longer fails to build (and no longer takes the whole Alloy process down) when Kafka is unreachable at startup. The Kafka client is now created on the first scrape and retried on every following scrape; the scrape exposes `kafka_up 0` until the connection succeeds. Configuration validation stays eager.

### Pull Request Details

## Problem

When the configured Kafka brokers cannot be reached while Alloy starts (for example Alloy and Kafka on the same host after a reboot, with Kafka still starting), `alloy run` exits with:

```
Failed to build component: building component: could not instantiate kafka lag exporter: Error Init Kafka Client: kafka: client has run out of available brokers to talk to: dial tcp 10.42.5.117:9093: connect: connection refused
```

Nothing else in the configuration runs and the HTTP server on `:12345` never comes up. Other `prometheus.exporter.*` components connect lazily, so an unreachable target only shows up as failed scrapes.

## Root cause

`internal/static/integrations/kafka_exporter/kafka_exporter.go:224` calls `kafka_exporter.New(...)` from the integration constructor `New()`. That upstream constructor (`github.com/grafana/kafka_exporter/exporter/exporter.go:250`) calls `sarama.NewClient(...)`, which dials the brokers and fetches metadata synchronously. `New()` runs inside `exporter.Component.Update()` during the component build (`internal/component/prometheus/exporter/exporter.go`), so a dial error is returned as a build error and Alloy refuses to start.

## Fix

`internal/static/integrations/kafka_exporter/kafka_exporter.go`:

- Wrap `kafka_exporter.New` in a small `lazyCollector` (`prometheus.Collector`) that creates the upstream exporter on the first `Collect` and retries on later scrapes while creation keeps failing. The failure is logged and the scrape exposes `kafka_up 0`; once the client exists the scrape exposes `kafka_up 1` followed by the regular `kafka_*` metrics.
- `Describe` sends no descriptors (unchecked collector) because the upstream exporter only initializes its descriptors in its constructor.
- Keep configuration errors eager so they still fail the build: the existing `kafka_uris` / SASL / ZooKeeper checks, plus `kafka_version`, `metadata_refresh_interval` and the four filter regexes, which the upstream constructor would otherwise only evaluate on the first scrape (the regexes via `regexp.MustCompile`, which would panic inside the scrape handler instead of at build time).

The `prometheus.exporter.kafka` component itself (`internal/component/prometheus/exporter/kafka/kafka.go`) is unchanged; it goes through this constructor. The static-mode integration and the v2 legacy shim share the same code path.

Docs: one short paragraph in the "Component health" section of `docs/sources/reference/components/prometheus/prometheus.exporter.kafka.md` describing `kafka_up` and the retry behavior.

## How tested

New unit tests in `internal/static/integrations/kafka_exporter/kafka_test.go`; no Kafka broker needed.

- `TestNew_KafkaUnreachableAtStartup`: builds the integration against a closed localhost port, scrapes the handler (HTTP 200, `kafka_up 0`, no `kafka_brokers`), then starts a `sarama.MockBroker` on the same address and scrapes again (`kafka_up 1`, `kafka_brokers 1`).
- `TestNew_InvalidConfig`: empty `kafka_uris`, SASL without credentials, ZooKeeper lag without URIs, invalid `kafka_version`, invalid `metadata_refresh_interval`, invalid `topics_filter_regex` all still fail eagerly in `New()`.

Before the fix (`go test -count=1 -run 'TestNew_' ./internal/static/integrations/kafka_exporter/`):

```
--- FAIL: TestNew_KafkaUnreachableAtStartup (0.75s)
    kafka_test.go:39:
        	Error:      	Received unexpected error:
        	            	could not instantiate kafka lag exporter: Error Init Kafka Client: kafka: client has run out of available brokers to talk to: dial tcp 127.0.0.1:42335: connect: connection refused
        	Messages:   	an unreachable broker must not fail integration construction
--- FAIL: TestNew_InvalidConfig (0.75s)
    --- FAIL: TestNew_InvalidConfig/invalid_kafka_version (0.00s)
    --- FAIL: TestNew_InvalidConfig/invalid_metadata_refresh_interval (0.00s)
    --- FAIL: TestNew_InvalidConfig/invalid_topics_filter_regex (0.75s)
FAIL
FAIL	github.com/grafana/alloy/internal/static/integrations/kafka_exporter	1.547s
```

After the fix:

```
--- PASS: TestNew_KafkaUnreachableAtStartup (0.76s)
--- PASS: TestNew_InvalidConfig (0.00s)
ok  	github.com/grafana/alloy/internal/static/integrations/kafka_exporter	1.898s
```

Also run: `go test -count=1 -race ./internal/static/integrations/kafka_exporter/ ./internal/component/prometheus/exporter/kafka/` (ok), `go vet` on both packages (clean), `golangci-lint run ./internal/static/integrations/kafka_exporter/...` with the repo config (0 issues).

## Links

- https://github.com/grafana/alloy/issues/4391

### Issue(s) fixed by this Pull Request

Fixes https://github.com/grafana/alloy/issues/4391

### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Can leave empty if not needed. -->


### PR Checklist

<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
