### PR TITLE
fix(otelcol.receiver.cloudflare): Apply the documented default arguments

### DIFF
--- a/docs/sources/reference/components/otelcol/otelcol.receiver.cloudflare.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.cloudflare.md
@@ -44,7 +44,7 @@ You can use the following arguments with `otelcol.receiver.cloudflare`:
 | `endpoint`         | `string`            | The `<HOST:PORT>` endpoint address on which the receiver awaits requests from Cloudflare.                  |                        | yes      |
 | `secret`           | `string`            | If this value is set, the receiver expects to see it in any valid requests under the `X-CF-Secret` header. |                        | no       |
 | `attributes`       | `map[string]string` | Sets log attributes from message fields. Only string, boolean, integer, or float fields can be mapped.     |                        | no       |
-| `delimiter`        | `string`            | The separator to join nested fields in the log message when setting attributes.                            | `"."`                  | no       |
+| `separator`        | `string`            | The separator to join nested fields in the log message when setting attributes.                            | `"."`                  | no       |
 | `timestamp_field`  | `string`            | Log field name that contains timestamp.                                                                    | `"EdgeStartTimestamp"` | no       |
 | `timestamp_format` | `string`            | One of `unix`, `unixnano`, or `rfc3339`, matching how your LogPush job encodes the timestamp field.        | `"rfc3339"`            | no       |
 

--- a/internal/component/otelcol/receiver/cloudflare/cloudflare.go
+++ b/internal/component/otelcol/receiver/cloudflare/cloudflare.go
@@ -47,24 +47,25 @@ type Arguments struct {
 
 // SetToDefault implements syntax.Defaulter.
 func (args *Arguments) SetToDefault() {
-	// Defaults filled by upstream OTel receiver in a factory.
+	cfg := cloudflarereceiver.NewFactory().CreateDefaultConfig().(*cloudflarereceiver.Config)
+	*args = Arguments{
+		TimestampField:  cfg.Logs.TimestampField,
+		TimestampFormat: cfg.Logs.TimestampFormat,
+		Separator:       cfg.Logs.Separator,
+	}
 }
 
 func (args Arguments) receiverConfig() *cloudflarereceiver.Config {
 	tlsCfg := args.TLS.Convert()
-	logCfg := cloudflarereceiver.LogsConfig{
-		Secret:          args.Secret,
-		Endpoint:        args.Endpoint,
-		TLS:             tlsCfg.Get(),
-		Attributes:      args.Attributes,
-		TimestampField:  args.TimestampField,
-		TimestampFormat: args.TimestampFormat,
-		Separator:       args.Separator,
-	}
-
-	return &cloudflarereceiver.Config{
-		Logs: logCfg,
-	}
+	cfg := cloudflarereceiver.NewFactory().CreateDefaultConfig().(*cloudflarereceiver.Config)
+	cfg.Logs.Secret = args.Secret
+	cfg.Logs.Endpoint = args.Endpoint
+	cfg.Logs.TLS = tlsCfg.Get()
+	cfg.Logs.Attributes = args.Attributes
+	cfg.Logs.TimestampField = args.TimestampField
+	cfg.Logs.TimestampFormat = args.TimestampFormat
+	cfg.Logs.Separator = args.Separator
+	return cfg
 }
 
 // Validate implements syntax.Validator.

--- a/internal/component/otelcol/receiver/cloudflare/cloudflare_test.go
+++ b/internal/component/otelcol/receiver/cloudflare/cloudflare_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/grafana/alloy/syntax"
 )
 
+// expectedConfig returns the upstream factory defaults with override applied,
+// so each case only spells out what it actually overrides.
+func expectedConfig(override func(logs *cloudflarereceiver.LogsConfig)) cloudflarereceiver.Config {
+	cfg := cloudflarereceiver.NewFactory().CreateDefaultConfig().(*cloudflarereceiver.Config)
+	override(&cfg.Logs)
+	return *cfg
+}
+
 func TestArguments_UnmarshalAlloy(t *testing.T) {
 	cases := []struct {
 		testName string
@@ -23,11 +31,9 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				endpoint = "localhost:8080/webhook"
 				output {}
 			`,
-			expected: cloudflarereceiver.Config{
-				Logs: cloudflarereceiver.LogsConfig{
-					Endpoint: "localhost:8080/webhook",
-				},
-			},
+			expected: expectedConfig(func(logs *cloudflarereceiver.LogsConfig) {
+				logs.Endpoint = "localhost:8080/webhook"
+			}),
 		},
 		{
 			testName: "full configuration without TLS",
@@ -43,19 +49,17 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				separator = "_"
 				output {}
 			`,
-			expected: cloudflarereceiver.Config{
-				Logs: cloudflarereceiver.LogsConfig{
-					Secret:   "my-secret",
-					Endpoint: "localhost:8080/cloudflare-webhook",
-					Attributes: map[string]string{
-						"service.name": "cloudflare-logs",
-						"environment":  "production",
-					},
-					TimestampField:  "EdgeStartTimestamp",
-					TimestampFormat: "unix",
-					Separator:       "_",
-				},
-			},
+			expected: expectedConfig(func(logs *cloudflarereceiver.LogsConfig) {
+				logs.Secret = "my-secret"
+				logs.Endpoint = "localhost:8080/cloudflare-webhook"
+				logs.Attributes = map[string]string{
+					"service.name": "cloudflare-logs",
+					"environment":  "production",
+				}
+				logs.TimestampField = "EdgeStartTimestamp"
+				logs.TimestampFormat = "unix"
+				logs.Separator = "_"
+			}),
 		},
 		{
 			testName: "configuration with TLS",
@@ -69,19 +73,17 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				timestamp_format = "unixnano"
 				output {}
 			`,
-			expected: cloudflarereceiver.Config{
-				Logs: cloudflarereceiver.LogsConfig{
-					Secret:   "my-secret",
-					Endpoint: "localhost:8443/secure-webhook",
-					TLS: &configtls.ServerConfig{
-						Config: configtls.Config{
-							CertFile: "/path/to/cert.pem",
-							KeyFile:  "/path/to/key.pem",
-						},
+			expected: expectedConfig(func(logs *cloudflarereceiver.LogsConfig) {
+				logs.Secret = "my-secret"
+				logs.Endpoint = "localhost:8443/secure-webhook"
+				logs.TLS = &configtls.ServerConfig{
+					Config: configtls.Config{
+						CertFile: "/path/to/cert.pem",
+						KeyFile:  "/path/to/key.pem",
 					},
-					TimestampFormat: "unixnano",
-				},
-			},
+				}
+				logs.TimestampFormat = "unixnano"
+			}),
 		},
 		{
 			testName: "configuration with custom timestamp field",
@@ -92,14 +94,12 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 				timestamp_format = "rfc3339"
 				output {}
 			`,
-			expected: cloudflarereceiver.Config{
-				Logs: cloudflarereceiver.LogsConfig{
-					Secret:          "my-secret",
-					Endpoint:        "localhost:8080/webhook",
-					TimestampField:  "RequestTimestamp",
-					TimestampFormat: "rfc3339",
-				},
-			},
+			expected: expectedConfig(func(logs *cloudflarereceiver.LogsConfig) {
+				logs.Secret = "my-secret"
+				logs.Endpoint = "localhost:8080/webhook"
+				logs.TimestampField = "RequestTimestamp"
+				logs.TimestampFormat = "rfc3339"
+			}),
 		},
 	}
 


### PR DESCRIPTION
### Brief description of Pull Request

Seed the cloudflare receiver's config from the factory default so `timestamp_field`, `timestamp_format` and `separator` get the defaults the reference docs already document, and rename the argument table's `delimiter` to `separator`, the name the component actually accepts. `SetToDefault` was an empty stub, so configs that left these unset got no log timestamp and nested attribute keys flattened with no separator between them. Those records now carry a `Timestamp`, and those keys gain a `.`.

### Issue(s) fixed by this Pull Request

Related to https://github.com/grafana/alloy/issues/6866

### PR Checklist

- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated
- [x] This pull request was substantially generated with AI assistance (see the [GenAI policy](https://github.com/grafana/alloy/blob/main/docs/developer/genai.md))
