### PR TITLE
docs: Update otelcol.receiver.kafka for deprecated encoding

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.receiver.kafka.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.kafka.md
@@ -365,7 +365,7 @@ Available only for logs:
 - `raw`: the payload's bytes are inserted as the body of a log record.
 - `text`: the payload are decoded as text and inserted as the body of a log record. By default, it uses UTF-8 to decode. You can use `text_<ENCODING>`, like `text_utf-8`, `text_shift_jis`, etc., to customize this behavior.
 - `json`: the payload is decoded as JSON and inserted as the body of a log record.
-- `azure_resource_logs`: the payload is converted from Azure Resource Logs format to OTel format.
+- `azure_resource_logs`: Deprecated in {{< param "PRODUCT_NAME" >}} v1.17.
 
 ## Message header propagation
 


### PR DESCRIPTION
The `otelcol.receiver.kafka` component documentation lists `azure_resource_logs` as a supported/available encoding. This was deprecated in the Otel Collector v0.149.0.

Alloy 1.16 used Otel Collector v0.147.0, and Alloy v1.17 was bumped to Otel Collector 0.151.0.

The alloy documentation is updated to note that the `azure_resource_logs` encoding is deprecated as of Alloy v1.17.

Fixes: https://github.com/grafana/alloy/issues/7055