### PR TITLE
feat: Add 32MB and 64MB buckets to Loki histograms

### DIFF
--- a/internal/component/common/loki/client/metrics.go
+++ b/internal/component/common/loki/client/metrics.go
@@ -71,7 +71,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	m.batchSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            "loki_write_batch_size_bytes",
 		Help:                            "Number of uncompressed bytes of log lines in a batch when it's sent, to be compared against the configured batch_size.",
-		Buckets:                         []float64{1 * KiB, 4 * KiB, 16 * KiB, 64 * KiB, 256 * KiB, 512 * KiB, 1 * MiB, 2 * MiB, 4 * MiB, 8 * MiB, 16 * MiB, 20 * MiB},
+		Buckets:                         []float64{1 * KiB, 4 * KiB, 16 * KiB, 64 * KiB, 256 * KiB, 512 * KiB, 1 * MiB, 2 * MiB, 4 * MiB, 8 * MiB, 16 * MiB, 32 * MiB, 64 * MiB},
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
@@ -79,7 +79,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	m.requestSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            "loki_write_request_size_bytes",
 		Help:                            "Number of bytes for requests.",
-		Buckets:                         []float64{1 * KiB, 4 * KiB, 16 * KiB, 64 * KiB, 256 * KiB, 512 * KiB, 1 * MiB, 2 * MiB, 4 * MiB, 8 * MiB, 16 * MiB, 20 * MiB},
+		Buckets:                         []float64{1 * KiB, 4 * KiB, 16 * KiB, 64 * KiB, 256 * KiB, 512 * KiB, 1 * MiB, 2 * MiB, 4 * MiB, 8 * MiB, 16 * MiB, 32 * MiB, 64 * MiB},
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,


### PR DESCRIPTION
### Brief description of Pull Request

Grafana Cloud Logs encourages batches up to 64MB in size, this updates the existing histograms to be able to count up to 64MB. It drops the existing 20MB to maintain powers of 2.

### Pull Request Details

<!-- Motivations, trade-offs, and decisions. Can leave empty if not needed. -->


### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id or leave empty if not applicable -->


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Can leave empty if not needed. -->


### PR Checklist

<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
