### PR TITLE
refactor(common/net): Use native Go HTTP/2 for receiver servers

### DIFF
--- a/docs/sources/shared/reference/components/server-http.md
+++ b/docs/sources/shared/reference/components/server-http.md
@@ -16,5 +16,3 @@ You can use the following arguments to configure the `http` block. Any omitted f
 | `server_idle_timeout`  | `duration` | Idle timeout for HTTP server.                                                                                    | `"120s"` | no       |
 | `server_read_timeout`  | `duration` | Read timeout for HTTP server.                                                                                    | `"30s"`  | no       |
 | `server_write_timeout` | `duration` | Write timeout for HTTP server.                                                                                   | `"30s"`  | no       |
-
-For unencrypted HTTP/2, clients must use prior knowledge rather than the legacy `Upgrade: h2c` handshake.

--- a/docs/sources/shared/reference/components/server-http.md
+++ b/docs/sources/shared/reference/components/server-http.md
@@ -17,12 +17,4 @@ You can use the following arguments to configure the `http` block. Any omitted f
 | `server_read_timeout`  | `duration` | Read timeout for HTTP server.                                                                                    | `"30s"`  | no       |
 | `server_write_timeout` | `duration` | Write timeout for HTTP server.                                                                                   | `"30s"`  | no       |
 
-{{< admonition type="caution" >}}
-When upgrading from the legacy HTTP/2 handler to the native Go HTTP/2 server, review these changes if you already use an `http2` block with `enabled = true`:
-
-- Clients that require the HTTP/1.1 `Upgrade: h2c` handshake must switch to HTTP/2 with prior knowledge or HTTP/2 over TLS. Clients that support HTTP/1.1 fallback can continue using HTTP/1.1.
-- HTTP/1 and HTTP/2 share an idle timeout. A nonzero `http2.idle_timeout` overrides `server_idle_timeout` for both protocols and logs a deprecation warning. Move this setting to `server_idle_timeout`. A zero `http2.idle_timeout` now inherits the server idle timeout instead of disabling the HTTP/2 idle timeout.
-- Existing HTTP/2 settings also apply to TLS connections. Review any settings you previously used only for unencrypted connections.
-
-The `max_handlers` setting remains accepted but has no effect. Remove it to avoid a deprecation warning when HTTP/2 is enabled.
-{{< /admonition >}}
+For unencrypted HTTP/2, clients must use prior knowledge rather than the legacy `Upgrade: h2c` handshake.

--- a/docs/sources/shared/reference/components/server-http.md
+++ b/docs/sources/shared/reference/components/server-http.md
@@ -16,3 +16,13 @@ You can use the following arguments to configure the `http` block. Any omitted f
 | `server_idle_timeout`  | `duration` | Idle timeout for HTTP server.                                                                                    | `"120s"` | no       |
 | `server_read_timeout`  | `duration` | Read timeout for HTTP server.                                                                                    | `"30s"`  | no       |
 | `server_write_timeout` | `duration` | Write timeout for HTTP server.                                                                                   | `"30s"`  | no       |
+
+{{< admonition type="caution" >}}
+When upgrading from the legacy HTTP/2 handler to the native Go HTTP/2 server, review these changes if you already use an `http2` block with `enabled = true`:
+
+- Clients that require the HTTP/1.1 `Upgrade: h2c` handshake must switch to HTTP/2 with prior knowledge or HTTP/2 over TLS. Clients that support HTTP/1.1 fallback can continue using HTTP/1.1.
+- HTTP/1 and HTTP/2 share an idle timeout. A nonzero `http2.idle_timeout` overrides `server_idle_timeout` for both protocols and logs a deprecation warning. Move this setting to `server_idle_timeout`. A zero `http2.idle_timeout` now inherits the server idle timeout instead of disabling the HTTP/2 idle timeout.
+- Existing HTTP/2 settings also apply to TLS connections. Review any settings you previously used only for unencrypted connections.
+
+The `max_handlers` setting remains accepted but has no effect. Remove it to avoid a deprecation warning when HTTP/2 is enabled.
+{{< /admonition >}}

--- a/internal/component/common/net/config.go
+++ b/internal/component/common/net/config.go
@@ -117,8 +117,9 @@ func (c *HTTP2Config) Server() *http.HTTP2Config {
 	if c == nil || !c.Enabled {
 		return nil
 	}
-	// MaxHandlers has always been a no-op in x/net/http2. Keep accepting it
-	// for configuration compatibility. IdleTimeout is applied to http.Server.
+	// Intentionally omit MaxHandlers: it was a no-op in x/net/http2 and is
+	// still accepted for configuration compatibility. Also omit IdleTimeout:
+	// TargetServer.MountAndRun applies it to http.Server.IdleTimeout instead.
 	return &http.HTTP2Config{
 		MaxConcurrentStreams:          int(c.MaxConcurrentStreams),
 		MaxDecoderHeaderTableSize:     int(c.MaxDecoderHeaderTableSize),

--- a/internal/component/common/net/config.go
+++ b/internal/component/common/net/config.go
@@ -5,12 +5,12 @@ package net
 import (
 	"flag"
 	"math"
+	"net/http"
 	"time"
 
 	"github.com/grafana/alloy/syntax/alloytypes"
 	dskit "github.com/grafana/dskit/server"
 	"github.com/prometheus/common/config"
-	"golang.org/x/net/http2"
 )
 
 const (
@@ -113,23 +113,23 @@ type HTTP2Config struct {
 	MaxUploadBufferPerStream     int32         `alloy:"max_upload_buffer_per_stream,attr,optional"`
 }
 
-func (c *HTTP2Config) Server() *http2.Server {
+func (c *HTTP2Config) Server() *http.HTTP2Config {
 	if c == nil || !c.Enabled {
 		return nil
 	}
-	return &http2.Server{
-		MaxHandlers:                  c.MaxHandlers,
-		MaxConcurrentStreams:         c.MaxConcurrentStreams,
-		MaxDecoderHeaderTableSize:    c.MaxDecoderHeaderTableSize,
-		MaxEncoderHeaderTableSize:    c.MaxEncoderHeaderTableSize,
-		MaxReadFrameSize:             c.MaxReadFrameSize,
-		PermitProhibitedCipherSuites: c.PermitProhibitedCipherSuites,
-		IdleTimeout:                  c.IdleTimeout,
-		ReadIdleTimeout:              c.ReadIdleTimeout,
-		PingTimeout:                  c.PingTimeout,
-		WriteByteTimeout:             c.WriteByteTimeout,
-		MaxUploadBufferPerConnection: c.MaxUploadBufferPerConnection,
-		MaxUploadBufferPerStream:     c.MaxUploadBufferPerStream,
+	// MaxHandlers has always been a no-op in x/net/http2. Keep accepting it
+	// for configuration compatibility. IdleTimeout is applied to http.Server.
+	return &http.HTTP2Config{
+		MaxConcurrentStreams:          int(c.MaxConcurrentStreams),
+		MaxDecoderHeaderTableSize:     int(c.MaxDecoderHeaderTableSize),
+		MaxEncoderHeaderTableSize:     int(c.MaxEncoderHeaderTableSize),
+		MaxReadFrameSize:              int(c.MaxReadFrameSize),
+		PermitProhibitedCipherSuites:  c.PermitProhibitedCipherSuites,
+		SendPingTimeout:               c.ReadIdleTimeout,
+		PingTimeout:                   c.PingTimeout,
+		WriteByteTimeout:              c.WriteByteTimeout,
+		MaxReceiveBufferPerConnection: int(c.MaxUploadBufferPerConnection),
+		MaxReceiveBufferPerStream:     int(c.MaxUploadBufferPerStream),
 	}
 }
 

--- a/internal/component/common/net/config_test.go
+++ b/internal/component/common/net/config_test.go
@@ -1,6 +1,7 @@
 package net
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -10,6 +11,47 @@ import (
 
 	"github.com/grafana/alloy/syntax"
 )
+
+func TestHTTP2Config(t *testing.T) {
+	var absent *HTTP2Config
+	require.Nil(t, absent.Server())
+	require.Nil(t, (&HTTP2Config{}).Server())
+
+	var args testArguments
+	require.NoError(t, syntax.Unmarshal([]byte(`
+		http {
+			http2 {
+				enabled = true
+				max_handlers = 42
+				max_concurrent_streams = 123
+				max_decoder_header_table_size = 8192
+				max_encoder_header_table_size = 16384
+				max_read_frame_size = 32768
+				permit_prohibited_ciphers = true
+				idle_timeout = "1m"
+				read_idle_timeout = "10s"
+				ping_timeout = "5s"
+				write_byte_timeout = "3s"
+				max_upload_buffer_per_connection = 1048576
+				max_upload_buffer_per_stream = 524288
+			}
+		}
+	`), &args))
+	require.Equal(t, 42, args.Server.HTTP.HTTP2.MaxHandlers)
+	require.Equal(t, time.Minute, args.Server.HTTP.HTTP2.IdleTimeout)
+	require.Equal(t, &http.HTTP2Config{
+		MaxConcurrentStreams:          123,
+		MaxDecoderHeaderTableSize:     8192,
+		MaxEncoderHeaderTableSize:     16384,
+		MaxReadFrameSize:              32768,
+		PermitProhibitedCipherSuites:  true,
+		SendPingTimeout:               10 * time.Second,
+		PingTimeout:                   5 * time.Second,
+		WriteByteTimeout:              3 * time.Second,
+		MaxReceiveBufferPerConnection: 1048576,
+		MaxReceiveBufferPerStream:     524288,
+	}, args.Server.HTTP.HTTP2.Server())
+}
 
 // testArguments mimics an arguments type used by a component, applying the defaults to ServerConfig
 // from it's UnmarshalAlloy implementation, since the block is squashed.

--- a/internal/component/common/net/http2_test.go
+++ b/internal/component/common/net/http2_test.go
@@ -1,0 +1,246 @@
+package net
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+
+	"github.com/grafana/alloy/internal/util"
+	"github.com/grafana/alloy/syntax/alloytypes"
+)
+
+func newHTTP2TestServer(t *testing.T, cfg *ServerConfig, handler http.Handler) *TargetServer {
+	t.Helper()
+	cfg.HTTP.ListenAddress = "127.0.0.1"
+	cfg.HTTP.ListenPort = 0
+	cfg.GRPC.ListenAddress = "127.0.0.1"
+	cfg.GRPC.ListenPort = 0
+	ts, err := NewTargetServer(util.TestAlloyLogger(t).Slog(), "test_http2", prometheus.NewRegistry(), cfg)
+	require.NoError(t, err)
+	require.NoError(t, ts.MountAndRun(func(router *mux.Router) {
+		router.Path("/test").Handler(handler)
+	}))
+	t.Cleanup(ts.StopAndShutdown)
+	return ts
+}
+
+func TestTargetServer_Protocols(t *testing.T) {
+	for _, useTLS := range []bool{false, true} {
+		for _, mode := range []string{"absent", "disabled", "enabled"} {
+			t.Run(mode+map[bool]string{false: "/plaintext", true: "/tls"}[useTLS], func(t *testing.T) {
+				cfg := DefaultServerConfig()
+				cfg.HTTP.HTTP2.Enabled = mode == "enabled"
+				if mode == "absent" {
+					cfg.HTTP.HTTP2 = nil
+				}
+				var clientTLS *tls.Config
+				if useTLS {
+					// Reuse httptest's trusted loopback certificate for the dskit server.
+					fixture := httptest.NewTLSServer(http.NotFoundHandler())
+					t.Cleanup(fixture.Close)
+					cert := fixture.TLS.Certificates[0]
+					key, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+					require.NoError(t, err)
+					cfg.HTTP.TLSConfig = &TLSConfig{
+						Cert: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})),
+						Key:  alloytypes.Secret(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key})),
+					}
+					clientTLS = fixture.Client().Transport.(*http.Transport).TLSClientConfig.Clone()
+				}
+				ts := newHTTP2TestServer(t, cfg, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("X-Protocol", r.Proto)
+					_, _ = io.Copy(w, r.Body)
+				}))
+				scheme := "http://"
+				if useTLS {
+					scheme = "https://"
+				}
+				for _, major := range []int{1, 2} {
+					protocols := new(http.Protocols)
+					protocols.SetHTTP1(major == 1)
+					protocols.SetHTTP2(major == 2 && useTLS)
+					protocols.SetUnencryptedHTTP2(major == 2 && !useTLS)
+					transport := &http.Transport{Protocols: protocols, TLSClientConfig: clientTLS}
+					t.Cleanup(transport.CloseIdleConnections)
+					client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+					res, err := client.Post(scheme+ts.HTTPListenAddr()+"/test", "text/plain", strings.NewReader("payload"))
+					if major == 2 && !useTLS && mode != "enabled" {
+						require.Error(t, err)
+						continue
+					}
+					require.NoError(t, err)
+					body, err := io.ReadAll(res.Body)
+					require.NoError(t, res.Body.Close())
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, res.StatusCode)
+					require.Equal(t, major, res.ProtoMajor)
+					require.Equal(t, res.Proto, res.Header.Get("X-Protocol"))
+					require.Equal(t, "payload", string(body))
+					if major == 1 && !useTLS && mode == "enabled" {
+						// Native HTTP/2 doesn't support the legacy Upgrade handshake.
+						req, err := http.NewRequest(http.MethodPost, scheme+ts.HTTPListenAddr()+"/test", strings.NewReader("upgrade payload"))
+						require.NoError(t, err)
+						req.Header.Set("Connection", "Upgrade, HTTP2-Settings")
+						req.Header.Set("Upgrade", "h2c")
+						req.Header.Set("HTTP2-Settings", "")
+						res, err := client.Do(req)
+						require.NoError(t, err)
+						body, err := io.ReadAll(res.Body)
+						require.NoError(t, res.Body.Close())
+						require.NoError(t, err)
+						require.Equal(t, http.StatusOK, res.StatusCode)
+						require.Equal(t, "HTTP/1.1", res.Header.Get("X-Protocol"))
+						require.Equal(t, "upgrade payload", string(body))
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestTargetServer_HTTP2MaxHandlersWarning(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		enabled      bool
+		maxHandlers  int
+		wantWarnings int
+	}{
+		{"default", true, 0, 0},
+		{"nonzero", true, 42, 1},
+		{"negative", true, -1, 1},
+		{"disabled", false, 42, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings := make(chan struct{}, 10)
+			logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+				Level: slog.LevelWarn,
+				ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+					if attr.Key == slog.MessageKey && attr.Value.String() == "http2 max_handlers is deprecated and has no effect; remove it from the configuration" {
+						warnings <- struct{}{}
+					}
+					return attr
+				},
+			}))
+			cfg := DefaultServerConfig()
+			cfg.HTTP.ListenAddress = "127.0.0.1"
+			cfg.HTTP.ListenPort = 0
+			cfg.GRPC.ListenAddress = "127.0.0.1"
+			cfg.HTTP.HTTP2.Enabled = tc.enabled
+			cfg.HTTP.HTTP2.MaxHandlers = tc.maxHandlers
+			ts, err := NewTargetServer(logger, "test_http2", prometheus.NewRegistry(), cfg)
+			require.NoError(t, err)
+			require.NoError(t, ts.MountAndRun(func(_ *mux.Router) {}))
+			t.Cleanup(ts.StopAndShutdown)
+			require.Len(t, warnings, tc.wantWarnings)
+		})
+	}
+}
+
+func TestTargetServer_HTTP2IdleTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+		idle    time.Duration
+		want    time.Duration
+	}{
+		{"inherit", true, 0, 2 * time.Minute},
+		{"override", true, time.Minute, time.Minute},
+		{"no timeout", true, -1, -1},
+		{"disabled", false, time.Minute, 2 * time.Minute},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultServerConfig()
+			cfg.HTTP.HTTP2.Enabled = tc.enabled
+			cfg.HTTP.HTTP2.IdleTimeout = tc.idle
+			ts := newHTTP2TestServer(t, cfg, http.NotFoundHandler())
+			require.Equal(t, tc.want, ts.server.HTTPServer.IdleTimeout)
+		})
+	}
+}
+
+func TestTargetServer_HTTP2Frames(t *testing.T) {
+	for _, mode := range []string{"ping", "idle", "shutdown"} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := DefaultServerConfig()
+			cfg.HTTP.HTTP2.Enabled = true
+			cfg.HTTP.HTTP2.MaxConcurrentStreams = 7
+			cfg.HTTP.HTTP2.MaxReadFrameSize = 32768
+			cfg.HTTP.HTTP2.MaxUploadBufferPerStream = 524288
+			if mode == "ping" {
+				cfg.HTTP.HTTP2.ReadIdleTimeout = 50 * time.Millisecond
+				cfg.HTTP.HTTP2.PingTimeout = 50 * time.Millisecond
+			}
+			if mode == "idle" {
+				cfg.HTTP.ServerIdleTimeout = 50 * time.Millisecond
+			}
+			ts := newHTTP2TestServer(t, cfg, http.NotFoundHandler())
+			conn, err := net.DialTimeout("tcp", ts.HTTPListenAddr(), 5*time.Second)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = conn.Close() })
+			require.NoError(t, conn.SetDeadline(time.Now().Add(5*time.Second)))
+			_, err = io.WriteString(conn, http2.ClientPreface)
+			require.NoError(t, err)
+			framer := http2.NewFramer(conn, conn)
+			require.NoError(t, framer.WriteSettings())
+			frame, err := framer.ReadFrame()
+			require.NoError(t, err)
+			settings, ok := frame.(*http2.SettingsFrame)
+			require.True(t, ok)
+			for id, want := range map[http2.SettingID]uint32{
+				http2.SettingMaxConcurrentStreams: 7,
+				http2.SettingMaxFrameSize:         32768,
+				http2.SettingInitialWindowSize:    524288,
+			} {
+				got, ok := settings.Value(id)
+				require.True(t, ok)
+				require.Equal(t, want, got)
+			}
+			require.NoError(t, framer.WriteSettingsAck())
+			var shutdownDone chan error
+			if mode == "shutdown" {
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+				defer cancel()
+				shutdownDone = make(chan error, 1)
+				go func() { shutdownDone <- ts.server.HTTPServer.Shutdown(ctx) }()
+			}
+			for {
+				frame, err := framer.ReadFrame()
+				require.NoError(t, err)
+				if ping, ok := frame.(*http2.PingFrame); ok && mode == "ping" {
+					require.False(t, ping.IsAck())
+					// An unanswered health check must close the connection.
+					for err == nil {
+						_, err = framer.ReadFrame()
+					}
+					var netErr net.Error
+					require.False(t, errors.As(err, &netErr) && netErr.Timeout(), "connection did not close before the test deadline")
+					break
+				}
+				if goAway, ok := frame.(*http2.GoAwayFrame); ok {
+					require.NotEqual(t, "ping", mode)
+					require.Equal(t, http2.ErrCodeNo, goAway.ErrCode)
+					break
+				}
+			}
+			if shutdownDone != nil {
+				require.NoError(t, conn.Close())
+				require.NoError(t, <-shutdownDone)
+			}
+		})
+	}
+}

--- a/internal/component/common/net/server.go
+++ b/internal/component/common/net/server.go
@@ -3,12 +3,12 @@ package net
 import (
 	"fmt"
 	"log/slog"
+	"net/http"
 
 	"github.com/gorilla/mux"
 	dskit "github.com/grafana/dskit/server"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"golang.org/x/net/http2/h2c" //nolint:staticcheck // TODO(#6347): migrate to http.Server.Protocols/HTTP2 once HTTP2Config field mapping (MaxHandlers, IdleTimeout, ReadIdleTimeout) is resolved.
 
 	"github.com/grafana/alloy/internal/slogadapter"
 )
@@ -78,8 +78,21 @@ func (ts *TargetServer) MountAndRun(mountRoute func(router *mux.Router)) error {
 
 	ts.server = srv
 
-	if http2Server := ts.http2.Server(); http2Server != nil {
-		ts.server.HTTPServer.Handler = h2c.NewHandler(ts.server.HTTPServer.Handler, http2Server) //nolint:staticcheck // TODO(#6347): migrate to http.Server.Protocols.SetUnencryptedHTTP2 once we map all HTTP2Config fields.
+	if http2Config := ts.http2.Server(); http2Config != nil {
+		ts.server.HTTPServer.HTTP2 = http2Config
+		protocols := new(http.Protocols)
+		protocols.SetHTTP1(true)
+		protocols.SetHTTP2(true)
+		protocols.SetUnencryptedHTTP2(true)
+		ts.server.HTTPServer.Protocols = protocols
+		if ts.http2.MaxHandlers != 0 {
+			ts.logger.Warn("http2 max_handlers is deprecated and has no effect; remove it from the configuration", "max_handlers", ts.http2.MaxHandlers)
+		}
+		if ts.http2.IdleTimeout != 0 {
+			// net/http uses one idle timeout for HTTP/1 and HTTP/2.
+			ts.server.HTTPServer.IdleTimeout = ts.http2.IdleTimeout
+			ts.logger.Warn("http2 idle_timeout is deprecated; use server_idle_timeout instead; the timeout now applies to both HTTP/1 and HTTP/2", "idle_timeout", ts.http2.IdleTimeout)
+		}
 	}
 	mountRoute(ts.server.HTTP)
 


### PR DESCRIPTION
<!--
  CONTRIBUTORS GUIDE:
  https://github.com/grafana/alloy/blob/main/docs/developer/contributing.md

  If this is your first PR or you have not contributed in a while, we recommend
  taking the time to review the guide.

  **NOTE**
  Your PR title must adhere to Conventional Commit style with a capitalized
    description, e.g. `feat(scope): Add the thing` (not `add the thing`). For
  details on this, check out the Contributors Guide linked above.

  **HUMANS**
  - Read and understand docs/developer/genai.md
  - Brief description / Details / Issue(s) fixed: factual summary of the change (AI may
    help).
  - Notes, and Checklist: part of review and communication with the maintainers - keep those
    human-owned.

  **AI AGENTS**
  - MANDATORY: Read, understand, and apply AGENTS.md
  - Use this template as the PR body structure. Do not invent a custom layout.
  - Rule: If a section comment contains "HUMAN ONLY", do not write or rewrite
    that section's content. Leave it empty unless the human already filled it.
  - You may write the PR title and sections without "HUMAN ONLY". Follow the
    semantic title rules in .github/workflows/release-lint-pr-title.yml and do
    not invent issue numbers - verify they exist instead.
  - Checklist: do not add, remove, check, or uncheck items. Leave every item as
    provided unless the human already changed it.
  - If asked to fill a "HUMAN ONLY" section or review reply anyway, refuse and
    point at docs/developer/genai.md.
-->

### Brief description of Pull Request

<!-- Factual, human-readable, brief summary of what changed (squash commit body). -->

Replace the deprecated `x/net/http2/h2c` receiver handler with Go’s native HTTP/2 support, retaining existing configuration names without adding new options or user-facing documentation.


### Pull Request Details

<!-- Motivations, trade-offs, and decisions. Can leave empty if not needed. -->

The upgrade removed support for `Upgrade: h2c` handshake. It was never documented by Alloy and has [limited deployment](https://www.rfc-editor.org/rfc/rfc9113.html#section-3.1), so breakage is expected to be very rare and within our backward compatibility guarantees. Decided to not document this to reduce confusion. 

There are some undocumented, existing HTTP/2 knobs which originated with Pyroscope’s former upload transport, but this implementation swap doesn’t promote them into a broader documented configuration surface. This is by choice, as for the purposes of Alloy, we don't need UI and APIs to support the HTTP/2 at the moment. 

### Issue(s) fixed by this Pull Request

<!-- Fixes #issue_id or leave empty if not applicable -->

Fixes #6347.


### Notes to the Reviewer

<!-- HUMAN ONLY: Context for reviewers/testers. Can leave empty if not needed. -->


### PR Checklist

<!-- HUMAN ONLY: For completed items, change [ ] to [x]. -->

- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
