### PR TITLE
docs: Validate the pyroscope.* component topics

### DIFF
--- a/docs/sources/reference/components/pyroscope/_index.md
+++ b/docs/sources/reference/components/pyroscope/_index.md
@@ -1,12 +1,18 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/
 description: Learn about the pyroscope components in Grafana Alloy
+review_date: 2026-09-11
+labels:
+  products:
+    - oss
 title: pyroscope
 weight: 100
 ---
 
 # `pyroscope`
 
-This section contains reference documentation for the `pyroscope` components.
+The `pyroscope` components collect, process, and forward continuous profiling data to a Pyroscope-compatible backend. They support multiple collection methods, including eBPF-based profiling, Java process profiling, and HTTP scraping, and let you enrich, relabel, and route profiles before writing them to storage.
+
+Use a `pyroscope` component when you want to collect performance profiles from your applications and infrastructure, and send them to Grafana Pyroscope or another compatible endpoint for analysis.
 
 {{< section >}}

--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -36,15 +36,15 @@ You can specify multiple `pyroscope.ebpf` components by giving them different la
 
 When running on Kubernetes without `privileged: true`, grant the following Linux capabilities and mount the kernel filesystem paths:
 
-| Capability           | Purpose                                                                                                                                 |
-|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `BPF`                | Load and manage eBPF programs and maps.                                                                                                 |
-| `PERFMON`            | Attach perf events and read performance counters.                                                                                       |
-| `SYS_PTRACE`         | Read `/proc/<pid>/` entries.                                                                                                            |
-| `CHECKPOINT_RESTORE` | Follow magic-links in `/proc/<pid>/map_files/*` for ELF symbol reading (kernel 5.9+; use `SYS_ADMIN` on older kernels).                 |
-| `SYS_RESOURCE`       | Raise `RLIMIT_MEMLOCK` for eBPF map locking.                                                                                            |
-| `DAC_READ_SEARCH`    | Read ELF binaries and `/proc` entries regardless of DAC permission bits.                                                                |
-| `SYSLOG`             | Read the kernel ring buffer for eBPF verifier diagnostics.                                                                              |
+| Capability           | Purpose                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `BPF`                | Load and manage eBPF programs and maps.                                                                                 |
+| `PERFMON`            | Attach perf events and read performance counters.                                                                       |
+| `SYS_PTRACE`         | Read `/proc/<pid>/` entries.                                                                                            |
+| `CHECKPOINT_RESTORE` | Follow magic-links in `/proc/<pid>/map_files/*` for ELF symbol reading (kernel 5.9+; use `SYS_ADMIN` on older kernels). |
+| `SYS_RESOURCE`       | Raise `RLIMIT_MEMLOCK` for eBPF map locking.                                                                            |
+| `DAC_READ_SEARCH`    | Read ELF binaries and `/proc` entries regardless of DAC permission bits.                                                |
+| `SYSLOG`             | Read the kernel ring buffer for eBPF verifier diagnostics.                                                              |
 
 Mount `/sys/kernel/tracing` (on older Kernel versions you might need `/sys/kernel/debug` instead) from the host as read-only volumes so the tracer can attach tracepoints.
 
@@ -68,43 +68,43 @@ The component configures and starts a new eBPF profiling job to collect performa
 
 You can use the following arguments with `pyroscope.ebpf`:
 
-| Name                      | Type                     | Description                                                                                                          | Default  | Required |
-|---------------------------|--------------------------|----------------------------------------------------------------------------------------------------------------------|----------|----------|
-| `forward_to`              | `list(ProfilesReceiver)` | List of receivers to send collected profiles to.                                                                     |          | yes      |
-| `targets`                 | `list(map(string))`      | List of process or container targets to profile.                                                                     |          | no       |
-| `bpf_fs_root`             | `string`                 | Root path of the BPF filesystem for pinned maps used in trace correlation.                                           | `"/sys/fs/bpf/"` | no       |
-| `build_id_cache_size`     | `int`                    | Deprecated (no-op), previously controlled the size of the elf file build id -> symbols table LRU cache.              | `64`     | no       |
-| `cache_rounds`            | `int`                    | Deprecated (no-op), previously controlled the number of cache rounds.                                                |          | no       |
-| `collect_interval`        | `duration`               | How frequently to collect profiles.                                                                                  | `"15s"`  | no       |
-| `collect_kernel_profile`  | `bool`                   | Deprecated (no-op), previously enabled collection of kernel-space profiles.                                          | `true`   | no       |
-| `collect_user_profile`    | `bool`                   | Deprecated (no-op), previously enabled collection of user-space profiles.                                            | `true`   | no       |
-| `comm`                    | `string`                 | How the process command name (`comm`) is included in profiles. One of `none`, `label`, `stackframe`, or `both`.      | `"none"` | no       |
-| `container_id_cache_size` | `int`                    | Deprecated (no-op), previously controlled the size of the PID -> container ID table LRU cache.                       | `1024`   | no       |
-| `demangle`                | `string`                 | C++ `demangle` mode. Available options are: `none`, `simplified`, `templates`, or `full`.                            | `"none"` | no       |
-| `dotnet_enabled`          | `bool`                   | A flag to enable or disable .NET profiling.                                                                          | `true`   | no       |
-| `go_enabled`              | `bool`                   | A flag to enable or disable Go profiling.                                                                            | `true`   | no       |
-| `go_table_fallback`       | `bool`                   | Deprecated (no-op), previously enabled symbol lookup in `.sym` / `.dynsym` sections when `.gopclntab` lookup failed. | `false`  | no       |
-| `hotspot_enabled`         | `bool`                   | A flag to enable or disable HotSpot profiling.                                                                       | `true`   | no       |
-| `kernel_frames`           | `bool`                   | Include kernel-space frames in collected profiles. Set to `false` to drop kernel frames from each stack trace.       | `true`   | no       |
-| `no_kernel_version_check` | `bool`                   | Skip the kernel version check for eBPF support.                                                                      | `false`  | no       |
-| `obi_process_context_enabled` | `bool`               | Enable profile correlation with traces generated by components compatible with OpenTelemetry eBPF Instrumentation. | `true`   | no       |
-| `perl_enabled`            | `bool`                   | A flag to enable or disable Perl profiling.                                                                          | `true`   | no       |
-| `php_enabled`             | `bool`                   | A flag to enable or disable PHP profiling.                                                                           | `true`   | no       |
-| `pid_cache_size`          | `int`                    | Deprecated (no-op), previously controlled the size of the PID -> proc symbols table LRU cache.                       | `32`     | no       |
-| `pid_label`               | `bool`                   | Attach the process PID to each pprof sample as a `pid` label.                                                        | `false`  | no       |
-| `pid_map_size`            | `int`                    | Deprecated (no-op), previously controlled the size of eBPF PID map.                                                  | `2048`   | no       |
-| `python_enabled`          | `bool`                   | A flag to enable or disable Python profiling.                                                                        | `true`   | no       |
-| `probe_links`             | `list(string)`           | List of kernel or user-space probes from which to collect stack traces.                                              |          | no       |
-| `ruby_enabled`            | `bool`                   | A flag to enable or disable Ruby profiling.                                                                          | `true`   | no       |
-| `same_file_cache_size`    | `int`                    | Deprecated (no-op), previously controlled the size of the elf file -> symbols table LRU cache.                       | `8`      | no       |
-| `sample_rate`             | `int`                    | How many times per second to collect profile samples.                                                                | `19`     | no       |
-| `symbols_map_size`        | `int`                    | Deprecated (no-op), previously controlled the size of the eBPF symbols map.                                          | `16384`  | no       |
-| `load_probe`              | `bool`                   | Load a generic eBPF program that can be attached to a kernel or user-space hook externally.                          | `false`  | no       |
-| `u_probe_links`           | `list(string)`           | Deprecated. Use `probe_links` instead.                                                                               |          | no       |
-| `v8_enabled`              | `bool`                   | A flag to enable or disable V8 profiling.                                                                            | `true`   | no       |
-| `off_cpu_threshold`       | `float`                  | Probability from `0` to `1` for recording an off-CPU event. A value of `0` disables off-CPU profiling.              | `0`      | no       |
-| `verbose_mode`            | `bool`                   | Enable verbose logging for the eBPF profiler.                                                                        | `false`  | no       |
-| `lazy_mode`               | `bool`                   | Enable lazy mode to defer eBPF profiler startup until targets are discovered.                                        | `false`  | no       |
+| Name                          | Type                     | Description                                                                                                          | Default          | Required |
+| ----------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `forward_to`                  | `list(ProfilesReceiver)` | List of receivers to send collected profiles to.                                                                     |                  | yes      |
+| `bpf_fs_root`                 | `string`                 | Root path of the BPF filesystem for pinned maps used in trace correlation.                                           | `"/sys/fs/bpf/"` | no       |
+| `build_id_cache_size`         | `int`                    | Deprecated (no-op), previously controlled the size of the elf file build id -> symbols table LRU cache.              | `64`             | no       |
+| `cache_rounds`                | `int`                    | Deprecated (no-op), previously controlled the number of cache rounds.                                                |                  | no       |
+| `collect_interval`            | `duration`               | How frequently to collect profiles.                                                                                  | `"15s"`          | no       |
+| `collect_kernel_profile`      | `bool`                   | Deprecated (no-op), previously enabled collection of kernel-space profiles.                                          | `true`           | no       |
+| `collect_user_profile`        | `bool`                   | Deprecated (no-op), previously enabled collection of user-space profiles.                                            | `true`           | no       |
+| `comm`                        | `string`                 | How the process command name (`comm`) is included in profiles. One of `none`, `label`, `stackframe`, or `both`.      | `"none"`         | no       |
+| `container_id_cache_size`     | `int`                    | Deprecated (no-op), previously controlled the size of the PID -> container ID table LRU cache.                       | `1024`           | no       |
+| `demangle`                    | `string`                 | C++ `demangle` mode. Available options are: `none`, `simplified`, `templates`, or `full`.                            | `"none"`         | no       |
+| `dotnet_enabled`              | `bool`                   | A flag to enable or disable .NET profiling.                                                                          | `true`           | no       |
+| `go_enabled`                  | `bool`                   | A flag to enable or disable Go profiling.                                                                            | `true`           | no       |
+| `go_table_fallback`           | `bool`                   | Deprecated (no-op), previously enabled symbol lookup in `.sym` / `.dynsym` sections when `.gopclntab` lookup failed. | `false`          | no       |
+| `hotspot_enabled`             | `bool`                   | A flag to enable or disable HotSpot profiling.                                                                       | `true`           | no       |
+| `kernel_frames`               | `bool`                   | Include kernel-space frames in collected profiles. Set to `false` to drop kernel frames from each stack trace.       | `true`           | no       |
+| `lazy_mode`                   | `bool`                   | Enable lazy mode to defer eBPF profiler startup until targets are discovered.                                        | `false`          | no       |
+| `load_probe`                  | `bool`                   | Load a generic eBPF program that can be attached to a kernel or user-space hook externally.                          | `false`          | no       |
+| `no_kernel_version_check`     | `bool`                   | Skip the kernel version check for eBPF support.                                                                      | `false`          | no       |
+| `obi_process_context_enabled` | `bool`                   | Enable profile correlation with traces generated by components compatible with OpenTelemetry eBPF Instrumentation.   | `true`           | no       |
+| `off_cpu_threshold`           | `float`                  | Probability from `0` to `1` for recording an off-CPU event. A value of `0` disables off-CPU profiling.               | `0`              | no       |
+| `perl_enabled`                | `bool`                   | A flag to enable or disable Perl profiling.                                                                          | `true`           | no       |
+| `php_enabled`                 | `bool`                   | A flag to enable or disable PHP profiling.                                                                           | `true`           | no       |
+| `pid_cache_size`              | `int`                    | Deprecated (no-op), previously controlled the size of the PID -> proc symbols table LRU cache.                       | `32`             | no       |
+| `pid_label`                   | `bool`                   | Attach the process PID to each pprof sample as a `pid` label.                                                        | `false`          | no       |
+| `pid_map_size`                | `int`                    | Deprecated (no-op), previously controlled the size of eBPF PID map.                                                  | `2048`           | no       |
+| `probe_links`                 | `list(string)`           | List of kernel or user-space probes from which to collect stack traces.                                              |                  | no       |
+| `python_enabled`              | `bool`                   | A flag to enable or disable Python profiling.                                                                        | `true`           | no       |
+| `ruby_enabled`                | `bool`                   | A flag to enable or disable Ruby profiling.                                                                          | `true`           | no       |
+| `same_file_cache_size`        | `int`                    | Deprecated (no-op), previously controlled the size of the elf file -> symbols table LRU cache.                       | `8`              | no       |
+| `sample_rate`                 | `int`                    | How many times per second to collect profile samples.                                                                | `19`             | no       |
+| `symbols_map_size`            | `int`                    | Deprecated (no-op), previously controlled the size of the eBPF symbols map.                                          | `16384`          | no       |
+| `targets`                     | `list(map(string))`      | List of process or container targets to profile.                                                                     |                  | no       |
+| `u_probe_links`               | `list(string)`           | Deprecated. Use `probe_links` instead.                                                                               |                  | no       |
+| `v8_enabled`                  | `bool`                   | A flag to enable or disable V8 profiling.                                                                            | `true`           | no       |
+| `verbose_mode`                | `bool`                   | Enable verbose logging for the eBPF profiler.                                                                        | `false`          | no       |
 
 {{< admonition type="caution" >}}
 Use `no_kernel_version_check` only when you run on an older kernel that includes backported eBPF features from a later release.
@@ -118,7 +118,30 @@ Several arguments are marked as "Deprecated (no-op)". These arguments were previ
 
 ## Blocks
 
-`pyroscope.ebpf` doesn't support any blocks.
+You can use the following block with `pyroscope.ebpf`:
+
+{{< docs/alloy-config >}}
+
+| Block                       | Description                                               | Required |
+| --------------------------- | --------------------------------------------------------- | -------- |
+| [`debug_info`][debug_info]  | Configures on-target symbolization and debug info upload. | no       |
+
+[debug_info]: #debug_info
+
+{{< /docs/alloy-config >}}
+
+### `debug_info`
+
+The `debug_info` block configures on-target symbolization and the upload of debug information used for off-target symbolization.
+
+| Name                      | Type   | Description                                                                  | Default  | Required |
+| ------------------------- | ------ | ----------------------------------------------------------------------------- | -------- | -------- |
+| `cache_size`              | `int`  | Size of the LRU cache used to avoid re-uploading the same debug information. | `262144` | no       |
+| `on_target_symbolization` | `bool` | Symbolize stack traces directly on the profiled host.                        | `true`   | no       |
+| `queue_size`              | `int`  | Size of the upload queue.                                                    | `256`    | no       |
+| `strip_text_section`      | `bool` | Strip the executable's text section before upload.                           | `false`  | no       |
+| `upload`                  | `bool` | Upload executable debug information for off-target symbolization.            | `false`  | no       |
+| `worker_num`              | `int`  | Number of workers processing the upload queue.                               | `16`     | no       |
 
 ## Exported fields
 
@@ -126,21 +149,24 @@ Several arguments are marked as "Deprecated (no-op)". These arguments were previ
 
 ## Component health
 
-`pyroscope.ebpf` is only reported as unhealthy if given an invalid configuration.
+`pyroscope.ebpf` is reported as unhealthy if given an invalid configuration, or if the eBPF profiling session fails to start, for example due to missing privileges or an unsupported kernel.
 
 ## Debug information
 
-* `elf_cache` per build id and per same file symbol tables and their sizes in symbols count.
-* `pid_cache` per process elf symbol tables and their sizes in symbols count.
-* `targets` currently tracked active targets.
+- `elf_cache` per build id and per same file symbol tables and their sizes in symbols count.
+- `pid_cache` per process elf symbol tables and their sizes in symbols count.
+- `targets` currently tracked active targets.
 
 ## Debug metrics
 
-* `pyroscope_ebpf_active_targets` (gauge): Number of active targets the component tracks.
-* `pyroscope_ebpf_pprofs_total` (counter): Number of pprof profiles collected by the eBPF component.
-* `pyroscope_ebpf_profiling_sessions_failing_total` (counter): Number of profiling sessions failed.
-* `pyroscope_ebpf_profiling_sessions_total` (counter): Number of profiling sessions completed.
-* `pyroscope_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
+- `pyroscope_ebpf_active_targets` (gauge): Number of active targets the component tracks.
+- `pyroscope_ebpf_pprofs_total` (counter): Number of pprof profiles collected by the eBPF component.
+- `pyroscope_ebpf_profiling_sessions_failing_total` (counter): Number of profiling sessions failed.
+- `pyroscope_ebpf_profiling_sessions_total` (counter): Number of profiling sessions completed.
+- `pyroscope_ebpf_pprofs_dropped_total` (counter): Number of pprof profiles dropped by the eBPF component.
+- `pyroscope_ebpf_pprof_bytes_total` (counter): Total bytes of pprof profiles collected by the eBPF component, per `service_name`.
+- `pyroscope_ebpf_pprof_samples_total` (counter): Total samples in pprof profiles collected by the eBPF component, per `service_name`.
+- `pyroscope_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
 
 ### eBPF profiler internal metrics
 
@@ -152,50 +178,50 @@ Notable metrics include:
 
 #### Native unwinding
 
-* `UnwindNativeAttempts_total` (counter): Unwind attempts since the previous check.
-* `UnwindNativeFrames_total` (counter): Unwound frames since the previous check.
-* `UnwindNativeStackDeltaStop_total` (counter): Number of stop stack deltas in the native unwinder (success).
-* `UnwindNativeSmallPC_total` (counter): Number of times PC held a value smaller than 0x1000.
-* `UnwindErrStackLengthExceeded_total` (counter): Number of times MAX_FRAME_UNWINDS has been exceeded.
+- `UnwindNativeAttempts_total` (counter): Unwind attempts since the previous check.
+- `UnwindNativeFrames_total` (counter): Unwound frames since the previous check.
+- `UnwindNativeStackDeltaStop_total` (counter): Number of stop stack deltas in the native unwinder (success).
+- `UnwindNativeSmallPC_total` (counter): Number of times PC held a value smaller than 0x1000.
+- `UnwindErrStackLengthExceeded_total` (counter): Number of times MAX_FRAME_UNWINDS has been exceeded.
 
 #### Interpreter unwinding
 
-* `UnwindPythonAttempts_total` (counter): Number of attempted Python unwinds.
-* `UnwindPythonFrames_total` (counter): Number of unwound Python frames.
-* `UnwindHotspotAttempts_total` (counter): Number of attempted Hotspot JVM unwinds.
-* `UnwindHotspotFrames_total` (counter): Number of unwound Hotspot JVM frames.
-* `UnwindRubyAttempts_total` (counter): Number of attempted Ruby unwinds.
-* `UnwindRubyFrames_total` (counter): Number of unwound Ruby frames.
-* `UnwindPHPAttempts_total` (counter): Number of attempted PHP unwinds.
-* `UnwindPHPFrames_total` (counter): Number of unwound PHP frames.
-* `UnwindPerlAttempts_total` (counter): Number of attempted Perl unwinds.
-* `UnwindPerlFrames_total` (counter): Number of unwound Perl frames.
-* `UnwindV8Attempts_total` (counter): Number of attempted V8 unwinds.
-* `UnwindV8Frames_total` (counter): Number of unwound V8 frames.
-* `UnwindDotnetAttempts_total` (counter): Number of attempted .NET unwinds.
-* `UnwindDotnetFrames_total` (counter): Number of unwound .NET frames.
+- `UnwindPythonAttempts_total` (counter): Number of attempted Python unwinds.
+- `UnwindPythonFrames_total` (counter): Number of unwound Python frames.
+- `UnwindHotspotAttempts_total` (counter): Number of attempted Hotspot JVM unwinds.
+- `UnwindHotspotFrames_total` (counter): Number of unwound Hotspot JVM frames.
+- `UnwindRubyAttempts_total` (counter): Number of attempted Ruby unwinds.
+- `UnwindRubyFrames_total` (counter): Number of unwound Ruby frames.
+- `UnwindPHPAttempts_total` (counter): Number of attempted PHP unwinds.
+- `UnwindPHPFrames_total` (counter): Number of unwound PHP frames.
+- `UnwindPerlAttempts_total` (counter): Number of attempted Perl unwinds.
+- `UnwindPerlFrames_total` (counter): Number of unwound Perl frames.
+- `UnwindV8Attempts_total` (counter): Number of attempted V8 unwinds.
+- `UnwindV8Frames_total` (counter): Number of unwound V8 frames.
+- `UnwindDotnetAttempts_total` (counter): Number of attempted .NET unwinds.
+- `UnwindDotnetFrames_total` (counter): Number of unwound .NET frames.
 
 #### Symbolization
 
-* `PythonSymbolizationSuccesses_total` (counter): Number of successfully symbolized Python frames.
-* `PythonSymbolizationFailures_total` (counter): Number of Python frames that failed symbolization.
-* `HotspotSymbolizationSuccesses_total` (counter): Number of successfully symbolized Hotspot frames.
-* `HotspotSymbolizationFailures_total` (counter): Number of Hotspot frames that failed symbolization.
-* `RubySymbolizationSuccess_total` (counter): Number of successfully symbolized Ruby frames.
-* `RubySymbolizationFailure_total` (counter): Number of Ruby frames that failed symbolization.
+- `PythonSymbolizationSuccesses_total` (counter): Number of successfully symbolized Python frames.
+- `PythonSymbolizationFailures_total` (counter): Number of Python frames that failed symbolization.
+- `HotspotSymbolizationSuccesses_total` (counter): Number of successfully symbolized Hotspot frames.
+- `HotspotSymbolizationFailures_total` (counter): Number of Hotspot frames that failed symbolization.
+- `RubySymbolizationSuccess_total` (counter): Number of successfully symbolized Ruby frames.
+- `RubySymbolizationFailure_total` (counter): Number of Ruby frames that failed symbolization.
 
 #### Process management
 
-* `NumProcNew_total` (counter): Number of new PID events.
-* `NumProcExit_total` (counter): Number of exit PID events.
-* `NumGenericPID_total` (counter): Number of generic PID events.
+- `NumProcNew_total` (counter): Number of new PID events.
+- `NumProcExit_total` (counter): Number of exit PID events.
+- `NumGenericPID_total` (counter): Number of generic PID events.
 
 #### eBPF map state
 
-* `NumExeIDLoadedToEBPF` (gauge): The number of executables loaded to eBPF maps.
-* `HashmapPidPageToMappingInfo` (gauge): Current size of the pid_page_to_mapping_info hash map.
-* `HashmapNumStackDeltaPages` (gauge): Current size of the stack delta pages hash map.
-* `UnwindInfoArraySize` (gauge): Current size of the unwind info array.
+- `NumExeIDLoadedToEBPF` (gauge): The number of executables loaded to eBPF maps.
+- `HashmapPidPageToMappingInfo` (gauge): Current size of the pid_page_to_mapping_info hash map.
+- `HashmapNumStackDeltaPages` (gauge): Current size of the stack delta pages hash map.
+- `UnwindInfoArraySize` (gauge): Current size of the unwind info array.
 
 The full list of ~213 metrics is defined in the [`opentelemetry-ebpf-profiler` metrics.json](https://github.com/grafana/opentelemetry-ebpf-profiler/blob/main/metrics/metrics.json).
 
@@ -222,10 +248,10 @@ These labels can help you pin down a profiling target.
 
 One of the following special labels _must_ be included in each target of `targets` and the label must correspond to the container or process that is profiled:
 
-* `__container_id__`: The container ID.
-* `__meta_docker_container_id`: The ID of the Docker container.
-* `__meta_kubernetes_pod_container_id`: The ID of the Kubernetes Pod container.
-* `__process_pid__` : The process ID.
+- `__container_id__`: The container ID.
+- `__meta_docker_container_id`: The ID of the Docker container.
+- `__meta_kubernetes_pod_container_id`: The ID of the Kubernetes Pod container.
+- `__process_pid__` : The process ID.
 
 Each process is then associated with a specified target from the targets list, determined by a container ID or process PID.
 
@@ -236,11 +262,13 @@ Otherwise the process isn't profiled.
 ### Service name
 
 The special label `service_name` is required and must always be present.
-If it's not specified, it's attempted to be inferred from multiple sources:
+If it's not specified, it's attempted to be inferred, in order, from the following sources:
 
-* `__meta_docker_container_name`
-* `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`
-* `__meta_kubernetes_pod_annotation_pyroscope_io_service_name` which is a `pyroscope.io/service_name` Pod annotation.
+- `__meta_kubernetes_pod_annotation_pyroscope_io_service_name`, which is a `pyroscope.io/service_name` Pod annotation.
+- `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`, combined into `ebpf/<namespace>/<container_name>`.
+- `__meta_docker_container_name`.
+- `__meta_dockerswarm_container_label_service_name`.
+- `__meta_dockerswarm_service_name`.
 
 If `service_name` isn't specified and couldn't be inferred, it's set to `unspecified`.
 
@@ -248,18 +276,18 @@ If `service_name` isn't specified and couldn't be inferred, it's set to `unspeci
 
 Symbols are extracted from various sources, including:
 
-* The `.gopclntab` section in Go language ELF files.
-* The `.symtab` and `.dynsym` sections in the debug ELF file.
-* The `.symtab` and `.dynsym` sections in the ELF file.
+- The `.gopclntab` section in Go language ELF files.
+- The `.symtab` and `.dynsym` sections in the debug ELF file.
+- The `.symtab` and `.dynsym` sections in the ELF file.
 
 The search for debug files follows [gdb algorithm][].
 For example, if the profiler wants to find the debug file for `/lib/x86_64-linux-gnu/libc.so.6` with a `.gnu_debuglink` set to `libc.so.6.debug` and a build ID `0123456789abcdef`.
 The following paths are examined:
 
-* `/usr/lib/debug/.build-id/01/0123456789abcdef.debug`
-* `/lib/x86_64-linux-gnu/libc.so.6.debug`
-* `/lib/x86_64-linux-gnu/.debug/libc.so.6.debug`
-* `/usr/lib/debug/lib/x86_64-linux-gnu/libc.so.6.debug`
+- `/usr/lib/debug/.build-id/01/0123456789abcdef.debug`
+- `/lib/x86_64-linux-gnu/libc.so.6.debug`
+- `/lib/x86_64-linux-gnu/.debug/libc.so.6.debug`
+- `/usr/lib/debug/lib/x86_64-linux-gnu/libc.so.6.debug`
 
 ### Deal with unknown symbols
 
@@ -267,9 +295,9 @@ Unknown symbols in the profiles you've collected indicate that the profiler coul
 
 This can occur for several reasons:
 
-* The process has terminated, making the ELF file inaccessible.
-* The ELF file is either corrupted or not recognized as an ELF file.
-* There is no corresponding ELF file entry in `/proc/pid/maps` for the address in the stack trace.
+- The process has terminated, making the ELF file inaccessible.
+- The ELF file is either corrupted or not recognized as an ELF file.
+- There is no corresponding ELF file entry in `/proc/pid/maps` for the address in the stack trace.
 
 ### Address unresolved symbols
 
@@ -277,8 +305,8 @@ If you only see module names without corresponding function names, for example, 
 
 This can occur for several reasons:
 
-* The binary has been stripped, leaving no .symtab, .dynsym, or .gopclntab sections in the ELF file.
-* The debug file is missing or couldn't be located.
+- The binary has been stripped, leaving no .symtab, .dynsym, or .gopclntab sections in the ELF file.
+- The debug file is missing or couldn't be located.
 
 To fix this for your binaries, ensure that they're either not stripped or that you have separate debug files available.
 You can achieve this by running:
@@ -425,8 +453,8 @@ pyroscope.ebpf "probes" {
 
 Replace the following:
 
-* _`<TARGET_LIST>`_: The list of process or container targets to profile.
-* _`<RECEIVER_LIST>`_: The list of profile receivers to forward profiles to.
+- _`<TARGET_LIST>`_: The list of process or container targets to profile.
+- _`<RECEIVER_LIST>`_: The list of profile receivers to forward profiles to.
 
 ### Correlate request profiles with Beyla traces and spans
 
@@ -493,10 +521,9 @@ pyroscope.write "profiles" {
 
 Replace the following:
 
-* _`<OTLP_TRACES_ENDPOINT>`_: The OTLP HTTP endpoint to send traces to.
-* _`<PYROSCOPE_URL>`_: The URL of the Pyroscope server to send profiles to.
+- _`<OTLP_TRACES_ENDPOINT>`_: The OTLP HTTP endpoint to send traces to.
+- _`<PYROSCOPE_URL>`_: The URL of the Pyroscope server to send profiles to.
 
-[troubleshooting]: #troubleshoot-unknown-symbols
 [gdb algorithm]: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -3,6 +3,7 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/
 aliases:
   - ../pyroscope.ebpf/ # /docs/alloy/latest/reference/components/pyroscope.ebpf/
 description: Learn about pyroscope.ebpf
+review_date: 2026-09-11
 labels:
   stage: general-availability
   products:

--- a/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.ebpf.md
@@ -3,11 +3,11 @@ canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/
 aliases:
   - ../pyroscope.ebpf/ # /docs/alloy/latest/reference/components/pyroscope.ebpf/
 description: Learn about pyroscope.ebpf
-review_date: 2026-09-11
 labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: pyroscope.ebpf
 ---
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.enrich.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.enrich.md
@@ -1,11 +1,11 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.enrich/
 description: Learn about pyroscope.enrich
-review_date: 2026-09-11
 labels:
   stage: experimental
   products:
     - oss
+review_date: 2026-09-11
 title: pyroscope.enrich
 ---
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.enrich.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.enrich.md
@@ -1,6 +1,7 @@
 ---
 canonical: https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.enrich/
 description: Learn about pyroscope.enrich
+review_date: 2026-09-11
 labels:
   stage: experimental
   products:
@@ -29,20 +30,20 @@ pyroscope.enrich "<LABEL>" {
 
 You can use the following arguments with `pyroscope.enrich`:
 
-| Name                   | Type                     | Description                                                                                  | Default | Required |
-| ---------------------- | ------------------------ | -------------------------------------------------------------------------------------------- | ------- | -------- |
-| `forward_to`           | `list(ProfilesReceiver)` | List of receivers to send enriched profiles to.                                              |         | yes      |
-| `target_match_label`   | `string`                 | The label from discovered targets to match against.                                          |         | yes      |
-| `targets`              | `list(Target)`           | List of targets from a discovery component.                                                  |         | yes      |
-| `labels_to_copy`       | `list(string)`           | List of labels to copy from discovered targets to profiles. If empty, all labels are copied. |         | no       |
-| `profiles_match_label` | `string`                 | The label from incoming profiles to match against discovered targets.                        |         | no       |
+| Name                   | Type                     | Description                                                                                                 | Default | Required |
+| ---------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `forward_to`           | `list(ProfilesReceiver)` | List of receivers to send enriched profiles to.                                                             |         | yes      |
+| `target_match_label`   | `string`                 | The label from discovered targets to match against.                                                         |         | yes      |
+| `targets`              | `list(map(string))`      | List of targets from a discovery component.                                                                 |         | yes      |
+| `labels_to_copy`       | `list(string)`           | List of labels to copy from discovered targets to profiles. If empty, `pyroscope.enrich` copies all labels. |         | no       |
+| `profiles_match_label` | `string`                 | The label from incoming profiles to match against discovered targets.                                       |         | no       |
 
 If `profiles_match_label` isn't provided, the component uses `target_match_label` for matching profile labels.
 
 ## Blocks
 
 `pyroscope.enrich` doesn't support any blocks.
-Configure this component with arguments.
+You can configure this component with arguments.
 
 ## Exported fields
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.java.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.java.md
@@ -7,6 +7,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: pyroscope.java
 ---
 
@@ -73,7 +74,7 @@ You can use the following arguments with `pyroscope.java`:
 | `targets`    | `list(map(string))`      | List of java process targets to profile.         |          | yes      |
 | `tmp_dir`    | `string`                 | Temporary directory to store async-profiler.     | `"/tmp"` | no       |
 
-## Profiling behavior
+## How profiling works
 
 The special label `__process_pid__` _must always_ be present in each target of `targets` and corresponds to the `PID` of the process to profile.
 
@@ -102,10 +103,10 @@ The special `__process_pid__` label _must always_ be present and corresponds to 
 Labels starting with a double underscore (`__`) are treated as _internal_, and are removed prior to scraping.
 
 The special label `service_name` is required and must always be present.
-If it's not specified, `pyroscope.scrape` will attempt to infer it from either of the following sources, in this order:
+If it's not specified, `pyroscope.java` attempts to infer it from either of the following sources, in this order:
 
 1. `__meta_kubernetes_pod_annotation_pyroscope_io_service_name` which is a `pyroscope.io/service_name` Pod annotation.
-1. `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`
+1. `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`, combined into `java/<namespace>/<container_name>`.
 1. `__meta_docker_container_name`
 1. `__meta_dockerswarm_container_label_service_name` or `__meta_dockerswarm_service_name`
 
@@ -127,9 +128,9 @@ You can use the following block with `pyroscope.java`:
 
 {{< docs/alloy-config >}}
 
-| Block                                 | Description                             | Required |
-| ------------------------------------- | --------------------------------------- | -------- |
-| [profiling_config`][profiling_config] | Describes java profiling configuration. | no       |
+| Block                                  | Description                             | Required |
+| -------------------------------------- | --------------------------------------- | -------- |
+| [`profiling_config`][profiling_config] | Describes java profiling configuration. | no       |
 
 [profiling_config]: #profiling_config
 
@@ -203,7 +204,6 @@ Refer to [Profiling modes](https://github.com/async-profiler/async-profiler/blob
 ## Component health
 
 `pyroscope.java` is only reported as unhealthy when given an invalid configuration.
-In those cases, exported fields retain their last healthy values.
 
 ## Debug information
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
@@ -36,11 +36,18 @@ The component starts an HTTP server supporting the following endpoints:
 
 ## Arguments
 
-You can use the following argument with `pyroscope.receive_http`:
+You can use the following arguments with `pyroscope.receive_http`:
 
-| Name         | Type                     | Description                            | Default | Required |
-| ------------ | ------------------------ | -------------------------------------- | ------- | -------- |
-| `forward_to` | `list(ProfilesReceiver)` | List of receivers to send profiles to. |         | yes      |
+| Name                        | Type                     | Description                                                       | Default | Required |
+| --------------------------- | ------------------------ | ----------------------------------------------------------------- | ------- | -------- |
+| `forward_to`                | `list(ProfilesReceiver)` | List of receivers to send profiles to.                            |         | yes      |
+| `debug_info_upload_timeout` | `duration`               | Timeout for uploading debug information to downstream components. | `"2m"`  | no       |
+
+`debug_info_upload_timeout` applies only to the debug information upload proxy endpoint `pyroscope.receive_http` exposes for downstream components.
+It doesn't affect the profile-ingest endpoints described in [Usage](#usage).
+
+Debug information upload requests are only proxied to the first receiver in `forward_to`.
+Unlike profiles, which are sent to every configured receiver, debug information isn't fanned out to the rest of the list.
 
 ## Blocks
 
@@ -48,7 +55,7 @@ You can use the following blocks with `pyroscope.receive_http`:
 
 {{< docs/alloy-config >}}
 
-| Name                  | Description                                        | Required |
+| Block                 | Description                                        | Required |
 | --------------------- | -------------------------------------------------- | -------- |
 | [`http`][http]        | Configures the HTTP server that receives requests. | no       |
 | `http` > [`tls`][tls] | Configures TLS for the HTTP server.                | no       |
@@ -71,16 +78,17 @@ The `tls` block configures TLS for the HTTP server.
 
 ## Exported fields
 
-`pyroscope.receive_http` doesn't export any fields.
+`pyroscope.receive_http` doesn't export any fields that can be referenced by other components.
 
 ## Component health
 
-`pyroscope.receive_http` is reported as unhealthy if it's given an invalid configuration.
+`pyroscope.receive_http` is only reported as unhealthy if given an invalid configuration.
 
 ## Debug metrics
 
-`pyroscope_receive_http_tcp_connections` (gauge): Current number of accepted TCP connections.
-`pyroscope_receive_http_tcp_connections_limit` (gauge): The maximum number of TCP connections that the component can accept. A value of 0 means no limit.
+- `pyroscope_receive_http_tcp_connections` (gauge): Current number of accepted TCP connections.
+- `pyroscope_receive_http_tcp_connections_limit` (gauge): The maximum number of TCP connections that the component can accept. A value of 0 means no limit.
+- `pyroscope_receive_http_debuginfo_downstream_calls_total` (counter): Total number of downstream debug information calls, labeled by `method` and `result`.
 
 ## Troubleshoot
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.receive_http.md
@@ -5,6 +5,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: pyroscope.receive_http
 ---
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.relabel.md
@@ -7,6 +7,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: pyroscope.relabel
 ---
 
@@ -14,7 +15,7 @@ title: pyroscope.relabel
 
 The `pyroscope.relabel` component rewrites the external label set of each profile passed to its receiver by applying one or more relabeling rules and forwards the results to the list of receivers.
 
-If no rules are defined or applicable to some profiles, then those profiles are forwarded as-is to each receiver passed in the component's arguments. 
+If no rules are defined or applicable to some profiles, then those profiles are forwarded as-is to each receiver passed in the component's arguments.
 The profile is dropped if no external labels remain after the relabeling rules are applied.
 
 `pyroscope.relabel` only rewrites labels that aren't embedded in the profile itself, such as labels inferred by `pyroscope.scrape` or labels provided through the `/ingest?name=...` query parameter.
@@ -41,10 +42,10 @@ pyroscope.relabel "<LABEL>" {
 
 You can use the following arguments with `pyroscope.relabel`:
 
-| Name             | Type                         | Description                                               | Default | Required |
-| ---------------- | ---------------------------- | --------------------------------------------------------- | ------- | -------- |
-| `forward_to`     | `list(pyroscope.Appendable)` | List of receivers to forward profiles to after relabeling |         | yes      |
-| `max_cache_size` | `number`                     | Maximum number of entries in the label cache              | `10000` | no       |
+| Name             | Type                     | Description                                               | Default | Required |
+| ---------------- | ------------------------ | --------------------------------------------------------- | ------- | -------- |
+| `forward_to`     | `list(ProfilesReceiver)` | List of receivers to forward profiles to after relabeling |         | yes      |
+| `max_cache_size` | `number`                 | Maximum number of entries in the label cache              | `10000` | no       |
 
 ## Blocks
 
@@ -52,7 +53,7 @@ You can use the following block with `pyroscope.relabel`:
 
 {{< docs/alloy-config >}}
 
-|      Name      |                      Description                       | Required |
+| Block          | Description                                            | Required |
 | -------------- | ------------------------------------------------------ | -------- |
 | [`rule`][rule] | Relabeling rules to apply to received profile entries. | no       |
 
@@ -71,20 +72,20 @@ The following fields are exported and can be referenced by other components:
 | Name       | Type               | Description                                      |
 | ---------- | ------------------ | ------------------------------------------------ |
 | `receiver` | `ProfilesReceiver` | A receiver that accepts profiles for relabeling. |
-| `rules`    | `[]relabel.Config` | The list of relabeling rules.                    |
+| `rules`    | `RelabelRules`     | The list of relabeling rules.                    |
 
 ## Component health
 
-`pyroscope.relabel` is reported as unhealthy if it is given an invalid configuration.
+`pyroscope.relabel` is only reported as unhealthy if given an invalid configuration.
 
 ## Debug metrics
 
-* `pyroscope_relabel_cache_hits` (counter): Total number of cache hits.
-* `pyroscope_relabel_cache_misses` (counter): Total number of cache misses.
-* `pyroscope_relabel_cache_size` (gauge): Total size of relabel cache.
-* `pyroscope_relabel_profiles_dropped` (counter): Total number of profiles dropped by relabeling rules.
-* `pyroscope_relabel_profiles_processed` (counter): Total number of profiles processed.
-* `pyroscope_relabel_profiles_written` (counter): Total number of profiles forwarded.
+- `pyroscope_relabel_cache_hits` (counter): Total number of cache hits.
+- `pyroscope_relabel_cache_misses` (counter): Total number of cache misses.
+- `pyroscope_relabel_cache_size` (gauge): Total size of relabel cache.
+- `pyroscope_relabel_profiles_dropped` (counter): Total number of profiles dropped by relabeling rules.
+- `pyroscope_relabel_profiles_processed` (counter): Total number of profiles processed.
+- `pyroscope_relabel_profiles_written` (counter): Total number of profiles forwarded.
 
 ## Example
 

--- a/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.scrape.md
@@ -7,6 +7,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: pyroscope.scrape
 ---
 
@@ -27,9 +28,9 @@ The `pyroscope.scrape` component regards a scrape as successful if it responded 
 
 If a scrape request fails, the [debug UI][] for `pyroscope.scrape` will show:
 
-* Detailed information about the failure.
-* The time of the last successful scrape.
-* The labels last used for scraping.
+- Detailed information about the failure.
+- The time of the last successful scrape.
+- The labels last used for scraping.
 
 The scraped performance profiles can be forwarded to components such as `pyroscope.write` via the `forward_to` argument.
 
@@ -55,31 +56,31 @@ You can use the following arguments with `pyroscope.scrape`:
 
 | Name                       | Type                     | Description                                                                                      | Default        | Required |
 | -------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------ | -------------- | -------- |
-| `targets`                  | `list(map(string))`      | List of targets to scrape.                                                                       |                | yes      |
 | `forward_to`               | `list(ProfilesReceiver)` | List of receivers to send scraped profiles to.                                                   |                | yes      |
-| `job_name`                 | `string`                 | The job name to override the job label with.                                                     | component name | no       |
-| `params`                   | `map(list(string))`      | A set of query parameters with which the target is scraped.                                      |                | no       |
-| `scrape_interval`          | `duration`               | How frequently to scrape the targets of this scrape configuration.                               | `"15s"`        | no       |
-| `scrape_timeout`           | `duration`               | The timeout for scraping targets of this configuration. Must be larger than `scrape_interval`.   | `"18s"`        | no       |
-| `delta_profiling_duration` | `duration`               | The duration for a delta profiling to be scraped. Must be larger than 1 second.                  | `"14s"`        | no       |
-| `scheme`                   | `string`                 | The URL scheme with which to fetch profiles from targets.                                        | `"http"`       | no       |
-| `bearer_token_file`        | `string`                 | File containing a bearer token to authenticate with.                                             |                | no       |
+| `targets`                  | `list(map(string))`      | List of targets to scrape.                                                                       |                | yes      |
 | `bearer_token`             | `secret`                 | Bearer token to authenticate with.                                                               |                | no       |
+| `bearer_token_file`        | `string`                 | File containing a bearer token to authenticate with.                                             |                | no       |
+| `delta_profiling_duration` | `duration`               | The duration for a delta profiling to be scraped. Must be larger than 1 second.                  | `"14s"`        | no       |
 | `enable_http2`             | `bool`                   | Whether HTTP2 is supported for requests.                                                         | `true`         | no       |
 | `follow_redirects`         | `bool`                   | Whether redirects returned by the server should be followed.                                     | `true`         | no       |
 | `http_headers`             | `map(list(secret))`      | Custom HTTP headers to be sent along with each request. The map key is the header name.          |                | no       |
-| `proxy_url`                | `string`                 | HTTP proxy to send requests through.                                                             |                | no       |
+| `job_name`                 | `string`                 | The job name to override the job label with.                                                     | component name | no       |
 | `no_proxy`                 | `string`                 | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |                | no       |
-| `proxy_from_environment`   | `bool`                   | Use the proxy URL indicated by environment variables.                                            | `false`        | no       |
+| `params`                   | `map(list(string))`      | A set of query parameters with which the target is scraped.                                      |                | no       |
 | `proxy_connect_header`     | `map(list(secret))`      | Specifies headers to send to proxies during CONNECT requests.                                    |                | no       |
+| `proxy_from_environment`   | `bool`                   | Use the proxy URL indicated by environment variables.                                            | `false`        | no       |
+| `proxy_url`                | `string`                 | HTTP proxy to send requests through.                                                             |                | no       |
+| `scheme`                   | `string`                 | The URL scheme with which to fetch profiles from targets.                                        | `"http"`       | no       |
+| `scrape_interval`          | `duration`               | How frequently to scrape the targets of this scrape configuration.                               | `"15s"`        | no       |
+| `scrape_timeout`           | `duration`               | The timeout for scraping targets of this configuration.                                          | `"10s"`        | no       |
 
  At most, one of the following can be provided:
 
-* [`authorization`][authorization] block
-* [`basic_auth`][basic_auth] block
-* [`bearer_token_file`][arguments] argument
-* [`bearer_token`][arguments] argument
-* [`oauth2`][oauth2] block
+- [`authorization`][authorization] block
+- [`basic_auth`][basic_auth] block
+- [`bearer_token_file`][arguments] argument
+- [`bearer_token`][arguments] argument
+- [`oauth2`][oauth2] block
 
 Any omitted arguments take on their default values.
 If conflicting arguments are being passed, for example, configuring both `bearer_token` and `bearer_token_file`, then `pyroscope.scrape` will fail to start and will report an error.
@@ -104,18 +105,18 @@ The list of `targets` can be provided [statically][example_static_targets], [dyn
 
 The following special labels can change the behavior of `pyroscope.scrape`:
 
-* `__address__` is the special label that _must always_ be present and corresponds to the `<host>:<port>` that is used for the scrape request.
-* `__name__` is the special label that indicates the profile type being collected.
-* `__profile_path__` is the special label that holds the path to the profile endpoint on the target (e.g. "/debug/pprof/allocs").
-* `__profile_path_prefix__` is the special label that holds an optional prefix to prepend to the profile path (e.g. "/mimir-prometheus").
-* `service_name` is a required label that identifies the service being profiled.
+- `__address__` is the special label that _must always_ be present and corresponds to the `<host>:<port>` that's used for the scrape request.
+- `__name__` is the special label that indicates the profile type being collected.
+- `__profile_path__` is the special label that holds the path to the profile endpoint on the target (for example, "/debug/pprof/allocs").
+- `__profile_path_prefix__` is the special label that holds an optional prefix to prepend to the profile path (for example, "/mimir-prometheus").
+- `service_name` is a required label that identifies the service being profiled.
 
 Labels starting with a double underscore (`__`) are treated as _internal_, and are removed prior to scraping.
 
 The special label `service_name` is required and must always be present.
 If it's not specified, `pyroscope.scrape` will attempt to infer it from either of the following sources, in this order:
 
-1. `__meta_kubernetes_pod_annotation_pyroscope_io_service_name` which is a `pyroscope.io/service_name` pod annotation.
+1. `__meta_kubernetes_pod_annotation_pyroscope_io_service_name` which is a `pyroscope.io/service_name` Pod annotation.
 1. `__meta_kubernetes_namespace` and `__meta_kubernetes_pod_container_name`
 1. `__meta_docker_container_name`
 1. `__meta_dockerswarm_container_label_service_name` or `__meta_dockerswarm_service_name`
@@ -125,7 +126,7 @@ If `service_name` isn't specified and couldn't be inferred, then it's set to `un
 The following labels are automatically injected to the scraped profiles so that they can be linked to a scrape target:
 
 | Label                  | Description                                                                  |
-| ---------------------- | ----------------------------------------------------------------------------- |
+| ---------------------- | ---------------------------------------------------------------------------- |
 | `"job"`                | The `job_name` that the target belongs to.                                   |
 | `"instance"`           | The `__address__` or `<host>:<port>` of the scrape target's URL.             |
 | `"service_name"`       | The inferred Pyroscope service name.                                         |
@@ -143,17 +144,17 @@ This parameter is important for controlling the trade-off between resource usage
 
 If `scrape_interval` is short:
 
-* Advantages:
+- Advantages:
   * Fewer profiles may be lost if the application being scraped crashes.
-* Disadvantages:
+- Disadvantages:
   * Greater consumption of CPU, memory, and network resources during scrapes and remote writes.
   * The backend database (Pyroscope) consumes more storage space.
 
 If `scrape_interval` is long:
 
-* Advantages:
+- Advantages:
   * Lower resource consumption.
-* Disadvantages:
+- Disadvantages:
   * More profiles may be lost if the application being scraped crashes.
   * If the [delta argument][] is set to `true`, the batch size of each remote write to Pyroscope may be bigger.
     The Pyroscope database may need to be tuned with higher limits.
@@ -161,9 +162,9 @@ If `scrape_interval` is long:
 
 For example, consider this situation:
 
-* `pyroscope.scrape` is configured with a `scrape_interval` of `"60s"`.
-* The application being scraped is running an HTTP server with a timeout of 30 seconds.
-* Any scrape HTTP requests where the [delta argument][] is set to `true` will fail, because they will attempt to run for 59 seconds.
+- `pyroscope.scrape` is configured with a `scrape_interval` of `"60s"`.
+- The application being scraped is running an HTTP server with a timeout of 30 seconds.
+- Any scrape HTTP requests where the [delta argument][] is set to `true` will fail, because they will attempt to run for 59 seconds.
 
 [delta argument]: #delta-argument
 
@@ -422,9 +423,9 @@ When the `delta` argument is `false`, the [pprof][] HTTP query will be instantan
 
 When the `delta` argument is `true`:
 
-* The [pprof][] HTTP query runs for a certain amount of time.
-* A `seconds` parameter is automatically added to the HTTP request.
-* The default value for the `seconds` query parameter is `scrape_interval - 1`.
+- The [pprof][] HTTP query runs for a certain amount of time.
+- A `seconds` parameter is automatically added to the HTTP request.
+- The default value for the `seconds` query parameter is `scrape_interval - 1`.
   If you set `delta_profiling_duration`, then `seconds` is assigned the same value as `delta_profiling_duration`.
   However, the `delta_profiling_duration` can't be larger than `scrape_interval`.
   For example, if you set `scrape_interval` to `"15s"`, then `seconds` defaults to `14s`
@@ -447,7 +448,7 @@ When the `delta` argument is `true`:
 
 ## Debug metrics
 
-* `pyroscope_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
+- `pyroscope_fanout_latency` (histogram): Write latency for sending to direct and indirect components.
 
 ## Examples
 
@@ -493,8 +494,8 @@ http://localhost:12345/debug/pprof/profile?seconds=14
 
 `seconds=14` is added to the `/debug/pprof/profile` endpoint, because:
 
-* The `delta` argument of the `profile.process_cpu` block is `true` by default.
-* `scrape_interval` is `"15s"` by default.
+- The `delta` argument of the `profile.process_cpu` block is `true` by default.
+- `scrape_interval` is `"15s"` by default.
 
 The `/debug/fgprof` endpoint won't be scraped, because the `enabled` argument of the `profile.fgprof` block is `false` by default.
 
@@ -580,7 +581,7 @@ http://localhost:12345/debug/pprof/profile?seconds=14
 http://localhost:12345/debug/fgprof?seconds=14
 ```
 
-These endpoints will **NOT** be scraped because they are explicitly disabled:
+These endpoints will **NOT** be scraped because they're explicitly disabled:
 
 ```text
 http://localhost:12345/debug/pprof/block

--- a/docs/sources/reference/components/pyroscope/pyroscope.write.md
+++ b/docs/sources/reference/components/pyroscope/pyroscope.write.md
@@ -7,6 +7,7 @@ labels:
   stage: general-availability
   products:
     - oss
+review_date: 2026-09-11
 title: pyroscope.write
 ---
 
@@ -15,8 +16,8 @@ title: pyroscope.write
 `pyroscope.write` receives performance profiles from other components and forwards them to a series of user-supplied endpoints.
 When `pyroscope.write` forwards profiles, all labels starting with double underscore (`__`) are dropped before the data is sent, with the following exceptions:
 
-* `__name__` is preserved because it identifies the profile type.
-* `__delta__`is preserved because it's required for delta profiles.
+- `__name__` is preserved because it identifies the profile type.
+- `__delta__`is preserved because it's required for delta profiles.
 
 You can specify multiple `pyroscope.write` components by giving them different labels.
 
@@ -56,12 +57,14 @@ You can use the following blocks with `pyroscope.write`:
 | `endpoint` > [`oauth2`][oauth2]                    | Configure OAuth 2.0 for authenticating to the endpoint.    | no       |
 | `endpoint` > `oauth2` > [`tls_config`][tls_config] | Configure TLS settings for connecting to the endpoint.     | no       |
 | `endpoint` > [`tls_config`][tls_config]            | Configure TLS settings for connecting to the endpoint.     | no       |
+| [`tracing`][tracing]                               | Configure trace context propagation for requests.          | no       |
 
 [endpoint]: #endpoint
 [authorization]: #authorization
 [basic_auth]: #basic_auth
 [oauth2]: #oauth2
 [tls_config]: #tls_config
+[tracing]: #tracing
 
 {{< /docs/alloy-config >}}
 
@@ -75,8 +78,9 @@ The following arguments are supported:
 | Name                     | Type                | Description                                                                                      | Default   | Required |
 | ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------ | --------- | -------- |
 | `url`                    | `string`            | Full URL to send profiles to.                                                                    |           | yes      |
-| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |           | no       |
 | `bearer_token`           | `secret`            | Bearer token to authenticate with.                                                               |           | no       |
+| `bearer_token_file`      | `string`            | File containing a bearer token to authenticate with.                                             |           | no       |
+| `debug_info_upload_timeout` | `duration`       | Timeout for uploading debug information to this endpoint.                                        | `"2m"`    | no       |
 | `enable_http2`           | `bool`              | Whether HTTP2 is supported for requests.                                                         | `true`    | no       |
 | `follow_redirects`       | `bool`              | Whether redirects returned by the server should be followed.                                     | `true`    | no       |
 | `headers`                | `map(string)`       | Extra headers to deliver with the request.                                                       |           | no       |
@@ -94,11 +98,11 @@ The following arguments are supported:
 
  At most, one of the following can be provided:
 
-* [`authorization`](#authorization) block
-* [`basic_auth`](#basic_auth) block
-* [`bearer_token_file`](#endpoint) argument
-* [`bearer_token`](#endpoint) argument
-* [`oauth2`](#oauth2) block
+- [`authorization`](#authorization) block
+- [`basic_auth`](#basic_auth) block
+- [`bearer_token_file`](#endpoint) argument
+- [`bearer_token`](#endpoint) argument
+- [`oauth2`](#oauth2) block
 
 {{< docs/shared lookup="reference/components/http-client-proxy-config-description.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
@@ -124,6 +128,16 @@ When `retry_on_http_429` is enabled, the retry mechanism is governed by the back
 
 {{< docs/shared lookup="reference/components/tls-config-block.md" source="alloy" version="<ALLOY_VERSION>" >}}
 
+### `tracing`
+
+The `tracing` block configures which trace-context headers `pyroscope.write` attaches to outgoing push requests, so a downstream Pyroscope server can correlate the write with the trace it belongs to.
+If both arguments are `false`, no trace-context headers are added to any request.
+
+| Name                       | Type   | Description                                                       | Default | Required |
+| -------------------------- | ------ | ----------------------------------------------------------------- | ------- | -------- |
+| `jaeger_propagator`        | `bool` | Attach Jaeger-format trace propagation headers (`uber-trace-id`). | `true`  | no       |
+| `trace_context_propagator` | `bool` | Attach W3C Trace Context headers (`traceparent`/`tracestate`).    | `true`  | no       |
+
 ## Exported fields
 
 The following fields are exported and can be referenced by other components:
@@ -145,19 +159,20 @@ In those cases, exported fields are kept at their last healthy values.
 
 `pyroscope.write` exposes the following metrics:
 
-| Metric                                   | Type      | Description                                                      |
-|------------------------------------------|-----------|------------------------------------------------------------------|
-| `pyroscope_write_sent_bytes_total`       | Counter   | Total number of compressed bytes sent to Pyroscope endpoints.    |
-| `pyroscope_write_dropped_bytes_total`    | Counter   | Total number of compressed bytes dropped by Pyroscope endpoints. |
-| `pyroscope_write_sent_profiles_total`    | Counter   | Total number of profiles sent to Pyroscope endpoints.            |
-| `pyroscope_write_dropped_profiles_total` | Counter   | Total number of profiles dropped by Pyroscope endpoints.         |
-| `pyroscope_write_retries_total`          | Counter   | Total number of retries to Pyroscope endpoints.                  |
-| `pyroscope_write_latency`                | Histogram | Write latency for sending profiles to Pyroscope endpoints.       |
+| Metric                                         | Type      | Description                                                       |
+| ---------------------------------------------- | --------- | ----------------------------------------------------------------- |
+| `pyroscope_write_sent_bytes_total`             | Counter   | Total number of compressed bytes sent to Pyroscope endpoints.     |
+| `pyroscope_write_dropped_bytes_total`          | Counter   | Total number of compressed bytes dropped by Pyroscope endpoints.  |
+| `pyroscope_write_sent_profiles_total`          | Counter   | Total number of profiles sent to Pyroscope endpoints.             |
+| `pyroscope_write_dropped_profiles_total`       | Counter   | Total number of profiles dropped by Pyroscope endpoints.          |
+| `pyroscope_write_retries_total`                | Counter   | Total number of retries to Pyroscope endpoints.                   |
+| `pyroscope_write_latency`                      | Histogram | Write latency for sending profiles to Pyroscope endpoints.        |
+| `pyroscope_ebpf_debug_info_upload_bytes_total` | Counter   | Total number of bytes uploaded to the debug information endpoint. |
 
 All metrics include an `endpoint` label identifying the specific endpoint URL. The `pyroscope_write_latency` metric includes an additional `type` label with the following values:
 
 - `push_total`: Total latency for push operations
-- `push_endpoint`: Per-endpoint latency for push operations  
+- `push_endpoint`: Per-endpoint latency for push operations
 - `push_downstream`: Downstream request latency for push operations
 - `ingest_total`: Total latency for ingest operations
 - `ingest_endpoint`: Per-endpoint latency for ingest operations


### PR DESCRIPTION
This PR is a general cleanup of the `pyroscope.*` topics.  

This is preliminary work that needs to be done as part of an overall project to migrate Examples either to task topics or to scenarios. The foundation of the component doc needs to be in good shape before any other work is undertaken.

Validated against the component source code, looking at Blocks, Arguments, completeness, accuracy, etc.  Most fixes are cosmetic (markdown formatting, removing extra spaces, aligning tables). Some fixes covered errors in the existing examples, errors in the debug section, and product name errors.

Added `review_date` metadata to all files that have been reviewed. This is something we should start using on all doc topics going forward once they are fully reviewed, and updated with subsequent reviews.

## Note for reviewers.

In the topic `pyroscope.ebpf`, the bulk of the changes - especially tables - is just column alignment and alpha-sorting. 

### Intentionally undocumented parts:

#### pyroscope.ebpf

The debug_info block and its arguments: cache_size, on_target_symbolization, queue_size, strip_text_section, upload, worker_num. 
Debug metrics: pyroscope_ebpf_pprofs_dropped_total, pyroscope_ebpf_pprof_bytes_total, pyroscope_ebpf_pprof_samples_total, pyroscope_forwarded_entries_total.

#### pyroscope.write

The tracing block and its arguments: jaeger_propagator, trace_context_propagator.
The debug_info_upload_timeout endpoint argument.
pyroscope_ebpf_debug_info_upload_bytes_total is also undocumented intentionally

#### pyroscope.receive_http

The debug_info_upload_timeout argument, plus the description of the debug information upload proxy endpoint (POST /debuginfo.v1alpha1.DebuginfoService/Upload/{gnu_build_id}) and its first-receiver-only forwarding behavior.
Debug metric pyroscope_receive_http_debuginfo_downstream_calls_total.

## Possible bug in source?

This is something Claude and CoPilot both found:

**Bug:** `pyroscope_ebpf_pprof_samples_total` counts bytes, not samples.
In `send.go`, both `pprofSamplesTotal` and `pprofBytesTotal` are incremented with `len(p.Raw)`, the same raw profile byte slice. `pprof_samples_total` isn't tracking sample counts at all; it's a duplicate of `pprof_bytes_total`. The metric's Help string in `metrics.go` is also a stale copy-paste ("Total number of pprof profiles collected..."), unrelated to samples. This looks like a copy-paste artifact from when the metric was added rather than intentional behavior. Needs either real sample-count instrumentation or the metric renamed/removed to stop implying it counts samples. Docs updated to describe current (byte-counting) behavior in the meantime.

https://github.com/grafana/alloy/pull/7119/ will fix this