### PR TITLE
fix(database_observability.postgres): Set explain plan `search_path` to all schemas of the database

### DIFF
--- a/internal/component/database_observability/postgres/collector/explain_plans.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -227,6 +228,7 @@ type ExplainPlansArguments struct {
 	ExcludeUsers     []string
 	EntryHandler     loki.EntryHandler
 	DBVersion        string
+	TableRegistry    *TableRegistry
 
 	Logger *slog.Logger
 }
@@ -245,6 +247,7 @@ type ExplainPlans struct {
 	perScrapeRatio      float64
 	currentBatchSize    int
 	entryHandler        loki.EntryHandler
+	tableRegistry       *TableRegistry
 	lastEmittedAt       map[string]time.Time
 	now                 func() time.Time
 	logger              *slog.Logger
@@ -269,6 +272,7 @@ func NewExplainPlan(args ExplainPlansArguments) (*ExplainPlans, error) {
 		lastEmittedAt:       make(map[string]time.Time),
 		now:                 time.Now,
 		entryHandler:        args.EntryHandler,
+		tableRegistry:       args.TableRegistry,
 		logger:              args.Logger.With("collector", ExplainPlanCollector),
 		running:             atomic.NewBool(false),
 	}
@@ -643,6 +647,48 @@ func postgresPreparedStatementParamCount(queryText string) int {
 	return maxParam
 }
 
+// buildSearchPathStatement builds the "SET SESSION search_path ..." statement executed before
+// preparing an explain plan. When the table registry knows the schemas for the database, all of
+// them are included (with public always last as a catch-all) so that unqualified table names in
+// the query can resolve regardless of which schema they live in. When the registry is unavailable
+// (schema_details disabled, cold start, or a database with no tables) it falls back to the public
+// schema only.
+func (c *ExplainPlans) buildSearchPathStatement(datname string) string {
+	const prefix = "SET SESSION search_path TO "
+
+	if c.tableRegistry != nil {
+		if schemas := c.tableRegistry.SchemasForDatabase(database(datname)); len(schemas) > 0 {
+			nonPublic := make([]string, 0, len(schemas))
+			for _, s := range schemas {
+				if s != "public" {
+					nonPublic = append(nonPublic, s)
+				}
+			}
+
+			// Sort for deterministic output. Note that the order only affects resolution of
+			// table names that are duplicated across schemas, which is inherently ambiguous
+			// for queries that do not use qualified table names.
+			sort.Strings(nonPublic)
+
+			quoted := make([]string, 0, len(nonPublic)+1)
+			for _, s := range nonPublic {
+				quoted = append(quoted, quotePostgresIdentifier(s))
+			}
+			quoted = append(quoted, quotePostgresIdentifier("public"))
+
+			return prefix + strings.Join(quoted, ", ")
+		}
+	}
+
+	return prefix + quotePostgresIdentifier("public")
+}
+
+// quotePostgresIdentifier wraps an identifier in double quotes, escaping any embedded double
+// quotes, so it can be safely used as a schema name in a search_path statement.
+func quotePostgresIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
 func (c *ExplainPlans) fetchExplainPlanJSON(ctx context.Context, qi queryInfo) ([]byte, error) {
 	querySpecificDSN, err := replaceDatabaseNameInDSN(c.dbDSN, qi.datname)
 	if err != nil {
@@ -654,7 +700,7 @@ func (c *ExplainPlans) fetchExplainPlanJSON(ctx context.Context, qi queryInfo) (
 	}
 	defer conn.Close()
 
-	setSearchPathStatement := fmt.Sprintf("SET SESSION search_path TO \"%s\", public", qi.datname)
+	setSearchPathStatement := c.buildSearchPathStatement(qi.datname)
 	if _, err := conn.ExecContext(ctx, setSearchPathStatement); err != nil {
 		return nil, fmt.Errorf("failed to set search path: %w", err)
 	}

--- a/internal/component/database_observability/postgres/collector/explain_plans_test.go
+++ b/internal/component/database_observability/postgres/collector/explain_plans_test.go
@@ -44,6 +44,52 @@ func validatePlan(t *testing.T, expect, actual database_observability.ExplainPla
 	})
 }
 
+func Test_ExplainPlans_buildSearchPathStatement(t *testing.T) {
+	t.Run("falls back to public only when registry is nil", func(t *testing.T) {
+		ep := &ExplainPlans{}
+		assert.Equal(t, `SET SESSION search_path TO "public"`, ep.buildSearchPathStatement("testdb"))
+	})
+
+	t.Run("falls back to public only when database is unknown to the registry", func(t *testing.T) {
+		reg := NewTableRegistry()
+		reg.SetTablesForDatabase("otherdb", []*tableInfo{
+			{database: "otherdb", schema: "public", tableName: "users"},
+		})
+		ep := &ExplainPlans{tableRegistry: reg}
+		assert.Equal(t, `SET SESSION search_path TO "public"`, ep.buildSearchPathStatement("testdb"))
+	})
+
+	t.Run("includes all schemas with public last", func(t *testing.T) {
+		reg := NewTableRegistry()
+		reg.SetTablesForDatabase("testdb", []*tableInfo{
+			{database: "testdb", schema: "catalog", tableName: "products"},
+			{database: "testdb", schema: "auth", tableName: "users"},
+			{database: "testdb", schema: "public", tableName: "databasechangelog"},
+		})
+		ep := &ExplainPlans{tableRegistry: reg}
+		// Non-public schemas are sorted alphabetically; public is always appended last.
+		assert.Equal(t, `SET SESSION search_path TO "auth", "catalog", "public"`, ep.buildSearchPathStatement("testdb"))
+	})
+
+	t.Run("appends public when the database has no public schema", func(t *testing.T) {
+		reg := NewTableRegistry()
+		reg.SetTablesForDatabase("testdb", []*tableInfo{
+			{database: "testdb", schema: "catalog", tableName: "products"},
+		})
+		ep := &ExplainPlans{tableRegistry: reg}
+		assert.Equal(t, `SET SESSION search_path TO "catalog", "public"`, ep.buildSearchPathStatement("testdb"))
+	})
+
+	t.Run("escapes embedded double quotes in schema names", func(t *testing.T) {
+		reg := NewTableRegistry()
+		reg.SetTablesForDatabase("testdb", []*tableInfo{
+			{database: "testdb", schema: `we"ird`, tableName: "t"},
+		})
+		ep := &ExplainPlans{tableRegistry: reg}
+		assert.Equal(t, `SET SESSION search_path TO "we""ird", "public"`, ep.buildSearchPathStatement("testdb"))
+	})
+}
+
 type mockDbConnectionFactory struct {
 	Mock               *sqlmock.Sqlmock
 	InstantiationCount int
@@ -2422,7 +2468,7 @@ func TestExplainPlansThrottling(t *testing.T) {
 		require.Contains(t, c.queryCache, key)
 		require.Equal(t, 1, c.currentBatchSize)
 
-		mock.ExpectExec(`SET SESSION search_path TO "testdb", public`).WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(`SET SESSION search_path TO "public"`).WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec("PREPARE explain_plan_123456 AS select * from some_table").WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456").
@@ -3160,7 +3206,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 			require.Equal(t, "complex_aggregation_with_case.json", jsonFile.Name)
 			jsonData := jsonFile.Data
 
-			mock.ExpectExec("SET SESSION search_path TO \"testdb\", public").WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec("SET SESSION search_path TO \"public\"").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("PREPARE explain_plan_123456 AS select * from some_table where id = $1").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456(null)").WillReturnRows(sqlmock.NewRows([]string{"json"}).AddRow(jsonData))
@@ -3227,7 +3273,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 			require.Equal(t, "complex_aggregation_with_case.json", jsonFile.Name)
 			jsonData := jsonFile.Data
 
-			mock.ExpectExec("SET SESSION search_path TO \"testdb\", public").WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec("SET SESSION search_path TO \"public\"").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("PREPARE explain_plan_123456 AS with cte as (select * from some_table where id = $1) select * from cte").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456(null)").WillReturnRows(sqlmock.NewRows([]string{"json"}).AddRow(jsonData))
@@ -3295,7 +3341,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 			require.Equal(t, "complex_aggregation_with_case.json", jsonFile.Name)
 			jsonData := jsonFile.Data
 
-			mock.ExpectExec("SET SESSION search_path TO \"testdb\", public").WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec("SET SESSION search_path TO \"public\"").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("PREPARE explain_plan_123456 AS " + dupParamQuery).WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456(null,null,null)").WillReturnRows(sqlmock.NewRows([]string{"json"}).AddRow(jsonData))
@@ -3363,7 +3409,7 @@ func TestExplainPlanFetchExplainPlans(t *testing.T) {
 			require.Equal(t, "complex_aggregation_with_case.json", jsonFile.Name)
 			jsonData := jsonFile.Data
 
-			mock.ExpectExec("SET SESSION search_path TO \"testdb\", public").WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec("SET SESSION search_path TO \"public\"").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("PREPARE explain_plan_123456 AS select * from some_table").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectExec("SET plan_cache_mode = force_generic_plan").WillReturnResult(sqlmock.NewResult(0, 1))
 			mock.ExpectQuery("EXPLAIN (FORMAT JSON) EXECUTE explain_plan_123456").WillReturnRows(sqlmock.NewRows([]string{"json"}).AddRow(jsonData))

--- a/internal/component/database_observability/postgres/collector/schema_details.go
+++ b/internal/component/database_observability/postgres/collector/schema_details.go
@@ -242,6 +242,24 @@ func (tr *TableRegistry) SetTablesForDatabase(database database, tablesInfo []*t
 	}
 }
 
+// SchemasForDatabase returns the known schema names for a database, or nil if the
+// database is unknown to the registry.
+func (tr *TableRegistry) SchemasForDatabase(database database) []string {
+	tr.mu.RLock()
+	defer tr.mu.RUnlock()
+
+	schemas, ok := tr.tables[database]
+	if !ok {
+		return nil
+	}
+
+	out := make([]string, 0, len(schemas))
+	for s := range schemas {
+		out = append(out, string(s))
+	}
+	return out
+}
+
 // IsValid returns whether or not a given database and parsed table name exists in the source-of-truth table registry.
 // It also returns the resolved table name, which may differ from the input (e.g. lowercased due to PostgreSQL's identifier folding).
 func (tr *TableRegistry) IsValid(database database, parsedTableName string) (string, bool) {

--- a/internal/component/database_observability/postgres/collector/schema_details_test.go
+++ b/internal/component/database_observability/postgres/collector/schema_details_test.go
@@ -2008,6 +2008,34 @@ func Test_parseSchemaQualifiedIfAny(t *testing.T) {
 	}
 }
 
+func Test_TableRegistry_SchemasForDatabase(t *testing.T) {
+	t.Run("returns all schemas for a known database", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTablesForDatabase("mydb", []*tableInfo{
+			{database: "mydb", schema: "public", tableName: "users"},
+			{database: "mydb", schema: "catalog", tableName: "products"},
+			{database: "mydb", schema: "catalog", tableName: "categories"},
+		})
+
+		schemas := tr.SchemasForDatabase("mydb")
+		assert.ElementsMatch(t, []string{"public", "catalog"}, schemas)
+	})
+
+	t.Run("returns nil for an unknown database", func(t *testing.T) {
+		tr := NewTableRegistry()
+		tr.SetTablesForDatabase("mydb", []*tableInfo{
+			{database: "mydb", schema: "public", tableName: "users"},
+		})
+
+		assert.Nil(t, tr.SchemasForDatabase("otherdb"))
+	})
+
+	t.Run("returns nil for an empty registry", func(t *testing.T) {
+		tr := NewTableRegistry()
+		assert.Nil(t, tr.SchemasForDatabase("mydb"))
+	})
+}
+
 func Test_SchemaDetails_populates_TableRegistry(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"))
 

--- a/internal/component/database_observability/postgres/component.go
+++ b/internal/component/database_observability/postgres/component.go
@@ -661,6 +661,7 @@ func (c *Component) startCollectors(systemID string, engineVersion string, cloud
 			Logger:           c.opts.Logger,
 			DBVersion:        engineVersion,
 			EntryHandler:     entryHandler,
+			TableRegistry:    tableRegistry,
 		})
 		if err != nil {
 			logStartError(collector.ExplainPlanCollector, "create", err)


### PR DESCRIPTION
### Brief description of Pull Request
The `explain_plans` collector set the session `search_path` to the database name plus `public` before preparing each query. `search_path` takes schemas, not databases, so unqualified table names that live in any other schema failed to resolve: EXPLAIN returned "relation does not exist" and no plan was produced.

Here we source the database's schemas from the TableRegistry that `schema_details` already refreshes periodically and put them all on the `search_path` (`public` last). This reuses the existing cache instead of adding a per-query schema lookup. When the registry is unavailable it falls back to using just `public`.

Caveat: table names duplicated across different schemas resolve by `search_path` order. `queryid` calculation does not encode the app's `search_path`, so exact per-schema attribution not possible; the plan is generated against one representative schema.

### Pull Request Details

<!-- Motivations, trade-offs, and decisions. Can leave empty if not needed. -->


### Issue(s) fixed by this Pull Request

Fixes https://github.com/grafana/grafana-dbo11y-app/issues/2307


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Can leave empty if not needed. -->


### PR Checklist

<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
