### PR TITLE
fix(faro.receiver): Allow Faro SDK retry headers through CORS

### DIFF
--- a/docs/sources/reference/components/faro/faro.receiver.md
+++ b/docs/sources/reference/components/faro/faro.receiver.md
@@ -108,7 +108,10 @@ The default value, `[]`, disables CORS support.
 To support requests from all origins, set `cors_allowed_origins` to `["*"]`.
 The `*` character indicates a wildcard.
 
-You can use the following headers for cross-domain requests: `Content-Type`, `Content-Encoding`, `Traceparent`, `X-API-Key`, `X-Faro-Session-Id`, or `X-Scope-OrgID`.
+You can use the following headers for cross-domain requests: `Content-Type`, `Content-Encoding`, `Idempotency-Key`, `Traceparent`, `X-API-Key`, `X-Faro-Session-Id`, or `X-Scope-OrgID`.
+
+Browser clients can read the `Retry-After` response header when it's present.
+`faro.receiver` doesn't generate this header or deduplicate requests based on `Idempotency-Key`.
 
 The server supports gzip-compressed request bodies.
 When a client sends a request with a `Content-Encoding: gzip` header, the server automatically decompresses the body before processing.

--- a/internal/component/faro/receiver/handler.go
+++ b/internal/component/faro/receiver/handler.go
@@ -21,7 +21,15 @@ import (
 
 const apiKeyHeader = "x-api-key"
 
-var defaultAllowedHeaders = []string{"content-type", "content-encoding", "traceparent", apiKeyHeader, "x-faro-session-id", "x-scope-orgid"}
+var defaultAllowedHeaders = []string{
+	"content-type",
+	"content-encoding",
+	"idempotency-key",
+	"traceparent",
+	apiKeyHeader,
+	"x-faro-session-id",
+	"x-scope-orgid",
+}
 
 type handler struct {
 	log            *slog.Logger
@@ -88,6 +96,7 @@ func (h *handler) Update(args ServerArguments) {
 		h.cors = cors.New(cors.Options{
 			AllowedOrigins: args.CORSAllowedOrigins,
 			AllowedHeaders: defaultAllowedHeaders,
+			ExposedHeaders: []string{"Retry-After"},
 		})
 	} else {
 		h.cors = nil // Disable cors.

--- a/internal/component/faro/receiver/handler_test.go
+++ b/internal/component/faro/receiver/handler_test.go
@@ -310,6 +310,107 @@ func TestCORSPreflightWithAllowedHeader(t *testing.T) {
 	}
 }
 
+func TestCORSFaroSDKIngestion(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		compressed bool
+		headers    string
+	}{
+		{
+			name:    "uncompressed",
+			headers: "content-type,idempotency-key,x-api-key,x-faro-session-id",
+		},
+		{
+			name:       "compressed",
+			compressed: true,
+			headers:    "content-encoding,content-type,idempotency-key,x-api-key,x-faro-session-id",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := &testExporter{name: "test"}
+			h := newHandler(util.TestAlloyLogger(t).Slog(), prometheus.NewRegistry(), []exporter{out})
+			var args ServerArguments
+			args.SetToDefault()
+			args.CORSAllowedOrigins = []string{"https://example.com"}
+			args.RateLimiting.Enabled = false
+			h.Update(args)
+
+			preflight := httptest.NewRequest(http.MethodOptions, "/collect", nil)
+			preflight.Header.Set("Origin", "https://example.com")
+			preflight.Header.Set("Access-Control-Request-Method", http.MethodPost)
+			preflight.Header.Set("Access-Control-Request-Headers", tc.headers)
+			preflightResponse := httptest.NewRecorder()
+			h.ServeHTTP(preflightResponse, preflight)
+			require.Equal(t, http.StatusNoContent, preflightResponse.Code)
+			require.Equal(t, "https://example.com", preflightResponse.Header().Get("Access-Control-Allow-Origin"))
+			for _, header := range strings.Split(tc.headers, ",") {
+				require.Contains(t, preflightResponse.Header().Get("Access-Control-Allow-Headers"), header)
+			}
+			require.Empty(t, out.payloads)
+
+			body := []byte(emptyPayload)
+			if tc.compressed {
+				var compressed bytes.Buffer
+				writer := gzip.NewWriter(&compressed)
+				_, err := writer.Write(body)
+				require.NoError(t, err)
+				require.NoError(t, writer.Close())
+				body = compressed.Bytes()
+			}
+			request := httptest.NewRequest(http.MethodPost, "/collect", bytes.NewReader(body))
+			request.Header.Set("Origin", "https://example.com")
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Idempotency-Key", "faro-batch-id")
+			request.Header.Set("X-API-Key", "test-key")
+			request.Header.Set("X-Faro-Session-Id", "test-session")
+			if tc.compressed {
+				request.Header.Set("Content-Encoding", "gzip")
+			}
+			response := httptest.NewRecorder()
+			h.ServeHTTP(response, request)
+			require.Equal(t, http.StatusAccepted, response.Code)
+			require.Equal(t, "https://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+			require.Len(t, out.payloads, 1)
+		})
+	}
+}
+
+func TestCORSExposesOptionalRetryAfter(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		retryAfter string
+	}{
+		{name: "absent"},
+		{name: "provided by middleware", retryAfter: "30"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := &testExporter{name: "test"}
+			h := newHandler(util.TestAlloyLogger(t).Slog(), prometheus.NewRegistry(), []exporter{out})
+			var args ServerArguments
+			args.SetToDefault()
+			args.CORSAllowedOrigins = []string{"https://example.com"}
+			args.RateLimiting.Enabled = false
+			h.Update(args)
+
+			request := httptest.NewRequest(http.MethodPost, "/collect", strings.NewReader(emptyPayload))
+			request.Header.Set("Origin", "https://example.com")
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			if tc.retryAfter != "" {
+				// An outer middleware or proxy may provide a hint; the receiver does not generate one.
+				response.Header().Set("Retry-After", tc.retryAfter)
+			}
+			h.ServeHTTP(response, request)
+			require.Equal(t, http.StatusAccepted, response.Code)
+			require.Equal(t, tc.retryAfter, response.Header().Get("Retry-After"))
+			require.Contains(t, response.Header().Get("Access-Control-Expose-Headers"), "Retry-After")
+			require.Len(t, out.payloads, 1)
+		})
+	}
+}
+
 func TestRateLimiter(t *testing.T) {
 	var (
 		exporter1 = &testExporter{"exporter1", false, nil}


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
    description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.

  **HUMANS**
  - Read and understand docs/developer/genai.md
  - Brief description / Details / Issue(s) fixed: factual summary of the change (AI may
    help).
  - Notes, and Checklist: part of review and communication with the maintainers - keep those
    human-owned.

  **AI AGENTS**
  - MANDATORY: Read, understand, and apply AGENTS.md
  - Use this template as the PR body structure. Do not invent a custom layout.
  - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
    that section's content. Leave it empty unless the human already filled it.
  - You may write the PR title and sections without "HUMAN ONLY". Follow the
    semantic title rules in .github/workflows/release-lint-pr-title.yml and do
    not invent issue numbers - verify they exist instead.
  - Checklist: do not add, remove, check, or uncheck items. Leave every item as
    provided unless the human already changed it.
  - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
    point at docs/developer/genai.md.
-->

### Brief description of Pull Request

<!-- Factual, human-readable, brief summary of what changed (squash commit body). -->

Allow the Faro Web SDK's `Idempotency-Key` request header through CORS preflights and expose an optional `Retry-After` response header to browser clients.

### Pull Request Details

<!-- Motivations, trade-offs, and decisions. Can leave empty if not needed. -->

The [default transport update in the Faro Web SDK](https://github.com/grafana/faro-web-sdk/pull/2264) sends `Idempotency-Key` on every batch. Allowing the header lets those requests reach ingestion across origins.

This changes CORS settings only. The receiver continues to ingest payloads and apply its existing rate limiter. It does not generate `Retry-After` values or deduplicate requests. Exposing `Retry-After` only makes an existing response value readable; clients can use their own backoff when no value is present.

Regression tests cover preflight followed by ingestion with plain and gzip payloads, plus response-header visibility with an optional hint present or absent. Existing allowed/disallowed-header tests remain covered. Validation passed: `go test -race -tags=nodocker ./internal/component/faro/receiver/... -count=1`, targeted golangci-lint, full `make lint`, and `git diff --check`.

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id or leave empty if not applicable -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Can leave empty if not needed. -->


### PR Checklist

<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
