### PR TITLE
feat: Add special reason when Loki returns 413

### DIFF
--- a/internal/component/common/loki/client/metrics.go
+++ b/internal/component/common/loki/client/metrics.go
@@ -17,6 +17,7 @@ const (
 	reasonStreamLimited = "stream_limited"
 	reasonLineTooLong   = "line_too_long"
 	reasonQueueIsFull   = "queue_is_full"
+	reasonBatchTooLarge = "batch_too_large"
 )
 
 var reasons = []string{reasonGeneric, reasonRateLimited, reasonStreamLimited, reasonLineTooLong, reasonQueueIsFull}

--- a/internal/component/common/loki/client/shards.go
+++ b/internal/component/common/loki/client/shards.go
@@ -465,6 +465,8 @@ func (s *shards) sendBatch(tenantID string, batch *batch, protoBuf, snappyBuf *[
 	dropReason := reasonGeneric
 	if batchIsRateLimited(status) {
 		dropReason = reasonRateLimited
+	} else if batchIsTooLarge(status) {
+		dropReason = reasonBatchTooLarge
 	}
 	s.metrics.droppedBytes.WithLabelValues(s.cfg.URL.Host, tenantID, dropReason).Add(bufBytes)
 	s.metrics.droppedEntries.WithLabelValues(s.cfg.URL.Host, tenantID, dropReason).Add(float64(entriesCount))
@@ -538,4 +540,8 @@ func (s *shards) send(ctx context.Context, tenantID string, buf []byte) (int, er
 
 func batchIsRateLimited(status int) bool {
 	return status == 429
+}
+
+func batchIsTooLarge(status int) bool {
+	return status == 413
 }


### PR DESCRIPTION
### Brief description of Pull Request

This updates Alloy to use the reason "batch_too_large" instead of "ingester_error" when Loki returns an HTTP 413.

### Pull Request Details

<!-- Motivations, trade-offs, and decisions. Can leave empty if not needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id or leave empty if not applicable -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Can leave empty if not needed. -->


### PR Checklist

<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
