### PR TITLE
feat(loki.write): Add loki_write_batch_size_bytes histogram

### DIFF
--- a/docs/sources/reference/components/loki/loki.write.md
+++ b/docs/sources/reference/components/loki/loki.write.md
@@ -202,6 +202,7 @@ The following fields are exported and can be referenced by other components:
 * `loki_write_dropped_entries_total` (counter): Number of log entries dropped because they failed to be sent to the ingester after all retries.
 * `loki_write_sent_bytes_total` (counter): Number of bytes sent.
 * `loki_write_sent_entries_total` (counter): Number of log entries sent to the ingester.
+* `loki_write_batch_size_bytes` (histogram): Number of uncompressed bytes of log lines in a batch when it's sent, to be compared against the configured `batch_size`.
 * `loki_write_request_size_bytes` (histogram): Number of bytes for encoded requests.
 * `loki_write_request_duration_seconds` (histogram): Duration of sent requests.
 * `loki_write_entry_propagation_latency_seconds` (histogram): Time in seconds from entry creation until it's either successfully sent or dropped.

--- a/internal/component/common/loki/client/endpoint_test.go
+++ b/internal/component/common/loki/client/endpoint_test.go
@@ -454,3 +454,67 @@ func TestEndpointBlockOnOverflow(t *testing.T) {
 		require.NoError(t, e.enqueue(entry4, 0))
 	})
 }
+
+func TestEndpointBatchSizeMetric(t *testing.T) {
+	receivedReqsChan := make(chan util.RemoteWriteRequest, 10)
+	server := util.NewRemoteWriteServer(receivedReqsChan, http.StatusOK)
+	defer server.Close()
+
+	var url flagext.URLValue
+	require.NoError(t, url.Set(server.URL))
+
+	entries := []loki.Entry{
+		{Entry: push.Entry{Timestamp: time.Unix(1, 0), Line: "line 1"}},
+		{Entry: push.Entry{Timestamp: time.Unix(2, 0), Line: "line 2"}},
+	}
+
+	reg := prometheus.NewRegistry()
+	e, err := newEndpoint(newMetrics(reg), Config{
+		URL: url,
+		// Both entries fit in one batch, so they are sent together once
+		// BatchWait is reached.
+		BatchSize:     int(1 * units.MiB),
+		BatchWait:     50 * time.Millisecond,
+		Timeout:       time.Second,
+		Client:        config.DefaultHTTPClientConfig,
+		BackoffConfig: backoff.Config{MinBackoff: time.Millisecond, MaxBackoff: 2 * time.Millisecond, MaxRetries: 3},
+		QueueConfig:   QueueConfig{Capacity: int(10 * units.MiB), MinShards: 1, BlockOnOverflow: true, DrainTimeout: 30 * time.Second},
+	}, logging.NewSlogNop(), marker.NewNopTracker())
+	require.NoError(t, err)
+
+	for _, entry := range entries {
+		require.NoError(t, e.enqueue(entry, 0))
+	}
+
+	// Stopping the endpoint waits until the current batch is sent.
+	e.stop()
+
+	require.Equal(t, 1, len(receivedReqsChan), "expected both entries to be sent in a single batch")
+
+	// The observed size is the uncompressed size of the log lines, which is what
+	// the batch compares against the configured BatchSize.
+	sum, count := histogramSumAndCount(t, reg, "loki_write_batch_size_bytes")
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, float64(entries[0].Size()+entries[1].Size()), sum)
+}
+
+// histogramSumAndCount returns the sum and count of the single series of the
+// named histogram in reg.
+func histogramSumAndCount(t *testing.T, reg *prometheus.Registry, name string) (float64, uint64) {
+	t.Helper()
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		require.Len(t, family.GetMetric(), 1)
+		h := family.GetMetric()[0].GetHistogram()
+		return h.GetSampleSum(), h.GetSampleCount()
+	}
+
+	t.Fatalf("metric %s not found", name)
+	return 0, 0
+}

--- a/internal/component/common/loki/client/metrics.go
+++ b/internal/component/common/loki/client/metrics.go
@@ -26,6 +26,7 @@ type metrics struct {
 	droppedBytes                 *prometheus.CounterVec
 	sentEntries                  *prometheus.CounterVec
 	droppedEntries               *prometheus.CounterVec
+	batchSize                    *prometheus.HistogramVec
 	requestSize                  *prometheus.HistogramVec
 	requestDuration              *prometheus.HistogramVec
 	batchRetries                 *prometheus.CounterVec
@@ -67,6 +68,14 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	}, []string{labelHost, labelTenant})
+	m.batchSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:                            "loki_write_batch_size_bytes",
+		Help:                            "Number of uncompressed bytes of log lines in a batch when it's sent, to be compared against the configured batch_size.",
+		Buckets:                         []float64{1 * KiB, 4 * KiB, 16 * KiB, 64 * KiB, 256 * KiB, 512 * KiB, 1 * MiB, 2 * MiB, 4 * MiB, 8 * MiB, 16 * MiB, 20 * MiB},
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+	}, []string{labelHost, labelTenant})
 	m.requestSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            "loki_write_request_size_bytes",
 		Help:                            "Number of bytes for requests.",
@@ -102,6 +111,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		m.sentEntries = util.MustRegisterOrGet(reg, m.sentEntries).(*prometheus.CounterVec)
 		m.droppedEntries = util.MustRegisterOrGet(reg, m.droppedEntries).(*prometheus.CounterVec)
 		m.entryLatency = util.MustRegisterOrGet(reg, m.entryLatency).(*prometheus.HistogramVec)
+		m.batchSize = util.MustRegisterOrGet(reg, m.batchSize).(*prometheus.HistogramVec)
 		m.requestSize = util.MustRegisterOrGet(reg, m.requestSize).(*prometheus.HistogramVec)
 		m.requestDuration = util.MustRegisterOrGet(reg, m.requestDuration).(*prometheus.HistogramVec)
 		m.batchRetries = util.MustRegisterOrGet(reg, m.batchRetries).(*prometheus.CounterVec)

--- a/internal/component/common/loki/client/shards.go
+++ b/internal/component/common/loki/client/shards.go
@@ -403,6 +403,10 @@ func (s *shards) sendBatch(tenantID string, batch *batch, protoBuf, snappyBuf *[
 	obs := s.metrics.entryLatency.WithLabelValues(s.cfg.URL.Host, tenantID)
 	defer batch.reportAsSentData(s.tracker, obs)
 
+	// batch.size is the uncompressed size of the log lines, which is what's
+	// compared against the configured batch_size when filling the batch.
+	s.metrics.batchSize.WithLabelValues(s.cfg.URL.Host, tenantID).Observe(float64(batch.size))
+
 	r, entriesCount := batch.request()
 
 	size := r.Size()


### PR DESCRIPTION
### Brief description of Pull Request

`loki_write_request_size_bytes` measures the batch after proto encoding and snappy compression, so it can't be compared against the configured batch_size. Add `loki_write_batch_size_bytes`, which observes the uncompressed sum of entry sizes in a batch — the same quantity the batch compares against batch_size when deciding whether another entry fits.

The histogram is observed once per batch in sendBatch, before encoding, and is labelled by host and tenant with the same buckets as `loki_write_request_size_bytes`.

### Pull Request Details

This is important so Alloy users can see their batch size, for which there are limits in Loki. The existing metric `loki_write_request_size_bytes` counts the number of bytes after Snappy compression, and so unfortunately is not adequate for this purpose.

### Issue(s) fixed by this Pull Request

https://github.com/grafana/alloy/issues/2906

### Notes to the Reviewer

Created with Claude Opus 5, tested locally on my Mac.

### PR Checklist

<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->

- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
