### PR TITLE
docs: Validate the remote.* component topics

### DIFF
--- a/docs/sources/reference/components/remote/_index.md
+++ b/docs/sources/reference/components/remote/_index.md
@@ -1,12 +1,18 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/reference/components/remote/
 description: Learn about the remote components in Grafana Alloy
+review_date: 2026-09-11
+labels:
+  products:
+    - oss
 title: remote
 weight: 100
 ---
 
 # `remote`
 
-This section contains reference documentation for the `remote` components.
+The `remote` components retrieve content from sources outside of your {{< param "PRODUCT_NAME" >}} configuration, such as files in object storage, secrets in HashiCorp Vault, and Kubernetes ConfigMaps and Secrets, and expose that content to other components.
+
+Use a `remote` component when a value your configuration depends on, for example, a credential or a list of scrape targets, is managed somewhere else and can change independently of your configuration.
 
 {{< section >}}

--- a/docs/sources/reference/components/remote/remote.http.md
+++ b/docs/sources/reference/components/remote/remote.http.md
@@ -113,9 +113,9 @@ The `tls_config` block configures TLS settings for connecting to HTTPS servers.
 
 The following field is exported and can be referenced by other components:
 
-| Name      | Type                 | Description               | Default | Required |
-| --------- | -------------------- | ------------------------- | ------- | -------- |
-| `content` | `string` or `secret` | The contents of the file. |         | no       |
+| Name      | Type                 | Description                                                             |
+| --------- | -------------------- | ----------------------------------------------------------------------- |
+| `content` | `string` or `secret` | The contents of the response body from the most recent successful poll. |
 
 If the `is_secret` argument was `true`, `content` is a secret type.
 

--- a/docs/sources/reference/components/remote/remote.http.md
+++ b/docs/sources/reference/components/remote/remote.http.md
@@ -7,6 +7,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: remote.http
 ---
 
@@ -31,17 +32,18 @@ remote.http "<LABEL>" {
 
 You can use the following arguments with `remote.http`:
 
-| Name             | Type          | Description                                                  | Default | Required |
-| ---------------- | ------------- | ------------------------------------------------------------ | ------- | -------- |
-| `url`            | `string`      | URL to poll.                                                 |         | yes      |
-| `body`           | `string`      | The request body.                                            | `""`    | no       |
-| `headers`        | `map(string)` | Custom headers for the request.                              | `{}`    | no       |
-| `is_secret`      | `bool`        | Whether the response body should be treated as a [secret][]. | `false` | no       |
-| `method`         | `string`      | Define HTTP method for the request                           | `"GET"` | no       |
-| `poll_frequency` | `duration`    | Frequency to poll the URL.                                   | `"1m"`  | no       |
-| `poll_timeout`   | `duration`    | Timeout when polling the URL.                                | `"10s"` | no       |
+| Name             | Type          | Description                                                       | Default | Required |
+| ---------------- | ------------- | ----------------------------------------------------------------- | ------- | -------- |
+| `url`            | `string`      | URL to poll.                                                      |         | yes      |
+| `body`           | `string`      | The request body.                                                 | `""`    | no       |
+| `headers`        | `map(string)` | Custom headers for the request.                                   | `{}`    | no       |
+| `is_secret`      | `bool`        | Whether the response body should be treated as a [secret][].      | `false` | no       |
+| `method`         | `string`      | The HTTP method for the request.                                  | `"GET"` | no       |
+| `poll_frequency` | `duration`    | Frequency to poll the URL.                                        | `"1m"`  | no       |
+| `poll_timeout`   | `duration`    | Timeout when polling the URL. Must be less than `poll_frequency`. | `"10s"` | no       |
 
-When `remote.http` performs a poll operation, an HTTP `GET` request is made against the URL specified by the `url` argument.
+When `remote.http` performs a poll operation, an HTTP request using the method specified by the `method` argument is made against the URL specified by the `url` argument.
+If the `headers` argument doesn't set a `User-Agent` header, `remote.http` sends a default `User-Agent` header.
 A poll is triggered by the following:
 
 * When the component first loads.
@@ -52,7 +54,7 @@ The poll is successful if the URL returns a `200 OK` response code.
 All other response codes are treated as errors and mark the component as unhealthy.
 After a successful poll, the response body from the URL is exported.
 
-[secret]: ../../../../get-started/configuration-syntax/expressions/types_and_values/#secrets
+[secret]: ../../../../get-started/expressions/types_and_values/#secrets
 
 ## Blocks
 
@@ -119,7 +121,7 @@ If the `is_secret` argument was `true`, `content` is a secret type.
 
 ## Component health
 
-Instances of `remote.http` report as healthy if the most recent HTTP `GET` request of the specified URL succeeds.
+Instances of `remote.http` report as healthy if the most recent HTTP request of the specified URL succeeds.
 
 ## Debug information
 

--- a/docs/sources/reference/components/remote/remote.http.md
+++ b/docs/sources/reference/components/remote/remote.http.md
@@ -14,7 +14,7 @@ title: remote.http
 # `remote.http`
 
 `remote.http` exposes the response body of a URL to other components.
-The URL is polled for changes so that the most recent content is always available.
+`remote.http` polls the URL for changes, so the most recent content is always available.
 
 The most common use of `remote.http` is to load discovery targets from an HTTP server.
 
@@ -37,22 +37,22 @@ You can use the following arguments with `remote.http`:
 | `url`            | `string`      | URL to poll.                                                      |         | yes      |
 | `body`           | `string`      | The request body.                                                 | `""`    | no       |
 | `headers`        | `map(string)` | Custom headers for the request.                                   | `{}`    | no       |
-| `is_secret`      | `bool`        | Whether the response body should be treated as a [secret][].      | `false` | no       |
+| `is_secret`      | `bool`        | Whether to treat the response body as a [secret][].              | `false` | no       |
 | `method`         | `string`      | The HTTP method for the request.                                  | `"GET"` | no       |
 | `poll_frequency` | `duration`    | Frequency to poll the URL.                                        | `"1m"`  | no       |
 | `poll_timeout`   | `duration`    | Timeout when polling the URL. Must be less than `poll_frequency`. | `"10s"` | no       |
 
-When `remote.http` performs a poll operation, an HTTP request using the method specified by the `method` argument is made against the URL specified by the `url` argument.
+When `remote.http` performs a poll operation, it makes an HTTP request using the method specified by the `method` argument against the URL specified by the `url` argument.
 If the `headers` argument doesn't set a `User-Agent` header, `remote.http` sends a default `User-Agent` header.
-A poll is triggered by the following:
+The following triggers a poll:
 
-* When the component first loads.
-* Every time the component's arguments get re-evaluated.
-* At the frequency specified by the `poll_frequency` argument.
+- When the component first loads.
+- Every time the component's arguments get re-evaluated.
+- At the frequency specified by the `poll_frequency` argument.
 
 The poll is successful if the URL returns a `200 OK` response code.
-All other response codes are treated as errors and mark the component as unhealthy.
-After a successful poll, the response body from the URL is exported.
+`remote.http` treats all other response codes as errors and marks the component as unhealthy.
+After a successful poll, `remote.http` exports the response body from the URL.
 
 [secret]: ../../../../get-started/expressions/types_and_values/#secrets
 

--- a/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
@@ -38,14 +38,14 @@ You can use the following arguments with `remote.kubernetes.configmap`:
 | `poll_timeout`   | `duration` | Timeout when polling the Kubernetes API.               | `"15s"` | no       |
 
 When this component performs a poll operation, it requests the ConfigMap data from the Kubernetes API.
-A poll is triggered by the following:
+The following triggers a poll:
 
-* When the component first loads.
-* Every time the component's arguments get re-evaluated.
-* At the frequency specified by the `poll_frequency` argument.
+- When the component first loads.
+- Every time the component's arguments get re-evaluated.
+- At the frequency specified by the `poll_frequency` argument.
 
-Any error while polling will mark the component as unhealthy.
-After a successful poll, all data is exported with the same field names as the source ConfigMap.
+Any error while polling marks the component as unhealthy.
+After a successful poll, `remote.kubernetes.configmap` exports all data with the same field names as the source ConfigMap.
 
 ## Blocks
 
@@ -73,25 +73,25 @@ You can use the following blocks with `remote.kubernetes.configmap`:
 ### `client`
 
 The `client` block configures the Kubernetes client used to discover ConfigMaps.
-If the `client` block isn't provided, the default in-cluster configuration with the service account of the running {{< param "PRODUCT_NAME" >}} Pod is used.
+If the `client` block isn't provided, {{< param "PRODUCT_NAME" >}} uses the default in-cluster configuration with the service account of the running {{< param "PRODUCT_NAME" >}} Pod.
 
-The following arguments are supported:
+The `client` block supports the following arguments:
 
 | Name                     | Type                | Description                                                                                      | Default | Required |
 | ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------- |
 | `api_server`             | `string`            | URL of the Kubernetes API server.                                                                |         | no       |
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
 | `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
-| `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
-| `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
+| `enable_http2`           | `bool`              | Whether the client supports HTTP2 for requests.                                                  | `true`  | no       |
+| `follow_redirects`       | `bool`              | Whether the client follows redirects returned by the server.                                     | `true`  | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to send along with each request. The map key is the header name.             |         | no       |
 | `kubeconfig_file`        | `string`            | Path of the `kubeconfig` file to use for connecting to Kubernetes.                               |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
 
-At most, one of the following can be provided:
+At most, you can provide one of the following:
 
 - [`authorization`](#authorization) block
 - [`basic_auth`](#basic_auth) block
@@ -165,4 +165,4 @@ prometheus.remote_write "default" {
 }
 ```
 
-This example assumes that the Secret and ConfigMap have already been created, and that the appropriate field names exist in their data.
+This example assumes that the Secret and ConfigMap already exist, and that the appropriate field names exist in their data.

--- a/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.configmap.md
@@ -7,6 +7,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: remote.kubernetes.configmap
 ---
 
@@ -79,8 +80,8 @@ The following arguments are supported:
 | Name                     | Type                | Description                                                                                      | Default | Required |
 | ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------- |
 | `api_server`             | `string`            | URL of the Kubernetes API server.                                                                |         | no       |
-| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
+| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
 | `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
@@ -90,13 +91,13 @@ The following arguments are supported:
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
 
- At most, one of the following can be provided:
+At most, one of the following can be provided:
 
-* [`authorization`](#authorization) block
-* [`basic_auth`](#basic_auth) block
-* [`bearer_token_file`](#client) argument
-* [`bearer_token`](#client) argument
-* [`oauth2`](#oauth2) block
+- [`authorization`](#authorization) block
+- [`basic_auth`](#basic_auth) block
+- [`bearer_token_file`](#client) argument
+- [`bearer_token`](#client) argument
+- [`oauth2`](#oauth2) block
 
 {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -128,7 +129,7 @@ The `data` field contains a mapping from field names to values.
 
 ## Component health
 
-Instances of `remote.kubernetes.configmap` report as healthy if the most recent attempt to poll the kubernetes API succeeds.
+Instances of `remote.kubernetes.configmap` report as healthy if the most recent attempt to poll the Kubernetes API succeeds.
 
 ## Debug information
 

--- a/docs/sources/reference/components/remote/remote.kubernetes.secret.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.secret.md
@@ -7,6 +7,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: remote.kubernetes.secret
 ---
 
@@ -39,9 +40,9 @@ You can use the following arguments with `remote.kubernetes.secret`:
 When this component performs a poll operation, it requests the Secret data from the Kubernetes API.
 A poll is triggered by the following:
 
-* When the component first loads.
-* Every time the component's arguments get re-evaluated.
-* At the frequency specified by the `poll_frequency` argument.
+- When the component first loads.
+- Every time the component's arguments get re-evaluated.
+- At the frequency specified by the `poll_frequency` argument.
 
 Any error while polling will mark the component as unhealthy.
 After a successful poll, all data is exported with the same field names as the source Secret.
@@ -79,24 +80,24 @@ The following arguments are supported:
 | Name                     | Type                | Description                                                                                      | Default | Required |
 | ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------- |
 | `api_server`             | `string`            | URL of the Kubernetes API server.                                                                |         | no       |
-| `kubeconfig_file`        | `string`            | Path of the `kubeconfig` file to use for connecting to Kubernetes.                               |         | no       |
-| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
+| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
 | `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
-| `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
+| `kubeconfig_file`        | `string`            | Path of the `kubeconfig` file to use for connecting to Kubernetes.                               |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
-| `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
+| `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
+| `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
 
- At most, one of the following can be provided:
+At most, one of the following can be provided:
 
-* [`authorization`](#authorization) block
-* [`basic_auth`](#basic_auth) block
-* [`bearer_token_file`](#client) argument
-* [`bearer_token`](#client) argument
-* [`oauth2`](#oauth2) block
+- [`authorization`](#authorization) block
+- [`basic_auth`](#basic_auth) block
+- [`bearer_token_file`](#client) argument
+- [`bearer_token`](#client) argument
+- [`oauth2`](#oauth2) block
 
 {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -138,7 +139,7 @@ Using `convert.nonsensitive` allows for using the exports of `remote.kubernetes.
 
 ## Component health
 
-Instances of `remote.kubernetes.secret` report as healthy if the most recent attempt to poll the kubernetes API succeeds.
+Instances of `remote.kubernetes.secret` report as healthy if the most recent attempt to poll the Kubernetes API succeeds.
 
 ## Debug information
 
@@ -167,7 +168,7 @@ prometheus.remote_write "default" {
   endpoint {
     url = remote.kubernetes.configmap.endpoint.data["url"]
     basic_auth {
-      username = convert.nonsensitive(remote.kubernetes.configmap.endpoint.data["username"])
+      username = convert.nonsensitive(remote.kubernetes.secret.credentials.data["username"])
       password = remote.kubernetes.secret.credentials.data["password"]
     }
   }

--- a/docs/sources/reference/components/remote/remote.kubernetes.secret.md
+++ b/docs/sources/reference/components/remote/remote.kubernetes.secret.md
@@ -38,14 +38,14 @@ You can use the following arguments with `remote.kubernetes.secret`:
 | `poll_timeout`   | `duration` | Timeout when polling the Kubernetes API.            | `"15s"` | no       |
 
 When this component performs a poll operation, it requests the Secret data from the Kubernetes API.
-A poll is triggered by the following:
+The following triggers a poll:
 
 - When the component first loads.
 - Every time the component's arguments get re-evaluated.
 - At the frequency specified by the `poll_frequency` argument.
 
-Any error while polling will mark the component as unhealthy.
-After a successful poll, all data is exported with the same field names as the source Secret.
+Any error while polling marks the component as unhealthy.
+After a successful poll, `remote.kubernetes.secret` exports all data with the same field names as the source Secret.
 
 ## Blocks
 
@@ -73,25 +73,25 @@ You can use the following blocks with `remote.kubernetes.secret`:
 ### `client`
 
 The `client` block configures the Kubernetes client used to discover Secrets.
-If the `client` block isn't provided, the default in-cluster configuration with the service account of the running {{< param "PRODUCT_NAME" >}} Pod is used.
+If the `client` block isn't provided, {{< param "PRODUCT_NAME" >}} uses the default in-cluster configuration with the service account of the running {{< param "PRODUCT_NAME" >}} Pod.
 
-The following arguments are supported:
+The `client` block supports the following arguments:
 
 | Name                     | Type                | Description                                                                                      | Default | Required |
 | ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------- |
 | `api_server`             | `string`            | URL of the Kubernetes API server.                                                                |         | no       |
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |         | no       |
 | `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |         | no       |
-| `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`  | no       |
-| `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`  | no       |
-| `http_headers`           | `map(list(secret))` | Custom HTTP headers to be sent along with each request. The map key is the header name.          |         | no       |
+| `enable_http2`           | `bool`              | Whether the client supports HTTP2 for requests.                                                 | `true`  | no       |
+| `follow_redirects`       | `bool`              | Whether the client follows redirects returned by the server.                                    | `true`  | no       |
+| `http_headers`           | `map(list(secret))` | Custom HTTP headers to send along with each request. The map key is the header name.             |         | no       |
 | `kubeconfig_file`        | `string`            | Path of the `kubeconfig` file to use for connecting to Kubernetes.                               |         | no       |
 | `no_proxy`               | `string`            | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |         | no       |
 | `proxy_connect_header`   | `map(list(secret))` | Specifies headers to send to proxies during CONNECT requests.                                    |         | no       |
 | `proxy_from_environment` | `bool`              | Use the proxy URL indicated by environment variables.                                            | `false` | no       |
 | `proxy_url`              | `string`            | HTTP proxy to send requests through.                                                             |         | no       |
 
-At most, one of the following can be provided:
+At most, you can provide one of the following:
 
 - [`authorization`](#authorization) block
 - [`basic_auth`](#basic_auth) block
@@ -127,7 +127,7 @@ The following fields are exported and can be referenced by other components:
 
 The `data` field contains a mapping from field names to values.
 
-If an individual key stored in `data` doesn't hold sensitive data, it can be converted into a string using [the `convert.nonsensitive` function][convert]:
+If an individual key stored in `data` doesn't hold sensitive data, you can convert it into a string using [the `convert.nonsensitive` function][convert]:
 
 ```alloy
 convert.nonsensitive(remote.kubernetes.secret.LABEL.data.KEY_NAME)
@@ -175,4 +175,4 @@ prometheus.remote_write "default" {
 }
 ```
 
-This example assumes that the Secret and ConfigMap have already been created, and that the appropriate field names exist in their data.
+This example assumes that the Secret and ConfigMap already exist, and that the appropriate field names exist in their data.

--- a/docs/sources/reference/components/remote/remote.s3.md
+++ b/docs/sources/reference/components/remote/remote.s3.md
@@ -14,17 +14,17 @@ title: remote.s3
 # `remote.s3`
 
 `remote.s3` exposes the string contents of a file located in [AWS S3](https://aws.amazon.com/s3/) to other components.
-The file is polled for changes so that the most recent content is always available.
+`remote.s3` polls the file for changes, so the most recent content is always available.
 
 The most common use of `remote.s3` is to load secrets from files.
 
 You can specify multiple `remote.s3` components by giving them different labels.
-By default, [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) are used to authenticate against S3.
-The `key` and `secret` arguments inside `client` blocks can be used to provide custom authentication.
+By default, `remote.s3` uses [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) to authenticate against S3.
+Use the `key` and `secret` arguments inside `client` blocks to provide custom authentication.
 
 {{< admonition type="note" >}}
-Other S3-compatible systems can be read with `remote.s3` but may require specific authentication environment variables.
-There is no guarantee that `remote.s3` will work with non-AWS S3 systems.
+`remote.s3` can read other S3-compatible systems, but they may require specific authentication environment variables.
+`remote.s3` isn't guaranteed to work with non-AWS S3 systems.
 {{< /admonition >}}
 
 ## Usage
@@ -88,7 +88,7 @@ The following fields are exported and can be referenced by other components:
 | --------- | -------------------- | ------------------------- |
 | `content` | `string` or `secret` | The contents of the file. |
 
-The `content` field will be secret if `is_secret` is set to true.
+The `content` field is secret if `is_secret` is `true`.
 
 ## Component health
 
@@ -100,7 +100,7 @@ Instances of `remote.s3` report as healthy if the most recent read of the watche
 
 ## Debug metrics
 
-The following Prometheus metrics are exposed:
+`remote.s3` exposes the following metrics:
 
 | Name                                             | Type      | Description                                 |
 | ------------------------------------------------ | --------- | ------------------------------------------- |

--- a/docs/sources/reference/components/remote/remote.s3.md
+++ b/docs/sources/reference/components/remote/remote.s3.md
@@ -17,13 +17,13 @@ The file is polled for changes so that the most recent content is always availab
 
 The most common use of `remote.s3` is to load secrets from files.
 
-You can specify multiple `remote.s3` components by using different name labels.
+You can specify multiple `remote.s3` components by giving them different labels.
 By default, [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) are used to authenticate against S3.
 The `key` and `secret` arguments inside `client` blocks can be used to provide custom authentication.
 
 {{< admonition type="note" >}}
-Other S3-compatible systems can be read  with `remote.s3` but may require specific authentication environment variables.
-There is no  guarantee that `remote.s3` will work with non-AWS S3 systems.
+Other S3-compatible systems can be read with `remote.s3` but may require specific authentication environment variables.
+There is no guarantee that `remote.s3` will work with non-AWS S3 systems.
 {{< /admonition >}}
 
 ## Usage
@@ -49,7 +49,7 @@ You can use the following arguments with `remote.s3`:
 This doesn't support reading of directories.
 {{< /admonition >}}
 
-[secret]: ../../../../get-started/configuration-syntax/expressions/types_and_values/#secrets
+[secret]: ../../../../get-started/expressions/types_and_values/#secrets
 
 ## Blocks
 
@@ -57,7 +57,7 @@ You can use the following block with `remote.s3`:
 
 {{< docs/alloy-config >}}
 
-| Name               | Description                                       | Required |
+| Block              | Description                                       | Required |
 | ------------------ | ------------------------------------------------- | -------- |
 | [`client`][client] | Additional options for configuring the S3 client. | no       |
 
@@ -83,9 +83,9 @@ The `client` block customizes options to connect to the S3 server.
 
 The following fields are exported and can be referenced by other components:
 
-| Name      | Type                 | Description               | Default | Required |
-| --------- | -------------------- | ------------------------- | ------- | -------- |
-| `content` | `string` or `secret` | The contents of the file. |         | no       |
+| Name      | Type                 | Description               |
+| --------- | -------------------- | -------------------------- |
+| `content` | `string` or `secret` | The contents of the file. |
 
 The `content` field will be secret if `is_secret` is set to true.
 
@@ -99,7 +99,12 @@ Instances of `remote.s3` report as healthy if the most recent read of the watche
 
 ## Debug metrics
 
-`remote.s3` doesn't expose any component-specific debug metrics.
+The following Prometheus metrics are exposed:
+
+| Name                                             | Type      | Description                                 |
+| ------------------------------------------------ | --------- | ------------------------------------------- |
+| `remote_s3_errors_total`                         | `counter` | The number of errors while accessing S3.    |
+| `remote_s3_timestamp_last_accessed_unix_seconds` | `gauge`   | The last successful access in Unix seconds. |
 
 ## Example
 

--- a/docs/sources/reference/components/remote/remote.s3.md
+++ b/docs/sources/reference/components/remote/remote.s3.md
@@ -7,6 +7,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: remote.s3
 ---
 

--- a/docs/sources/reference/components/remote/remote.s3.md
+++ b/docs/sources/reference/components/remote/remote.s3.md
@@ -85,7 +85,7 @@ The `client` block customizes options to connect to the S3 server.
 The following fields are exported and can be referenced by other components:
 
 | Name      | Type                 | Description               |
-| --------- | -------------------- | -------------------------- |
+| --------- | -------------------- | ------------------------- |
 | `content` | `string` or `secret` | The contents of the file. |
 
 The `content` field will be secret if `is_secret` is set to true.

--- a/docs/sources/reference/components/remote/remote.vault.md
+++ b/docs/sources/reference/components/remote/remote.vault.md
@@ -40,19 +40,19 @@ remote.vault "<LABEL>" {
 
 You can use the following arguments with `remote.vault`:
 
-| Name               | Type       | Description                                                | Default | Required |
-| ------------------ | ---------- | ---------------------------------------------------------- | ------- | -------- |
-| `path`             | `string`   | The path to retrieve a secret from.                        |         | yes      |
-| `server`           | `string`   | The Vault server to connect to.                            |         | yes      |
-| `namespace`        | `string`   | The Vault namespace to connect to (Vault Enterprise only). |         | no       |
-| `key`              | `string`   | The key to retrieve a secret from.                         |         | no       |
-| `reread_frequency` | `duration` | Rate to re-read keys.                                      | `"0s"`  | no       |
+| Name               | Type       | Description                                   | Default | Required |
+| ------------------ | ---------- | --------------------------------------------- | ------- | -------- |
+| `path`             | `string`   | The path to retrieve a secret from.           |         | yes      |
+| `server`           | `string`   | The Vault server to connect to.               |         | yes      |
+| `namespace`        | `string`   | The Vault Enterprise namespace to connect to. |         | no       |
+| `key`              | `string`   | The key to retrieve a secret from.            |         | no       |
+| `reread_frequency` | `duration` | Rate to re-read keys.                         | `"0s"`  | no       |
 
 Tokens with a lease are automatically renewed roughly two-thirds through their lease duration.
 If the leased token isn't renewable, or renewing the lease fails, the token is re-read.
 
 All tokens, regardless of whether they have a lease, are automatically reread at a frequency specified by the `reread_frequency` argument.
-Setting `reread_frequency` to `"0s"` (the default) disables this behavior.
+The default value of `reread_frequency`, `"0s"`, disables this behavior.
 
 ## Blocks
 
@@ -86,7 +86,7 @@ You can use the following blocks with `remote.vault`:
 
 {{< /docs/alloy-config >}}
 
-Exactly one `auth.*` block **must** be provided, otherwise the component will fail to load.
+You must provide exactly one `auth.*` block, or the component fails to load.
 
 ### `auth.approle`
 
@@ -106,8 +106,8 @@ The `auth.approle` block authenticates to Vault using the [AppRole auth method][
 
 The `auth.aws` block authenticates to Vault using the [AWS auth method][AWS].
 
-Credentials used to connect to AWS are specified by the environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION`.
-The environment variable `AWS_SHARED_CREDENTIALS_FILE` may be specified to use a credentials file instead.
+The environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION` specify the credentials used to connect to AWS.
+You can specify the environment variable `AWS_SHARED_CREDENTIALS_FILE` to use a credentials file instead.
 
 | Name                   | Type     | Description                                       | Default       | Required |
 | ---------------------- | -------- | ------------------------------------------------- | ------------- | -------- |
@@ -118,15 +118,15 @@ The environment variable `AWS_SHARED_CREDENTIALS_FILE` may be specified to use a
 | `region`               | `string` | AWS region to connect to.                         | `"us-east-1"` | no       |
 | `role`                 | `string` | Overrides the inferred role name inferred.        | `""`          | no       |
 
-The `type` argument must be set to one of `"ec2"` or `"iam"`.
+Set the `type` argument to `"ec2"` or `"iam"`.
 
-The `iam_server_id_header` argument is required used when `type` is set to `"iam"`.
+You must set `iam_server_id_header` when `type` is `"iam"`.
 
-If the `region` argument is explicitly set to an empty string `""`, the region to connect to will be inferred using an API call to the EC2 metadata service.
+If you explicitly set the `region` argument to an empty string `""`, `remote.vault` infers the region using an API call to the EC2 metadata service.
 
 The `ec2_signature_type` argument configures the signature to use when authenticating against EC2.
-It only applies when `type` is set to `"ec2"`.
-`ec2_signature_type` must be set to either `"identity"` or `"pkcs7"`.
+It only applies when `type` is `"ec2"`.
+Set `ec2_signature_type` to `"identity"` or `"pkcs7"`.
 
 [AWS]: https://www.vaultproject.io/docs/auth/aws
 
@@ -134,7 +134,7 @@ It only applies when `type` is set to `"ec2"`.
 
 The `auth.azure` block authenticates to Vault using the [Azure auth method][Azure].
 
-Credentials are retrieved for the running Azure VM using Managed Identities for Azure Resources.
+`remote.vault` retrieves credentials for the running Azure VM using Managed Identities for Azure Resources.
 
 | Name           | Type     | Description                                          | Default                           | Required |
 | -------------- | -------- | ---------------------------------------------------- | --------------------------------- | -------- |
@@ -156,12 +156,12 @@ Using `auth.custom` is equivalent to calling `vault write PATH DATA` on the comm
 | `data`      | `map(secret)` | Authentication data.                                   |         | yes      |
 | `namespace` | `string`      | The namespace to authenticate to.                      |         | no       |
 
-All values in the `data` attribute are considered secret, even if they contain nonsensitive information like usernames.
+`remote.vault` considers all values in the `data` attribute secret, even if they contain nonsensitive information like usernames.
 
 With Vault Enterprise, you can authenticate against a parent namespace while storing secrets in a child namespace.
 By specifying the namespace argument in `auth.custom`, you can authenticate to a namespace different from the one used to retrieve the secrets.
 
-You can also define Vault environment variables, which the clients used by {{< param "PRODUCT_NAME" >}} will automatically load.
+You can also define Vault environment variables, which the clients used by {{< param "PRODUCT_NAME" >}} automatically load.
 This approach allows you to use certificate-based authentication by setting the `VAULT_CACERT` and `VAULT_CAPATH` environment variables.
 Refer to the [Vault Environment variables](https://developer.hashicorp.com/vault/docs/commands#configure-environment-variables) documentation for more information.
 
@@ -176,8 +176,8 @@ The `auth.gcp` block authenticates to Vault using the [GCP auth method][GCP].
 | `iam_service_account` | `string` | IAM service account name to use.           |         | no       |
 | `mount_path`          | `string` | Mount path for the login.                  | `"gcp"` | no       |
 
-The `type` argument must be set to `"gce"` or `"iam"`. When `type` is `"gce"`, credentials are retrieved using the metadata service on GCE VMs.
-When `type` is `"iam"`, credentials are retrieved from the file that the `GOOGLE_APPLICATION_CREDENTIALS` environment variable points to.
+Set the `type` argument to `"gce"` or `"iam"`. When `type` is `"gce"`, `remote.vault` retrieves credentials using the metadata service on GCE VMs.
+When `type` is `"iam"`, `remote.vault` retrieves credentials from the file that the `GOOGLE_APPLICATION_CREDENTIALS` environment variable points to.
 
 When `type` is `"iam"`, the `iam_service_account` argument determines what service account name to use.
 
@@ -193,7 +193,7 @@ The `auth.kubernetes` block authenticates to Vault using the [Kubernetes auth me
 | `service_account_file` | `string` | Override service account token file to use. | `"/var/run/secrets/kubernetes.io/serviceaccount/token"` | no       |
 | `mount_path`           | `string` | Mount path for the login.                   | `"kubernetes"`                                          | no       |
 
-When `service_account_file` is not specified, the JWT token to authenticate with is retrieved from `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+When `service_account_file` isn't specified, `remote.vault` retrieves the JWT token to authenticate with from `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 
 [Kubernetes]: https://www.vaultproject.io/docs/auth/kubernetes
 
@@ -240,14 +240,14 @@ The `client_options` block customizes the connection to vault.
 | `max_retries`    | `int`      | Maximum number of times to retry after a 5xx error.   | `2`        | no       |
 | `timeout`        | `duration` | Maximum time to wait before a request times out.      | `"60s"`    | no       |
 
-Requests which fail due to server errors (HTTP 5xx error codes) can be retried.
+`remote.vault` can retry requests that fail with an HTTP 5xx server error.
 The `max_retries` argument specifies how many times to retry failed requests.
 The `min_retry_wait` and `max_retry_wait` arguments specify how long to wait before retrying.
 The wait period starts at `min_retry_wait` and exponentially increases up to `max_retry_wait`.
 
 Other types of failed requests, including HTTP 4xx error codes, aren't retried.
 
-If the `max_retries` argument is set to `0`, failed requests aren't retried.
+If you set the `max_retries` argument to `0`, `remote.vault` doesn't retry failed requests.
 
 ## Exported fields
 
@@ -261,10 +261,10 @@ The `data` field contains a mapping from data field names to values.
 There is one mapping for each string-like field stored in the Vault secret.
 
 Vault permits secret engines to store arbitrary data within the key-value pairs for a secret.
-The `remote.vault` component is only able to use values which are strings or can be converted to strings.
-Keys with non-string values are ignored and omitted from the `data` field.
+The `remote.vault` component can only use values that are strings, or that it can convert to strings.
+`remote.vault` ignores and omits keys with non-string values from the `data` field.
 
-If an individual key stored in `data` doesn't hold sensitive data, it can be converted into a string using [the `nonsensitive` function][convert.nonsensitive]:
+If an individual key stored in `data` doesn't hold sensitive data, you can convert it into a string using [the `nonsensitive` function][convert.nonsensitive]:
 
 ```alloy
 convert.nonsensitive(remote.vault.LABEL.data.KEY_NAME)
@@ -276,17 +276,17 @@ Using `convert.nonsensitive` allows for using the exports of `remote.vault` for 
 
 ## Component health
 
-`remote.vault` is reported as unhealthy if the latest reread or renewal of secrets was unsuccessful.
+`remote.vault` reports as unhealthy if the most recent reread or renewal of secrets was unsuccessful.
 
 ## Debug information
 
 `remote.vault` exposes debug information for the authentication token and secret around:
 
-* The latest request ID used for retrieving or renewing the token.
-* The most recent time when the token was retrieved or renewed.
-* The expiration time for the token (if applicable).
-* Whether the token is renewable.
-* Warnings from Vault from when the token was retrieved.
+- The most recent request ID used for retrieving or renewing the token.
+- The most recent time `remote.vault` retrieved or renewed the token.
+- The token's expiration time, if applicable.
+- Whether the token is renewable.
+- Warnings from Vault when it retrieved the token.
 
 ## Debug metrics
 
@@ -295,7 +295,7 @@ Using `convert.nonsensitive` allows for using the exports of `remote.vault` for 
 | Name                                      | Type      | Description                                                                 |
 | ----------------------------------------- | --------- | --------------------------------------------------------------------------- |
 | `remote_vault_auth_total`                 | `counter` | Total number of times the component authenticated to Vault.                 |
-| `remote_vault_secret_reads_total`         | `counter` | Total number of times the secret was read from Vault.                       |
+| `remote_vault_secret_reads_total`         | `counter` | Total number of times `remote.vault` read the secret from Vault.            |
 | `remote_vault_auth_lease_renewal_total`   | `counter` | Total number of times the component renewed its authentication token lease. |
 | `remote_vault_secret_lease_renewal_total` | `counter` | Total number of times the component renewed its secret lease.               |
 

--- a/docs/sources/reference/components/remote/remote.vault.md
+++ b/docs/sources/reference/components/remote/remote.vault.md
@@ -7,6 +7,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: remote.vault
 ---
 
@@ -135,11 +136,11 @@ The `auth.azure` block authenticates to Vault using the [Azure auth method][Azur
 
 Credentials are retrieved for the running Azure VM using Managed Identities for Azure Resources.
 
-| Name           | Type     | Description                                          | Default   | Required |
-| -------------- | -------- | ---------------------------------------------------- | --------- | -------- |
-| `role`         | `string` | Role name to authenticate as.                        |           | yes      |
-| `resource_url` | `string` | Resource URL to include with authentication request. |           | no       |
-| `mount_path`   | `string` | Mount path for the login.                            | `"azure"` | no       |
+| Name           | Type     | Description                                          | Default                           | Required |
+| -------------- | -------- | ---------------------------------------------------- | --------------------------------- | -------- |
+| `role`         | `string` | Role name to authenticate as.                        |                                   | yes      |
+| `resource_url` | `string` | Resource URL to include with authentication request. | `"https://management.azure.com/"` | no       |
+| `mount_path`   | `string` | Mount path for the login.                            | `"azure"`                         | no       |
 
 [Azure]: https://www.vaultproject.io/docs/auth/azure
 
@@ -149,21 +150,21 @@ The `auth.custom` blocks allows authenticating against Vault using an arbitrary 
 
 Using `auth.custom` is equivalent to calling `vault write PATH DATA` on the command line.
 
-
-| Name         | Type            | Description                                            | Default | Required |
-|--------------|-----------------|--------------------------------------------------------| ------- |----------|
-| `path`       | `string`        | Path to write to for creating an authentication token. |         | yes      |
-| `data`       | `map(secret)`   | Authentication data.                                   |         | yes      |
-| `namespace`  | `string`        | The namespace to authenticate to.                      |         | no       |
+| Name        | Type          | Description                                            | Default | Required |
+| ----------- | ------------- | ------------------------------------------------------ | ------- | -------- |
+| `path`      | `string`      | Path to write to for creating an authentication token. |         | yes      |
+| `data`      | `map(secret)` | Authentication data.                                   |         | yes      |
+| `namespace` | `string`      | The namespace to authenticate to.                      |         | no       |
 
 All values in the `data` attribute are considered secret, even if they contain nonsensitive information like usernames.
 
-With Vault Enterprise, you can authenticate against a parent namespace while storing secrets in a child namespace. 
+With Vault Enterprise, you can authenticate against a parent namespace while storing secrets in a child namespace.
 By specifying the namespace argument in `auth.custom`, you can authenticate to a namespace different from the one used to retrieve the secrets.
 
-You can also define Vault environment variables, which the clients used by {{< param "PRODUCT_NAME" >}} will automatically load. 
+You can also define Vault environment variables, which the clients used by {{< param "PRODUCT_NAME" >}} will automatically load.
 This approach allows you to use certificate-based authentication by setting the `VAULT_CACERT` and `VAULT_CAPATH` environment variables.
 Refer to the [Vault Environment variables](https://developer.hashicorp.com/vault/docs/commands#configure-environment-variables) documentation for more information.
+
 ### `auth.gcp`
 
 The `auth.gcp` block authenticates to Vault using the [GCP auth method][GCP].
@@ -186,11 +187,11 @@ When `type` is `"iam"`, the `iam_service_account` argument determines what servi
 
 The `auth.kubernetes` block authenticates to Vault using the [Kubernetes auth method][Kubernetes].
 
-| Name                   | Type     | Description                                 | Default        | Required |
-| ---------------------- | -------- | ------------------------------------------- | -------------- | -------- |
-| `role`                 | `string` | Role name to authenticate as.               |                | yes      |
-| `service_account_file` | `string` | Override service account token file to use. |                | no       |
-| `mount_path`           | `string` | Mount path for the login.                   | `"kubernetes"` | no       |
+| Name                   | Type     | Description                                 | Default                                                 | Required |
+| ---------------------- | -------- | ------------------------------------------- | ------------------------------------------------------- | -------- |
+| `role`                 | `string` | Role name to authenticate as.               |                                                         | yes      |
+| `service_account_file` | `string` | Override service account token file to use. | `"/var/run/secrets/kubernetes.io/serviceaccount/token"` | no       |
+| `mount_path`           | `string` | Mount path for the login.                   | `"kubernetes"`                                          | no       |
 
 When `service_account_file` is not specified, the JWT token to authenticate with is retrieved from `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 
@@ -291,10 +292,12 @@ Using `convert.nonsensitive` allows for using the exports of `remote.vault` for 
 
 `remote.vault` exposes the following metrics:
 
-* `remote_vault_auth_total` (counter): Total number of times the component authenticated to Vault.
-* `remote_vault_secret_reads_total` (counter): Total number of times the secret was read from Vault.
-* `remote_vault_auth_lease_renewal_total` (counter): Total number of times the component renewed its authentication token lease.
-* `remote_vault_secret_lease_renewal_total` (counter): Total number of times the component renewed its secret token lease.
+| Name                                      | Type      | Description                                                                 |
+| ----------------------------------------- | --------- | --------------------------------------------------------------------------- |
+| `remote_vault_auth_total`                 | `counter` | Total number of times the component authenticated to Vault.                 |
+| `remote_vault_secret_reads_total`         | `counter` | Total number of times the secret was read from Vault.                       |
+| `remote_vault_auth_lease_renewal_total`   | `counter` | Total number of times the component renewed its authentication token lease. |
+| `remote_vault_secret_lease_renewal_total` | `counter` | Total number of times the component renewed its secret lease.               |
 
 ## Example
 
@@ -314,8 +317,8 @@ remote.vault "remote_write" {
   }
 }
 
-metrics.remote_write "prod" {
-  remote_write {
+prometheus.remote_write "prod" {
+  endpoint {
     url = "https://onprem-mimir:9009/api/v1/push"
     basic_auth {
       username = remote.vault.remote_write.data.username


### PR DESCRIPTION
This PR is a general cleanup of the `remote.*` topics.  

This is preliminary work that needs to be done as part of an overall project to migrate Examples either to task topics or to scenarios. The foundation of the component doc needs to be in good shape before any other work is undertaken.

Validated against the component source code, looking at Blocks, Arguments, completeness, accuracy, etc.  Most fixes are cosmetic (markdown formatting, removing extra spaces, aligning tables). Some fixes covered errors in the existing examples, errors in the debug section, and product name errors.

Added `review_date` metadata to all files that have been reviewed. This is something we should start using on all doc topics going forward once they are fully reviewed, and updated with subsequent reviews.

## Note for reviewers.
 - I changed a line in the example in `remote.kubernetes.secret` to read `username = convert.nonsensitive(remote.kubernetes.secret.credentials.data["username"])`. Claude flagged the original line as redundant and suggested multiple variations. I picked this one as the most logical looking, but it needs to be validated.
 - I changed some default values in remote.vault that need a double check. Specifically for `resource_url` and `service_account_file`. This what they look like they should be in the source, but I can't tell if they were left out of the docs on purpose or not... or if I'm reading the source incorrectly.