### PR TITLE
feat(database_observability.mysql): Add index-usage collectors

### DIFF
--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -48,6 +48,8 @@ The following collectors are configurable:
 | `setup_actors`    | Check and update `performance_schema.setup_actors` settings. | yes                |
 | `locks`           | Collect queries that are waiting/blocking other queries.     | no                 |
 | `explain_plans`   | Collect explain plans information.                           | yes                |
+| `table_stats`     | Collect the no-index (`INDEX_NAME` is `NULL`) fetch count per table from `performance_schema.table_io_waits_summary_by_index_usage`, for missing-index detection. | no |
+| `index_stats`     | Collect the per-index fetch count from `performance_schema.table_io_waits_summary_by_index_usage`, and (MySQL 5.6.6+) per-index size from `mysql.innodb_index_stats`, for unused-index detection. | no |
 
 ## Blocks
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -49,7 +49,7 @@ The following collectors are configurable:
 | `locks`           | Collect queries that are waiting/blocking other queries.     | no                 |
 | `explain_plans`   | Collect explain plans information.                           | yes                |
 | `table_stats`     | Collect table-level index usage statistics.                  | no                 |
-| `index_stats`     | Collect per-index usage statistics.                           | no                 |
+| `index_stats`     | Collect per-index usage statistics.                          | no                 |
 
 ## Blocks
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -48,8 +48,8 @@ The following collectors are configurable:
 | `setup_actors`    | Check and update `performance_schema.setup_actors` settings. | yes                |
 | `locks`           | Collect queries that are waiting/blocking other queries.     | no                 |
 | `explain_plans`   | Collect explain plans information.                           | yes                |
-| `table_stats`     | Collect the no-index (`INDEX_NAME` is `NULL`) fetch count per table from `performance_schema.table_io_waits_summary_by_index_usage`, for missing-index detection. | no |
-| `index_stats`     | Collect the per-index fetch count from `performance_schema.table_io_waits_summary_by_index_usage`, and (MySQL 5.6.6+) per-index size from `mysql.innodb_index_stats`, for unused-index detection. | no |
+| `table_stats`     | Collect table-level index usage statistics, for missing-index detection. | no |
+| `index_stats`     | Collect per-index usage statistics, for unused-index detection. | no |
 
 ## Blocks
 

--- a/docs/sources/reference/components/database_observability/database_observability.mysql.md
+++ b/docs/sources/reference/components/database_observability/database_observability.mysql.md
@@ -48,8 +48,8 @@ The following collectors are configurable:
 | `setup_actors`    | Check and update `performance_schema.setup_actors` settings. | yes                |
 | `locks`           | Collect queries that are waiting/blocking other queries.     | no                 |
 | `explain_plans`   | Collect explain plans information.                           | yes                |
-| `table_stats`     | Collect table-level index usage statistics, for missing-index detection. | no |
-| `index_stats`     | Collect per-index usage statistics, for unused-index detection. | no |
+| `table_stats`     | Collect table-level index usage statistics.                  | no                 |
+| `index_stats`     | Collect per-index usage statistics.                           | no                 |
 
 ## Blocks
 

--- a/internal/component/database_observability/mysql/collector/exclude_schemas.go
+++ b/internal/component/database_observability/mysql/collector/exclude_schemas.go
@@ -1,6 +1,10 @@
 package collector
 
-import "github.com/grafana/alloy/internal/component/database_observability"
+import (
+	"strings"
+
+	"github.com/grafana/alloy/internal/component/database_observability"
+)
 
 var excludedSchemas = []string{"mysql", "performance_schema", "sys", "information_schema"}
 
@@ -15,4 +19,30 @@ func buildExcludedSchemasClause(schemas []string) string {
 	all = append(all, excludedSchemas...)
 	all = append(all, schemas...)
 	return database_observability.BuildExclusionClause(all)
+}
+
+// excludedSchemasArgs returns the combined default + custom excluded schemas
+// as query arguments, for callers that bind them as placeholders (`?`)
+// instead of formatting them into the SQL text.
+func excludedSchemasArgs(schemas []string) []any {
+	all := make([]string, 0, len(excludedSchemas)+len(schemas))
+	all = append(all, excludedSchemas...)
+	all = append(all, schemas...)
+
+	args := make([]any, len(all))
+	for i, s := range all {
+		args[i] = s
+	}
+	return args
+}
+
+// sqlPlaceholders returns a comma-separated list of n "?" placeholders, for
+// building a parameterized `IN (...)` / `NOT IN (...)` clause whose argument
+// count is dynamic.
+func sqlPlaceholders(n int) string {
+	placeholders := make([]string, n)
+	for i := range placeholders {
+		placeholders[i] = "?"
+	}
+	return strings.Join(placeholders, ", ")
 }

--- a/internal/component/database_observability/mysql/collector/exclude_schemas.go
+++ b/internal/component/database_observability/mysql/collector/exclude_schemas.go
@@ -22,8 +22,8 @@ func buildExcludedSchemasClause(schemas []string) string {
 }
 
 // excludedSchemasArgs returns the combined default + custom excluded schemas
-// as query arguments, for callers that bind them as placeholders (`?`)
-// instead of formatting them into the SQL text.
+// as query arguments, for binding as `?` placeholders instead of formatting
+// them into the SQL text.
 func excludedSchemasArgs(schemas []string) []any {
 	all := make([]string, 0, len(excludedSchemas)+len(schemas))
 	all = append(all, excludedSchemas...)

--- a/internal/component/database_observability/mysql/collector/exclude_schemas.go
+++ b/internal/component/database_observability/mysql/collector/exclude_schemas.go
@@ -25,13 +25,12 @@ func buildExcludedSchemasClause(schemas []string) string {
 // as query arguments, for binding as `?` placeholders instead of formatting
 // them into the SQL text.
 func excludedSchemasArgs(schemas []string) []any {
-	all := make([]string, 0, len(excludedSchemas)+len(schemas))
-	all = append(all, excludedSchemas...)
-	all = append(all, schemas...)
-
-	args := make([]any, len(all))
-	for i, s := range all {
-		args[i] = s
+	args := make([]any, 0, len(excludedSchemas)+len(schemas))
+	for _, s := range excludedSchemas {
+		args = append(args, s)
+	}
+	for _, s := range schemas {
+		args = append(args, s)
 	}
 	return args
 }

--- a/internal/component/database_observability/mysql/collector/exclude_schemas.go
+++ b/internal/component/database_observability/mysql/collector/exclude_schemas.go
@@ -1,10 +1,6 @@
 package collector
 
-import (
-	"strings"
-
-	"github.com/grafana/alloy/internal/component/database_observability"
-)
+import "github.com/grafana/alloy/internal/component/database_observability"
 
 var excludedSchemas = []string{"mysql", "performance_schema", "sys", "information_schema"}
 
@@ -19,29 +15,4 @@ func buildExcludedSchemasClause(schemas []string) string {
 	all = append(all, excludedSchemas...)
 	all = append(all, schemas...)
 	return database_observability.BuildExclusionClause(all)
-}
-
-// excludedSchemasArgs returns the combined default + custom excluded schemas
-// as query arguments, for binding as `?` placeholders instead of formatting
-// them into the SQL text.
-func excludedSchemasArgs(schemas []string) []any {
-	args := make([]any, 0, len(excludedSchemas)+len(schemas))
-	for _, s := range excludedSchemas {
-		args = append(args, s)
-	}
-	for _, s := range schemas {
-		args = append(args, s)
-	}
-	return args
-}
-
-// sqlPlaceholders returns a comma-separated list of n "?" placeholders, for
-// building a parameterized `IN (...)` / `NOT IN (...)` clause whose argument
-// count is dynamic.
-func sqlPlaceholders(n int) string {
-	placeholders := make([]string, n)
-	for i := range placeholders {
-		placeholders[i] = "?"
-	}
-	return strings.Join(placeholders, ", ")
 }

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -1,0 +1,177 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/blang/semver/v4"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+)
+
+// IndexStatsCollector emits the minimal per-index metrics needed for the
+// unused-index KG insight: the fetch count of each named-index row per
+// index, from performance_schema.table_io_waits_summary_by_index_usage, and
+// (MySQL >= 5.6.6 only, see minIndexSizeEngineVersion) its size in bytes,
+// from mysql.innodb_index_stats.
+const IndexStatsCollector = "index_stats"
+
+const selectIndexIOWaits = `
+	SELECT OBJECT_SCHEMA, OBJECT_NAME, INDEX_NAME, COUNT_FETCH
+	FROM performance_schema.table_io_waits_summary_by_index_usage
+	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN (%s)`
+
+// mysql.innodb_index_stats holds InnoDB's persistent optimizer statistics,
+// refreshed by MySQL itself (never by us) -- introduced in MySQL 5.6.6, its
+// schema (and the "size" stat, in pages) hasn't changed since. Reading it
+// requires the monitoring role to be granted SELECT on this one table, which
+// is not part of today's default grant set (see deployment_tools).
+const selectIndexSizeBytes = `
+	SELECT database_name, table_name, index_name, stat_value * @@innodb_page_size
+	FROM mysql.innodb_index_stats
+	WHERE stat_name = 'size' AND database_name NOT IN (%s)`
+
+// minIndexSizeEngineVersion is the first MySQL version where
+// mysql.innodb_index_stats exists at all (persistent optimizer statistics,
+// introduced 5.6.6) -- versions older than this have no size source, so the
+// query is skipped entirely below it rather than attempted and failing.
+var minIndexSizeEngineVersion = semver.MustParse("5.6.6")
+
+var indexLabels = []string{labelSchema, labelTable, "index"}
+
+var (
+	indexStatsIdxScanDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("mysql", "index_stats", "idx_scan_total"),
+		"Number of row fetches against this index",
+		indexLabels, nil,
+	)
+	indexStatsSizeBytesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("mysql", "index_stats", "size_bytes"),
+		"Total disk space used by this index, in bytes",
+		indexLabels, nil,
+	)
+)
+
+type IndexStatsArguments struct {
+	DB             *sql.DB
+	ExcludeSchemas []string
+	EngineVersion  semver.Version
+	Registry       *prometheus.Registry
+
+	Logger *slog.Logger
+}
+
+type IndexStats struct {
+	dbConnection   *sql.DB
+	excludeSchemas []string
+	engineVersion  semver.Version
+	registry       *prometheus.Registry
+
+	logger  *slog.Logger
+	running *atomic.Bool
+}
+
+func NewIndexStats(args IndexStatsArguments) (*IndexStats, error) {
+	return &IndexStats{
+		dbConnection:   args.DB,
+		excludeSchemas: args.ExcludeSchemas,
+		engineVersion:  args.EngineVersion,
+		registry:       args.Registry,
+		logger:         args.Logger.With("collector", IndexStatsCollector),
+		running:        &atomic.Bool{},
+	}, nil
+}
+
+func (c *IndexStats) Name() string {
+	return IndexStatsCollector
+}
+
+func (c *IndexStats) Start(_ context.Context) error {
+	if err := c.registry.Register(c); err != nil {
+		return err
+	}
+	c.running.Store(true)
+	return nil
+}
+
+func (c *IndexStats) Stopped() bool {
+	return !c.running.Load()
+}
+
+func (c *IndexStats) Stop() {
+	c.registry.Unregister(c)
+	c.running.Store(false)
+}
+
+// Describe implements prometheus.Collector.
+func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
+	ch <- indexStatsIdxScanDesc
+	ch <- indexStatsSizeBytesDesc
+}
+
+// Collect implements prometheus.Collector. It runs synchronously at scrape time.
+func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	c.collectIdxScan(ctx, ch)
+
+	if c.engineVersion.GE(minIndexSizeEngineVersion) {
+		c.collectIndexSize(ctx, ch)
+	}
+}
+
+func (c *IndexStats) collectIdxScan(ctx context.Context, ch chan<- prometheus.Metric) {
+	args := excludedSchemasArgs(c.excludeSchemas)
+	query := fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))
+	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
+	if err != nil {
+		c.logger.Error("failed to query table_io_waits_summary_by_index_usage", "err", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var objectSchema, objectName, indexName string
+		var countFetch uint64
+
+		if err := rows.Scan(&objectSchema, &objectName, &indexName, &countFetch); err != nil {
+			c.logger.Error("failed to scan table_io_waits_summary_by_index_usage row", "err", err)
+			return
+		}
+
+		ch <- prometheus.MustNewConstMetric(indexStatsIdxScanDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName, indexName)
+	}
+
+	if err := rows.Err(); err != nil {
+		c.logger.Error("error iterating table_io_waits_summary_by_index_usage rows", "err", err)
+	}
+}
+
+func (c *IndexStats) collectIndexSize(ctx context.Context, ch chan<- prometheus.Metric) {
+	args := excludedSchemasArgs(c.excludeSchemas)
+	query := fmt.Sprintf(selectIndexSizeBytes, sqlPlaceholders(len(args)))
+	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
+	if err != nil {
+		c.logger.Error("failed to query mysql.innodb_index_stats", "err", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var databaseName, tableName, indexName string
+		var sizeBytes float64
+
+		if err := rows.Scan(&databaseName, &tableName, &indexName, &sizeBytes); err != nil {
+			c.logger.Error("failed to scan mysql.innodb_index_stats row", "err", err)
+			return
+		}
+
+		ch <- prometheus.MustNewConstMetric(indexStatsSizeBytesDesc, prometheus.GaugeValue, sizeBytes, databaseName, tableName, indexName)
+	}
+
+	if err := rows.Err(); err != nil {
+		c.logger.Error("error iterating mysql.innodb_index_stats rows", "err", err)
+	}
+}

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -21,8 +21,7 @@ const selectIndexIOWaits = `
 	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN %s`
 
 // mysql.innodb_index_stats holds InnoDB's persistent optimizer statistics,
-// refreshed by MySQL itself, never by us. Reading it requires SELECT on this
-// one table, which isn't in today's default grant set.
+// refreshed by MySQL itself.
 const selectIndexSizeBytes = `
 	SELECT database_name, table_name, index_name, stat_value * @@innodb_page_size
 	FROM mysql.innodb_index_stats

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -18,7 +18,7 @@ const IndexStatsCollector = "index_stats"
 const selectIndexIOWaits = `
 	SELECT OBJECT_SCHEMA, OBJECT_NAME, INDEX_NAME, COUNT_FETCH
 	FROM performance_schema.table_io_waits_summary_by_index_usage
-	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN (%s)`
+	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN %s`
 
 // mysql.innodb_index_stats holds InnoDB's persistent optimizer statistics,
 // refreshed by MySQL itself, never by us. Reading it requires SELECT on this
@@ -26,7 +26,7 @@ const selectIndexIOWaits = `
 const selectIndexSizeBytes = `
 	SELECT database_name, table_name, index_name, stat_value * @@innodb_page_size
 	FROM mysql.innodb_index_stats
-	WHERE stat_name = 'size' AND database_name NOT IN (%s)`
+	WHERE stat_name = 'size' AND database_name NOT IN %s`
 
 var indexLabels = []string{labelSchema, labelTable, "index"}
 
@@ -106,9 +106,8 @@ func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (c *IndexStats) collectIdxScan(ctx context.Context, ch chan<- prometheus.Metric) {
-	args := excludedSchemasArgs(c.excludeSchemas)
-	query := fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))
-	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
+	query := fmt.Sprintf(selectIndexIOWaits, buildExcludedSchemasClause(c.excludeSchemas))
+	rows, err := c.dbConnection.QueryContext(ctx, query)
 	if err != nil {
 		c.logger.Error("failed to query table_io_waits_summary_by_index_usage", "err", err)
 		return
@@ -133,9 +132,8 @@ func (c *IndexStats) collectIdxScan(ctx context.Context, ch chan<- prometheus.Me
 }
 
 func (c *IndexStats) collectIndexSize(ctx context.Context, ch chan<- prometheus.Metric) {
-	args := excludedSchemasArgs(c.excludeSchemas)
-	query := fmt.Sprintf(selectIndexSizeBytes, sqlPlaceholders(len(args)))
-	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
+	query := fmt.Sprintf(selectIndexSizeBytes, buildExcludedSchemasClause(c.excludeSchemas))
+	rows, err := c.dbConnection.QueryContext(ctx, query)
 	if err != nil {
 		c.logger.Error("failed to query mysql.innodb_index_stats", "err", err)
 		return

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -6,15 +6,13 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 )
 
 // IndexStatsCollector emits the fetch count of each named-index row, from
-// performance_schema.table_io_waits_summary_by_index_usage, and (MySQL >=
-// 5.6.6, see minIndexSizeEngineVersion) its size in bytes, from
-// mysql.innodb_index_stats.
+// performance_schema.table_io_waits_summary_by_index_usage, and its size in
+// bytes, from mysql.innodb_index_stats.
 const IndexStatsCollector = "index_stats"
 
 const selectIndexIOWaits = `
@@ -29,11 +27,6 @@ const selectIndexSizeBytes = `
 	SELECT database_name, table_name, index_name, stat_value * @@innodb_page_size
 	FROM mysql.innodb_index_stats
 	WHERE stat_name = 'size' AND database_name NOT IN (%s)`
-
-// minIndexSizeEngineVersion is the first MySQL version with
-// mysql.innodb_index_stats; older versions have no size source, so the
-// query is skipped below it rather than attempted and failing.
-var minIndexSizeEngineVersion = semver.MustParse("5.6.6")
 
 var indexLabels = []string{labelSchema, labelTable, "index"}
 
@@ -53,7 +46,6 @@ var (
 type IndexStatsArguments struct {
 	DB             *sql.DB
 	ExcludeSchemas []string
-	EngineVersion  semver.Version
 	Registry       *prometheus.Registry
 
 	Logger *slog.Logger
@@ -62,7 +54,6 @@ type IndexStatsArguments struct {
 type IndexStats struct {
 	dbConnection   *sql.DB
 	excludeSchemas []string
-	engineVersion  semver.Version
 	registry       *prometheus.Registry
 
 	logger  *slog.Logger
@@ -73,7 +64,6 @@ func NewIndexStats(args IndexStatsArguments) (*IndexStats, error) {
 	return &IndexStats{
 		dbConnection:   args.DB,
 		excludeSchemas: args.ExcludeSchemas,
-		engineVersion:  args.EngineVersion,
 		registry:       args.Registry,
 		logger:         args.Logger.With("collector", IndexStatsCollector),
 		running:        &atomic.Bool{},
@@ -112,10 +102,7 @@ func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
 	c.collectIdxScan(ctx, ch)
-
-	if c.engineVersion.GE(minIndexSizeEngineVersion) {
-		c.collectIndexSize(ctx, ch)
-	}
+	c.collectIndexSize(ctx, ch)
 }
 
 func (c *IndexStats) collectIdxScan(ctx context.Context, ch chan<- prometheus.Metric) {

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -11,11 +11,10 @@ import (
 	"go.uber.org/atomic"
 )
 
-// IndexStatsCollector emits the minimal per-index metrics needed for the
-// unused-index KG insight: the fetch count of each named-index row per
-// index, from performance_schema.table_io_waits_summary_by_index_usage, and
-// (MySQL >= 5.6.6 only, see minIndexSizeEngineVersion) its size in bytes,
-// from mysql.innodb_index_stats.
+// IndexStatsCollector emits the fetch count of each named-index row, from
+// performance_schema.table_io_waits_summary_by_index_usage, and (MySQL >=
+// 5.6.6, see minIndexSizeEngineVersion) its size in bytes, from
+// mysql.innodb_index_stats.
 const IndexStatsCollector = "index_stats"
 
 const selectIndexIOWaits = `
@@ -24,19 +23,16 @@ const selectIndexIOWaits = `
 	WHERE INDEX_NAME IS NOT NULL AND OBJECT_SCHEMA NOT IN (%s)`
 
 // mysql.innodb_index_stats holds InnoDB's persistent optimizer statistics,
-// refreshed by MySQL itself (never by us) -- introduced in MySQL 5.6.6, its
-// schema (and the "size" stat, in pages) hasn't changed since. Reading it
-// requires the monitoring role to be granted SELECT on this one table, which
-// is not part of today's default grant set (see deployment_tools).
+// refreshed by MySQL itself, never by us. Reading it requires SELECT on this
+// one table, which isn't in today's default grant set.
 const selectIndexSizeBytes = `
 	SELECT database_name, table_name, index_name, stat_value * @@innodb_page_size
 	FROM mysql.innodb_index_stats
 	WHERE stat_name = 'size' AND database_name NOT IN (%s)`
 
-// minIndexSizeEngineVersion is the first MySQL version where
-// mysql.innodb_index_stats exists at all (persistent optimizer statistics,
-// introduced 5.6.6) -- versions older than this have no size source, so the
-// query is skipped entirely below it rather than attempted and failing.
+// minIndexSizeEngineVersion is the first MySQL version with
+// mysql.innodb_index_stats; older versions have no size source, so the
+// query is skipped below it rather than attempted and failing.
 var minIndexSizeEngineVersion = semver.MustParse("5.6.6")
 
 var indexLabels = []string{labelSchema, labelTable, "index"}

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -39,12 +39,12 @@ var indexLabels = []string{labelSchema, labelTable, "index"}
 
 var (
 	indexStatsIdxScanDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("mysql", "index_stats", "idx_scan_total"),
+		prometheus.BuildFQName("database_observability", "mysql_index_stats", "idx_scan_total"),
 		"Number of row fetches against this index",
 		indexLabels, nil,
 	)
 	indexStatsSizeBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("mysql", "index_stats", "size_bytes"),
+		prometheus.BuildFQName("database_observability", "mysql_index_stats", "size_bytes"),
 		"Total disk space used by this index, in bytes",
 		indexLabels, nil,
 	)

--- a/internal/component/database_observability/mysql/collector/index_stats.go
+++ b/internal/component/database_observability/mysql/collector/index_stats.go
@@ -31,9 +31,9 @@ const selectIndexSizeBytes = `
 var indexLabels = []string{labelSchema, labelTable, "index"}
 
 var (
-	indexStatsIdxScanDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("database_observability", "mysql_index_stats", "idx_scan_total"),
-		"Number of row fetches against this index",
+	indexStatsIdxFetchDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("database_observability", "mysql_index_stats", "idx_fetch_total"),
+		"Count of index I/O wait events for fetch operations",
 		indexLabels, nil,
 	)
 	indexStatsSizeBytesDesc = prometheus.NewDesc(
@@ -93,7 +93,7 @@ func (c *IndexStats) Stop() {
 
 // Describe implements prometheus.Collector.
 func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
-	ch <- indexStatsIdxScanDesc
+	ch <- indexStatsIdxFetchDesc
 	ch <- indexStatsSizeBytesDesc
 }
 
@@ -101,11 +101,11 @@ func (c *IndexStats) Describe(ch chan<- *prometheus.Desc) {
 func (c *IndexStats) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
-	c.collectIdxScan(ctx, ch)
+	c.collectIdxFetch(ctx, ch)
 	c.collectIndexSize(ctx, ch)
 }
 
-func (c *IndexStats) collectIdxScan(ctx context.Context, ch chan<- prometheus.Metric) {
+func (c *IndexStats) collectIdxFetch(ctx context.Context, ch chan<- prometheus.Metric) {
 	query := fmt.Sprintf(selectIndexIOWaits, buildExcludedSchemasClause(c.excludeSchemas))
 	rows, err := c.dbConnection.QueryContext(ctx, query)
 	if err != nil {
@@ -123,7 +123,7 @@ func (c *IndexStats) collectIdxScan(ctx context.Context, ch chan<- prometheus.Me
 			return
 		}
 
-		ch <- prometheus.MustNewConstMetric(indexStatsIdxScanDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName, indexName)
+		ch <- prometheus.MustNewConstMetric(indexStatsIdxFetchDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName, indexName)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/component/database_observability/mysql/collector/index_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/index_stats_test.go
@@ -1,0 +1,98 @@
+package collector
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/blang/semver/v4"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
+)
+
+func TestIndexStats(t *testing.T) {
+	t.Run("below minIndexSizeEngineVersion, size query is skipped", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		registry := prometheus.NewRegistry()
+
+		c, err := NewIndexStats(IndexStatsArguments{
+			DB:            db,
+			EngineVersion: semver.MustParse("5.5.62"),
+			Registry:      registry,
+			Logger:        util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, c.Start(t.Context()))
+		defer c.Stop()
+
+		args := excludedSchemasArgs(nil)
+		mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
+			WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
+					AddRow("books_store", "books", "idx_books_title", 0),
+			)
+
+		expected := `
+		# HELP mysql_index_stats_idx_scan_total Number of row fetches against this index
+		# TYPE mysql_index_stats_idx_scan_total counter
+		mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
+`
+
+		require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("at or above minIndexSizeEngineVersion, size is collected from mysql.innodb_index_stats", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		defer db.Close()
+
+		registry := prometheus.NewRegistry()
+
+		c, err := NewIndexStats(IndexStatsArguments{
+			DB:            db,
+			EngineVersion: semver.MustParse("8.0.36"),
+			Registry:      registry,
+			Logger:        util.TestAlloyLogger(t).Slog(),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, c.Start(t.Context()))
+		defer c.Stop()
+
+		args := excludedSchemasArgs(nil)
+		mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
+			WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
+					AddRow("books_store", "books", "idx_books_title", 0),
+			)
+		mock.ExpectQuery(fmt.Sprintf(selectIndexSizeBytes, sqlPlaceholders(len(args)))).
+			WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+			WillReturnRows(
+				sqlmock.NewRows([]string{"database_name", "table_name", "index_name", "size_bytes"}).
+					AddRow("books_store", "books", "idx_books_title", 14196736),
+			)
+
+		expected := `
+		# HELP mysql_index_stats_idx_scan_total Number of row fetches against this index
+		# TYPE mysql_index_stats_idx_scan_total counter
+		mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
+		# HELP mysql_index_stats_size_bytes Total disk space used by this index, in bytes
+		# TYPE mysql_index_stats_size_bytes gauge
+		mysql_index_stats_size_bytes{index="idx_books_title",schema="books_store",table="books"} 1.4196736e+07
+`
+
+		require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/internal/component/database_observability/mysql/collector/index_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/index_stats_test.go
@@ -30,15 +30,12 @@ func TestIndexStats(t *testing.T) {
 	require.NoError(t, c.Start(t.Context()))
 	defer c.Stop()
 
-	args := excludedSchemasArgs(nil)
-	mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
-		WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+	mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 		WillReturnRows(
 			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
 				AddRow("books_store", "books", "idx_books_title", 0),
 		)
-	mock.ExpectQuery(fmt.Sprintf(selectIndexSizeBytes, sqlPlaceholders(len(args)))).
-		WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+	mock.ExpectQuery(fmt.Sprintf(selectIndexSizeBytes, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 		WillReturnRows(
 			sqlmock.NewRows([]string{"database_name", "table_name", "index_name", "size_bytes"}).
 				AddRow("books_store", "books", "idx_books_title", 14196736),

--- a/internal/component/database_observability/mysql/collector/index_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/index_stats_test.go
@@ -42,9 +42,9 @@ func TestIndexStats(t *testing.T) {
 		)
 
 	expected := `
-	# HELP database_observability_mysql_index_stats_idx_scan_total Number of row fetches against this index
-	# TYPE database_observability_mysql_index_stats_idx_scan_total counter
-	database_observability_mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
+	# HELP database_observability_mysql_index_stats_idx_fetch_total Count of index I/O wait events for fetch operations
+	# TYPE database_observability_mysql_index_stats_idx_fetch_total counter
+	database_observability_mysql_index_stats_idx_fetch_total{index="idx_books_title",schema="books_store",table="books"} 0
 	# HELP database_observability_mysql_index_stats_size_bytes Total disk space used by this index, in bytes
 	# TYPE database_observability_mysql_index_stats_size_bytes gauge
 	database_observability_mysql_index_stats_size_bytes{index="idx_books_title",schema="books_store",table="books"} 1.4196736e+07

--- a/internal/component/database_observability/mysql/collector/index_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/index_stats_test.go
@@ -42,9 +42,9 @@ func TestIndexStats(t *testing.T) {
 			)
 
 		expected := `
-		# HELP mysql_index_stats_idx_scan_total Number of row fetches against this index
-		# TYPE mysql_index_stats_idx_scan_total counter
-		mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
+		# HELP database_observability_mysql_index_stats_idx_scan_total Number of row fetches against this index
+		# TYPE database_observability_mysql_index_stats_idx_scan_total counter
+		database_observability_mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
 `
 
 		require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
@@ -84,12 +84,12 @@ func TestIndexStats(t *testing.T) {
 			)
 
 		expected := `
-		# HELP mysql_index_stats_idx_scan_total Number of row fetches against this index
-		# TYPE mysql_index_stats_idx_scan_total counter
-		mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
-		# HELP mysql_index_stats_size_bytes Total disk space used by this index, in bytes
-		# TYPE mysql_index_stats_size_bytes gauge
-		mysql_index_stats_size_bytes{index="idx_books_title",schema="books_store",table="books"} 1.4196736e+07
+		# HELP database_observability_mysql_index_stats_idx_scan_total Number of row fetches against this index
+		# TYPE database_observability_mysql_index_stats_idx_scan_total counter
+		database_observability_mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
+		# HELP database_observability_mysql_index_stats_size_bytes Total disk space used by this index, in bytes
+		# TYPE database_observability_mysql_index_stats_size_bytes gauge
+		database_observability_mysql_index_stats_size_bytes{index="idx_books_title",schema="books_store",table="books"} 1.4196736e+07
 `
 
 		require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))

--- a/internal/component/database_observability/mysql/collector/index_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/index_stats_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -15,84 +14,45 @@ import (
 )
 
 func TestIndexStats(t *testing.T) {
-	t.Run("below minIndexSizeEngineVersion, size query is skipped", func(t *testing.T) {
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-		require.NoError(t, err)
-		defer db.Close()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
 
-		registry := prometheus.NewRegistry()
+	registry := prometheus.NewRegistry()
 
-		c, err := NewIndexStats(IndexStatsArguments{
-			DB:            db,
-			EngineVersion: semver.MustParse("5.5.62"),
-			Registry:      registry,
-			Logger:        util.TestAlloyLogger(t).Slog(),
-		})
-		require.NoError(t, err)
+	c, err := NewIndexStats(IndexStatsArguments{
+		DB:       db,
+		Registry: registry,
+		Logger:   util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
 
-		require.NoError(t, c.Start(t.Context()))
-		defer c.Stop()
+	require.NoError(t, c.Start(t.Context()))
+	defer c.Stop()
 
-		args := excludedSchemasArgs(nil)
-		mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
-			WithArgs(toDriverValues(args)...).RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
-					AddRow("books_store", "books", "idx_books_title", 0),
-			)
+	args := excludedSchemasArgs(nil)
+	mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
+		WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
+				AddRow("books_store", "books", "idx_books_title", 0),
+		)
+	mock.ExpectQuery(fmt.Sprintf(selectIndexSizeBytes, sqlPlaceholders(len(args)))).
+		WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{"database_name", "table_name", "index_name", "size_bytes"}).
+				AddRow("books_store", "books", "idx_books_title", 14196736),
+		)
 
-		expected := `
-		# HELP database_observability_mysql_index_stats_idx_scan_total Number of row fetches against this index
-		# TYPE database_observability_mysql_index_stats_idx_scan_total counter
-		database_observability_mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
+	expected := `
+	# HELP database_observability_mysql_index_stats_idx_scan_total Number of row fetches against this index
+	# TYPE database_observability_mysql_index_stats_idx_scan_total counter
+	database_observability_mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
+	# HELP database_observability_mysql_index_stats_size_bytes Total disk space used by this index, in bytes
+	# TYPE database_observability_mysql_index_stats_size_bytes gauge
+	database_observability_mysql_index_stats_size_bytes{index="idx_books_title",schema="books_store",table="books"} 1.4196736e+07
 `
 
-		require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
-		require.NoError(t, mock.ExpectationsWereMet())
-	})
-
-	t.Run("at or above minIndexSizeEngineVersion, size is collected from mysql.innodb_index_stats", func(t *testing.T) {
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-		require.NoError(t, err)
-		defer db.Close()
-
-		registry := prometheus.NewRegistry()
-
-		c, err := NewIndexStats(IndexStatsArguments{
-			DB:            db,
-			EngineVersion: semver.MustParse("8.0.36"),
-			Registry:      registry,
-			Logger:        util.TestAlloyLogger(t).Slog(),
-		})
-		require.NoError(t, err)
-
-		require.NoError(t, c.Start(t.Context()))
-		defer c.Stop()
-
-		args := excludedSchemasArgs(nil)
-		mock.ExpectQuery(fmt.Sprintf(selectIndexIOWaits, sqlPlaceholders(len(args)))).
-			WithArgs(toDriverValues(args)...).RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH"}).
-					AddRow("books_store", "books", "idx_books_title", 0),
-			)
-		mock.ExpectQuery(fmt.Sprintf(selectIndexSizeBytes, sqlPlaceholders(len(args)))).
-			WithArgs(toDriverValues(args)...).RowsWillBeClosed().
-			WillReturnRows(
-				sqlmock.NewRows([]string{"database_name", "table_name", "index_name", "size_bytes"}).
-					AddRow("books_store", "books", "idx_books_title", 14196736),
-			)
-
-		expected := `
-		# HELP database_observability_mysql_index_stats_idx_scan_total Number of row fetches against this index
-		# TYPE database_observability_mysql_index_stats_idx_scan_total counter
-		database_observability_mysql_index_stats_idx_scan_total{index="idx_books_title",schema="books_store",table="books"} 0
-		# HELP database_observability_mysql_index_stats_size_bytes Total disk space used by this index, in bytes
-		# TYPE database_observability_mysql_index_stats_size_bytes gauge
-		database_observability_mysql_index_stats_size_bytes{index="idx_books_title",schema="books_store",table="books"} 1.4196736e+07
-`
-
-		require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
-		require.NoError(t, mock.ExpectationsWereMet())
-	})
+	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
+	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/component/database_observability/mysql/collector/stats_registration_test.go
+++ b/internal/component/database_observability/mysql/collector/stats_registration_test.go
@@ -1,0 +1,36 @@
+package collector
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
+)
+
+// TestTableStatsAndIndexStatsShareRegistry guards against a regression where
+// TableStats and IndexStats fail to both register on the single registry the
+// component actually shares them on (e.g. if a future change makes them
+// declare an identical metric descriptor again). Per-collector tests each use
+// their own fresh registry and can't catch this; only registering both
+// together, as the component does, can.
+func TestTableStatsAndIndexStatsShareRegistry(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	registry := prometheus.NewRegistry()
+	logger := util.TestAlloyLogger(t).Slog()
+
+	tableStats, err := NewTableStats(TableStatsArguments{DB: db, Registry: registry, Logger: logger})
+	require.NoError(t, err)
+	require.NoError(t, tableStats.Start(t.Context()))
+	defer tableStats.Stop()
+
+	indexStats, err := NewIndexStats(IndexStatsArguments{DB: db, Registry: registry, Logger: logger})
+	require.NoError(t, err)
+	require.NoError(t, indexStats.Start(t.Context()))
+	defer indexStats.Stop()
+}

--- a/internal/component/database_observability/mysql/collector/stats_registration_test.go
+++ b/internal/component/database_observability/mysql/collector/stats_registration_test.go
@@ -11,11 +11,9 @@ import (
 )
 
 // TestTableStatsAndIndexStatsShareRegistry guards against a regression where
-// TableStats and IndexStats fail to both register on the single registry the
-// component actually shares them on (e.g. if a future change makes them
-// declare an identical metric descriptor again). Per-collector tests each use
-// their own fresh registry and can't catch this; only registering both
-// together, as the component does, can.
+// TableStats and IndexStats fail to both register on the registry the
+// component actually shares them on. Per-collector tests each use their own
+// fresh registry and can't catch this.
 func TestTableStatsAndIndexStatsShareRegistry(t *testing.T) {
 	db, _, err := sqlmock.New()
 	require.NoError(t, err)

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -1,0 +1,116 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+)
+
+// TableStatsCollector emits the minimal table-level metric needed for the
+// missing-index KG insight: the fetch count of the index="NONE" ("no index
+// used") row per table, from
+// performance_schema.table_io_waits_summary_by_index_usage.
+const TableStatsCollector = "table_stats"
+
+const selectTableIOWaitsNoIndex = `
+	SELECT OBJECT_SCHEMA, OBJECT_NAME, COUNT_FETCH
+	FROM performance_schema.table_io_waits_summary_by_index_usage
+	WHERE INDEX_NAME IS NULL AND OBJECT_SCHEMA NOT IN (%s)`
+
+const (
+	labelSchema = "schema"
+	labelTable  = "table"
+)
+
+var tableStatsSeqScanDesc = prometheus.NewDesc(
+	prometheus.BuildFQName("mysql", "table_stats", "seq_scan_total"),
+	"Number of row fetches against this table that did not use an index",
+	[]string{labelSchema, labelTable}, nil,
+)
+
+type TableStatsArguments struct {
+	DB             *sql.DB
+	ExcludeSchemas []string
+	Registry       *prometheus.Registry
+
+	Logger *slog.Logger
+}
+
+type TableStats struct {
+	dbConnection   *sql.DB
+	excludeSchemas []string
+	registry       *prometheus.Registry
+
+	logger  *slog.Logger
+	running *atomic.Bool
+}
+
+func NewTableStats(args TableStatsArguments) (*TableStats, error) {
+	return &TableStats{
+		dbConnection:   args.DB,
+		excludeSchemas: args.ExcludeSchemas,
+		registry:       args.Registry,
+		logger:         args.Logger.With("collector", TableStatsCollector),
+		running:        &atomic.Bool{},
+	}, nil
+}
+
+func (c *TableStats) Name() string {
+	return TableStatsCollector
+}
+
+func (c *TableStats) Start(_ context.Context) error {
+	if err := c.registry.Register(c); err != nil {
+		return err
+	}
+	c.running.Store(true)
+	return nil
+}
+
+func (c *TableStats) Stopped() bool {
+	return !c.running.Load()
+}
+
+func (c *TableStats) Stop() {
+	c.registry.Unregister(c)
+	c.running.Store(false)
+}
+
+// Describe implements prometheus.Collector.
+func (c *TableStats) Describe(ch chan<- *prometheus.Desc) {
+	ch <- tableStatsSeqScanDesc
+}
+
+// Collect implements prometheus.Collector. It runs synchronously at scrape time.
+func (c *TableStats) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	args := excludedSchemasArgs(c.excludeSchemas)
+	query := fmt.Sprintf(selectTableIOWaitsNoIndex, sqlPlaceholders(len(args)))
+	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
+	if err != nil {
+		c.logger.Error("failed to query table_io_waits_summary_by_index_usage", "err", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var objectSchema, objectName string
+		var countFetch uint64
+
+		if err := rows.Scan(&objectSchema, &objectName, &countFetch); err != nil {
+			c.logger.Error("failed to scan table_io_waits_summary_by_index_usage row", "err", err)
+			return
+		}
+
+		ch <- prometheus.MustNewConstMetric(tableStatsSeqScanDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName)
+	}
+
+	if err := rows.Err(); err != nil {
+		c.logger.Error("error iterating table_io_waits_summary_by_index_usage rows", "err", err)
+	}
+}

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -25,9 +25,9 @@ const (
 	labelTable  = "table"
 )
 
-var tableStatsNoIndexFetchDesc = prometheus.NewDesc(
-	prometheus.BuildFQName("database_observability", "mysql_table_stats", "no_index_fetch_total"),
-	"Number of row fetches against this table that did not use an index",
+var tableStatsNoIdxFetchDesc = prometheus.NewDesc(
+	prometheus.BuildFQName("database_observability", "mysql_table_stats", "no_idx_fetch_total"),
+	"Count of index I/O wait events for fetch operations that did not use an index",
 	[]string{labelSchema, labelTable}, nil,
 )
 
@@ -81,7 +81,7 @@ func (c *TableStats) Stop() {
 
 // Describe implements prometheus.Collector.
 func (c *TableStats) Describe(ch chan<- *prometheus.Desc) {
-	ch <- tableStatsNoIndexFetchDesc
+	ch <- tableStatsNoIdxFetchDesc
 }
 
 // Collect implements prometheus.Collector. It runs synchronously at scrape time.
@@ -105,7 +105,7 @@ func (c *TableStats) Collect(ch chan<- prometheus.Metric) {
 			return
 		}
 
-		ch <- prometheus.MustNewConstMetric(tableStatsNoIndexFetchDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName)
+		ch <- prometheus.MustNewConstMetric(tableStatsNoIdxFetchDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -10,8 +10,7 @@ import (
 	"go.uber.org/atomic"
 )
 
-// TableStatsCollector emits the minimal table-level metric needed for the
-// missing-index KG insight: the fetch count of the index="NONE" ("no index
+// TableStatsCollector emits the fetch count of the index="NONE" ("no index
 // used") row per table, from
 // performance_schema.table_io_waits_summary_by_index_usage.
 const TableStatsCollector = "table_stats"

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -26,7 +26,7 @@ const (
 )
 
 var tableStatsSeqScanDesc = prometheus.NewDesc(
-	prometheus.BuildFQName("mysql", "table_stats", "seq_scan_total"),
+	prometheus.BuildFQName("database_observability", "mysql_table_stats", "seq_scan_total"),
 	"Number of row fetches against this table that did not use an index",
 	[]string{labelSchema, labelTable}, nil,
 )

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -18,7 +18,7 @@ const TableStatsCollector = "table_stats"
 const selectTableIOWaitsNoIndex = `
 	SELECT OBJECT_SCHEMA, OBJECT_NAME, COUNT_FETCH
 	FROM performance_schema.table_io_waits_summary_by_index_usage
-	WHERE INDEX_NAME IS NULL AND OBJECT_SCHEMA NOT IN (%s)`
+	WHERE INDEX_NAME IS NULL AND OBJECT_SCHEMA NOT IN %s`
 
 const (
 	labelSchema = "schema"
@@ -88,9 +88,8 @@ func (c *TableStats) Describe(ch chan<- *prometheus.Desc) {
 func (c *TableStats) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
-	args := excludedSchemasArgs(c.excludeSchemas)
-	query := fmt.Sprintf(selectTableIOWaitsNoIndex, sqlPlaceholders(len(args)))
-	rows, err := c.dbConnection.QueryContext(ctx, query, args...)
+	query := fmt.Sprintf(selectTableIOWaitsNoIndex, buildExcludedSchemasClause(c.excludeSchemas))
+	rows, err := c.dbConnection.QueryContext(ctx, query)
 	if err != nil {
 		c.logger.Error("failed to query table_io_waits_summary_by_index_usage", "err", err)
 		return

--- a/internal/component/database_observability/mysql/collector/table_stats.go
+++ b/internal/component/database_observability/mysql/collector/table_stats.go
@@ -25,8 +25,8 @@ const (
 	labelTable  = "table"
 )
 
-var tableStatsSeqScanDesc = prometheus.NewDesc(
-	prometheus.BuildFQName("database_observability", "mysql_table_stats", "seq_scan_total"),
+var tableStatsNoIndexFetchDesc = prometheus.NewDesc(
+	prometheus.BuildFQName("database_observability", "mysql_table_stats", "no_index_fetch_total"),
 	"Number of row fetches against this table that did not use an index",
 	[]string{labelSchema, labelTable}, nil,
 )
@@ -81,7 +81,7 @@ func (c *TableStats) Stop() {
 
 // Describe implements prometheus.Collector.
 func (c *TableStats) Describe(ch chan<- *prometheus.Desc) {
-	ch <- tableStatsSeqScanDesc
+	ch <- tableStatsNoIndexFetchDesc
 }
 
 // Collect implements prometheus.Collector. It runs synchronously at scrape time.
@@ -105,7 +105,7 @@ func (c *TableStats) Collect(ch chan<- prometheus.Metric) {
 			return
 		}
 
-		ch <- prometheus.MustNewConstMetric(tableStatsSeqScanDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName)
+		ch <- prometheus.MustNewConstMetric(tableStatsNoIndexFetchDesc, prometheus.CounterValue, float64(countFetch), objectSchema, objectName)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/component/database_observability/mysql/collector/table_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/table_stats_test.go
@@ -1,0 +1,60 @@
+package collector
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alloy/internal/util"
+)
+
+// toDriverValues converts args built for QueryContext (a mysql query's
+// natural argument type is any) into the []driver.Value sqlmock expects.
+func toDriverValues(args []any) []driver.Value {
+	values := make([]driver.Value, len(args))
+	for i, a := range args {
+		values[i] = a
+	}
+	return values
+}
+
+func TestTableStats(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	registry := prometheus.NewRegistry()
+
+	c, err := NewTableStats(TableStatsArguments{
+		DB:       db,
+		Registry: registry,
+		Logger:   util.TestAlloyLogger(t).Slog(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Start(t.Context()))
+	defer c.Stop()
+
+	args := excludedSchemasArgs(nil)
+	mock.ExpectQuery(fmt.Sprintf(selectTableIOWaitsNoIndex, sqlPlaceholders(len(args)))).
+		WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+		WillReturnRows(
+			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "COUNT_FETCH"}).
+				AddRow("books_store", "books", 39),
+		)
+
+	expected := `
+	# HELP mysql_table_stats_seq_scan_total Number of row fetches against this table that did not use an index
+	# TYPE mysql_table_stats_seq_scan_total counter
+	mysql_table_stats_seq_scan_total{schema="books_store",table="books"} 39
+`
+
+	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/component/database_observability/mysql/collector/table_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/table_stats_test.go
@@ -1,7 +1,6 @@
 package collector
 
 import (
-	"database/sql/driver"
 	"fmt"
 	"strings"
 	"testing"
@@ -13,16 +12,6 @@ import (
 
 	"github.com/grafana/alloy/internal/util"
 )
-
-// toDriverValues converts args built for QueryContext (a mysql query's
-// natural argument type is any) into the []driver.Value sqlmock expects.
-func toDriverValues(args []any) []driver.Value {
-	values := make([]driver.Value, len(args))
-	for i, a := range args {
-		values[i] = a
-	}
-	return values
-}
 
 func TestTableStats(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -41,9 +30,7 @@ func TestTableStats(t *testing.T) {
 	require.NoError(t, c.Start(t.Context()))
 	defer c.Stop()
 
-	args := excludedSchemasArgs(nil)
-	mock.ExpectQuery(fmt.Sprintf(selectTableIOWaitsNoIndex, sqlPlaceholders(len(args)))).
-		WithArgs(toDriverValues(args)...).RowsWillBeClosed().
+	mock.ExpectQuery(fmt.Sprintf(selectTableIOWaitsNoIndex, exclusionClause)).WithoutArgs().RowsWillBeClosed().
 		WillReturnRows(
 			sqlmock.NewRows([]string{"OBJECT_SCHEMA", "OBJECT_NAME", "COUNT_FETCH"}).
 				AddRow("books_store", "books", 39),

--- a/internal/component/database_observability/mysql/collector/table_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/table_stats_test.go
@@ -50,9 +50,9 @@ func TestTableStats(t *testing.T) {
 		)
 
 	expected := `
-	# HELP mysql_table_stats_seq_scan_total Number of row fetches against this table that did not use an index
-	# TYPE mysql_table_stats_seq_scan_total counter
-	mysql_table_stats_seq_scan_total{schema="books_store",table="books"} 39
+	# HELP database_observability_mysql_table_stats_seq_scan_total Number of row fetches against this table that did not use an index
+	# TYPE database_observability_mysql_table_stats_seq_scan_total counter
+	database_observability_mysql_table_stats_seq_scan_total{schema="books_store",table="books"} 39
 `
 
 	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))

--- a/internal/component/database_observability/mysql/collector/table_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/table_stats_test.go
@@ -37,9 +37,9 @@ func TestTableStats(t *testing.T) {
 		)
 
 	expected := `
-	# HELP database_observability_mysql_table_stats_no_index_fetch_total Number of row fetches against this table that did not use an index
-	# TYPE database_observability_mysql_table_stats_no_index_fetch_total counter
-	database_observability_mysql_table_stats_no_index_fetch_total{schema="books_store",table="books"} 39
+	# HELP database_observability_mysql_table_stats_no_idx_fetch_total Count of index I/O wait events for fetch operations that did not use an index
+	# TYPE database_observability_mysql_table_stats_no_idx_fetch_total counter
+	database_observability_mysql_table_stats_no_idx_fetch_total{schema="books_store",table="books"} 39
 `
 
 	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))

--- a/internal/component/database_observability/mysql/collector/table_stats_test.go
+++ b/internal/component/database_observability/mysql/collector/table_stats_test.go
@@ -37,9 +37,9 @@ func TestTableStats(t *testing.T) {
 		)
 
 	expected := `
-	# HELP database_observability_mysql_table_stats_seq_scan_total Number of row fetches against this table that did not use an index
-	# TYPE database_observability_mysql_table_stats_seq_scan_total counter
-	database_observability_mysql_table_stats_seq_scan_total{schema="books_store",table="books"} 39
+	# HELP database_observability_mysql_table_stats_no_index_fetch_total Number of row fetches against this table that did not use an index
+	# TYPE database_observability_mysql_table_stats_no_index_fetch_total counter
+	database_observability_mysql_table_stats_no_index_fetch_total{schema="books_store",table="books"} 39
 `
 
 	require.NoError(t, testutil.CollectAndCompare(registry, strings.NewReader(expected)))

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -1024,7 +1024,6 @@ func (c *Component) startCollectors(inst *dbInstance, serverID string, engineVer
 		isCollector, err := collector.NewIndexStats(collector.IndexStatsArguments{
 			DB:             inst.dbConnection,
 			ExcludeSchemas: c.args.ExcludeSchemas,
-			EngineVersion:  parsedEngineVersion,
 			Registry:       inst.registry,
 			Logger:         c.opts.Logger,
 		})

--- a/internal/component/database_observability/mysql/component.go
+++ b/internal/component/database_observability/mysql/component.go
@@ -810,6 +810,8 @@ func enableOrDisableCollectors(a Arguments) map[string]bool {
 		collector.QuerySamplesCollector:   true,
 		collector.ExplainPlansCollector:   true,
 		collector.LocksCollector:          false,
+		collector.TableStatsCollector:     false,
+		collector.IndexStatsCollector:     false,
 	}
 
 	for _, disabled := range a.DisableCollectors {
@@ -998,6 +1000,41 @@ func (c *Component) startCollectors(inst *dbInstance, serverID string, engineVer
 				logStartError(collector.ExplainPlansCollector, "start", err)
 			}
 			inst.collectors = append(inst.collectors, epCollector)
+		}
+	}
+
+	if collectors[collector.TableStatsCollector] {
+		tsCollector, err := collector.NewTableStats(collector.TableStatsArguments{
+			DB:             inst.dbConnection,
+			ExcludeSchemas: c.args.ExcludeSchemas,
+			Registry:       inst.registry,
+			Logger:         c.opts.Logger,
+		})
+		if err != nil {
+			logStartError(collector.TableStatsCollector, "create", err)
+		} else {
+			if err := tsCollector.Start(context.Background()); err != nil {
+				logStartError(collector.TableStatsCollector, "start", err)
+			}
+			inst.collectors = append(inst.collectors, tsCollector)
+		}
+	}
+
+	if collectors[collector.IndexStatsCollector] {
+		isCollector, err := collector.NewIndexStats(collector.IndexStatsArguments{
+			DB:             inst.dbConnection,
+			ExcludeSchemas: c.args.ExcludeSchemas,
+			EngineVersion:  parsedEngineVersion,
+			Registry:       inst.registry,
+			Logger:         c.opts.Logger,
+		})
+		if err != nil {
+			logStartError(collector.IndexStatsCollector, "create", err)
+		} else {
+			if err := isCollector.Start(context.Background()); err != nil {
+				logStartError(collector.IndexStatsCollector, "start", err)
+			}
+			inst.collectors = append(inst.collectors, isCollector)
 		}
 	}
 

--- a/internal/component/database_observability/mysql/component_test.go
+++ b/internal/component/database_observability/mysql/component_test.go
@@ -263,6 +263,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          false,
+			collector.TableStatsCollector:     false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -288,6 +290,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          true,
+			collector.TableStatsCollector:     false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -313,6 +317,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    false,
 			collector.ExplainPlansCollector:   false,
 			collector.LocksCollector:          false,
+			collector.TableStatsCollector:     false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -339,6 +345,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          true,
+			collector.TableStatsCollector:     false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -365,6 +373,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    false,
 			collector.ExplainPlansCollector:   false,
 			collector.LocksCollector:          false,
+			collector.TableStatsCollector:     false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 
@@ -391,6 +401,8 @@ func Test_enableOrDisableCollectors(t *testing.T) {
 			collector.SetupActorsCollector:    true,
 			collector.ExplainPlansCollector:   true,
 			collector.LocksCollector:          false,
+			collector.TableStatsCollector:     false,
+			collector.IndexStatsCollector:     false,
 		}, actualCollectors)
 	})
 }


### PR DESCRIPTION
### Brief description of Pull Request

Split out of #7003 (originally combined postgres + mysql; splitting per one-logical-change-per-PR).

Adds two opt-in collectors to `database_observability.mysql`, disabled by default and enabled via `enable_collectors`, emitting only the metrics needed for missing-index and unused-index:

- `table_stats` — `mysql_table_stats_seq_scan_total{schema,table}`, the fetch count of the `index="NONE"` ("no index used") row per table.
- `index_stats` — `mysql_index_stats_idx_scan_total{schema,table,index}`, the same counter for each named-index row, plus (MySQL >= 5.6.6) `mysql_index_stats_size_bytes{schema,table,index}` from `mysql.innodb_index_stats` (InnoDB's persistent optimizer statistics, refreshed by MySQL itself, never triggered by us).

Both read `performance_schema.table_io_waits_summary_by_index_usage` and bind the excluded-schema list as query parameters rather than formatting it into the SQL text. Each collector owns its own metric name rather than sharing one upstream-style name (`mysqld_exporter`'s `perf_schema.indexiowaits`) across two independently-toggleable collectors, which would mean one collector's data being silently incomplete under a shared name whenever only one is enabled.

**Known dependency**: `mysql_index_stats_size_bytes` requires `GRANT SELECT ON mysql.innodb_index_stats` on the monitoring role, which is not part of today's default grant set (verified against the actual `db-o11y` MySQL role's live grants). Missing the grant degrades gracefully (logged error, the metric just doesn't appear).

Validated against a live `db-o11y` MySQL test instance hosting real `books_store`/`employees` data: every emitted series across both collectors, including the size metric, matched the database source exactly.

### Pull Request Details



### Issue(s) fixed by this Pull Request



### Notes to the Reviewer



### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))