### PR TITLE
fix(database_observability.sql_server): Fix explain_plans timeout

### DIFF
--- a/internal/component/database_observability/sql_server/collector/explain_plans.go
+++ b/internal/component/database_observability/sql_server/collector/explain_plans.go
@@ -30,28 +30,30 @@ const (
 // SET SHOWPLAN_XML ON compilation - the plan is read from the same Query
 // Store data query_metrics already joins). A query_hash can map to more than
 // one query_id/plan_id (recompiles, parameter sniffing), so ROW_NUMBER picks
-// exactly one plan per hash rather than enumerating every match.
+// exactly one plan per hash rather than enumerating every match. Recency is
+// ranked by the plan's own last_execution_time rather than the latest
+// runtime-stats interval end time, since that avoids joining through
+// runtime_stats/runtime_stats_interval entirely - see the plan_id-keyed fetch
+// below. plan_id DESC breaks ties (including NULL last_execution_time for a
+// plan that has never executed, which sorts last under DESC) deterministically.
 const selectExplainPlansTemplate = `
 	WITH ranked_plans AS (
 		SELECT
 			q.query_hash,
-			p.query_plan,
+			p.plan_id,
 			ROW_NUMBER() OVER (
 				PARTITION BY q.query_hash
-				ORDER BY MAX(i.end_time) DESC
+				ORDER BY p.last_execution_time DESC, p.plan_id DESC
 			) AS rn
 		FROM sys.query_store_query q
 		JOIN sys.query_store_plan p ON p.query_id = q.query_id
-		JOIN sys.query_store_runtime_stats rs ON rs.plan_id = p.plan_id
-		JOIN sys.query_store_runtime_stats_interval i
-			ON i.runtime_stats_interval_id = rs.runtime_stats_interval_id
 		WHERE q.is_internal_query = 0
 			AND q.query_hash IN (%s)
-		GROUP BY q.query_hash, p.plan_id, p.query_plan
 	)
-	SELECT query_hash, query_plan
-	FROM ranked_plans
-	WHERE rn = 1`
+	SELECT rp.query_hash, p.query_plan
+	FROM ranked_plans rp
+	JOIN sys.query_store_plan p ON p.plan_id = rp.plan_id
+	WHERE rp.rn = 1`
 
 type ExplainPlansArguments struct {
 	DB              *sql.DB


### PR DESCRIPTION
### Brief description of Pull Request

Rewrites the `explain_plans` collector's hash-to-plan resolution query
(`selectExplainPlansTemplate` in `explain_plans.go`) to stop timing out in
production. The query no longer joins `sys.query_store_runtime_stats` /
`sys.query_store_runtime_stats_interval` to rank plans by recency, and no
longer groups by the plan's `nvarchar(max)` XML across the resulting
fanned-out rows. Instead it ranks by `sys.query_store_plan.last_execution_time`
(with `plan_id` as a tiebreaker) and fetches the winning plan's XML via a
single `plan_id`-keyed join.

### Pull Request Details

**Root cause**: `sys.query_store_runtime_stats` has one row per
`(plan_id, interval, execution_type)`, and Query Store retains this history
for days/weeks. The old query joined through both runtime-stats views purely
to compute `MAX(interval.end_time)` for "most recent plan", then had to
`GROUP BY` on the fanned-out result including the full plan XML blob -
sorting/hashing that blob across a large fanned-out row set is what timed
out (confirmed via `context deadline exceeded`, 100s, in production logs).

**Semantic note**: ordering shifts from "latest runtime-stats interval end
time" to the plan's own `last_execution_time` (same intent - most recently
active plan wins - just computed without the fan-out). `last_execution_time`
is `NULL` for a plan that has never executed, which sorts last under `DESC`,
so an already-executed plan is still always preferred; `plan_id DESC` breaks
remaining ties deterministically.

**Validated compatibility**: this collector's "report on change, or at least
every 30 minutes" behavior lives entirely downstream of this query, in a
separate emission gate keyed off a structural hash of whichever plan this
query returns (`shouldEmit`, using the shared `EmitInterval` constant). This
query still runs every `collect_interval` regardless; the rewrite only
changes which `plan_id` wins per `query_hash` before that gate ever sees it,
so there's no interaction with or change to that cadence.

**Manual verification** (one-off, not part of this diff): seeded a throwaway
local SQL Server with 50 query_hashes, 2 plan variants each, and ~2.8
`runtime_stats_interval` rows per plan on average, then timed the old vs. new
query text with `SET STATISTICS TIME, IO ON`, 3 runs each:

| Query | Mean elapsed (ms) | Mean CPU (ms) | Logical + LOB reads |
|-------|--------------------|-----------------|----------------------|
| OLD   | 90.0               | 88.3            | 622                  |
| NEW   | 14.7               | 14.3            | 128                  |

~6x faster and ~5x fewer reads at this reduced scale. Since the old query's
cost scales multiplicatively with `plans x intervals`, and this session's
history (minutes) is far smaller than production's (days/weeks), this is a
conservative lower bound on the actual production regression, not a claim of
matching its exact magnitude.

### Issue(s) fixed by this Pull Request



### Notes to the Reviewer



### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [ ] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))