### PR TITLE
docs: Fix bad link in the OTel components inclusion guide

### DIFF
--- a/docs/developer/add-otel-component.md
+++ b/docs/developer/add-otel-component.md
@@ -310,4 +310,4 @@ You can find us most easily in the `#alloy` channel in the Grafana [community sl
 We also have monthly community calls that you can participate in.
 You can find more details in Slack or in the [community calendar](https://calendar.google.com/calendar/u/0/embed?src=grafana.com_n57lluqpn4h4edroeje6199o00@group.calendar.google.com).
 
-[ocb]: ../sources/set-up/otel_engine.md#custom-builds-with-the-opentelemetry-collector-builder-ocb
+[ocb]: https://grafana.com/docs/alloy/latest/set-up/otel_engine/#custom-builds-with-the-opentelemetry-collector-builder-ocb


### PR DESCRIPTION
### Brief description of Pull Request
The current link in the OTel component inclusion docs to the OCB guide takes users to the .md file, but that file is supposed to be rendered in the web docs since it includes `{{ ... }}` params. This PR fixes the link so it points to the web docs instead of the raw file.